### PR TITLE
fix(generate-manifest): detectHostRoot accepts template's actual package name and walks one level up

### DIFF
--- a/scripts/generate-manifest.js
+++ b/scripts/generate-manifest.js
@@ -28,17 +28,24 @@ import yaml from 'yaml';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const kbRoot = resolve(__dirname, '..');
 
-// Detect if running as submodule
+// Detect if running as submodule / vendored install inside a host repo.
 function detectHostRoot() {
-  const parentRoot = resolve(kbRoot, '..', '..');
+  // Explicit override from the CLI wins.
+  if (process.env.VITE_KB_HOST_ROOT) {
+    const explicit = resolve(process.env.VITE_KB_HOST_ROOT);
+    if (existsSync(explicit)) return explicit;
+  }
+  // When this script lives at <host>/.kbexplorer/scripts/, kbRoot is
+  // <host>/.kbexplorer, so the host repo is exactly one level up.
+  const parentRoot = resolve(kbRoot, '..');
   try {
     const pkg = JSON.parse(readFileSync(resolve(kbRoot, 'package.json'), 'utf-8'));
-    if (pkg.name === 'kbexplorer') {
-      // Check if parent looks like a host repo
-      if (existsSync(resolve(parentRoot, '.git')) && existsSync(resolve(parentRoot, 'package.json'))) {
-        const parentPkg = JSON.parse(readFileSync(resolve(parentRoot, 'package.json'), 'utf-8'));
-        if (parentPkg.name !== 'kbexplorer') return parentRoot;
-      }
+    const isTemplatePkg = pkg.name === 'kbexplorer'
+      || pkg.name === 'kbexplorer-template'
+      || pkg.name === '@anokye-labs/kbexplorer-template';
+    if (!isTemplatePkg) return kbRoot; // self-hosted: use kbRoot itself
+    if (existsSync(resolve(parentRoot, '.git')) && existsSync(resolve(parentRoot, 'package.json'))) {
+      return parentRoot;
     }
   } catch { /* ignore */ }
   return kbRoot;


### PR DESCRIPTION
## The bug

Vendored/submodule installs render the template's own bundled demo content instead of the host repo's content/.  detectHostRoot() never resolves correctly because of two compounding bugs:

1. Checks pkg.name === 'kbexplorer', but the template's own  package.json#name is kbexplorer-template — so the if-branch never executed for any real install.
2.  parentRoot = resolve(kbRoot, '..', '..') goes **two** levels up from  <host>/.kbexplorer, landing in the parent of the host repo.

## The fix

- Accept  'kbexplorer',  'kbexplorer-template', and  '@anokye-labs/kbexplorer-template' as template package names.
-  parentRoot = resolve(kbRoot, '..') — one level up, which is the host root.
- Honor a  VITE_KB_HOST_ROOT env override so consumers (kbexplorer-cli) can be explicit instead of relying on filename heuristics.

## Verification

- 176/176 existing tests still pass ( npm test).
- End-to-end: copied this script into a vendored install of the template inside the kbexplorer-cli repo. Before the fix, the manifest reported  Submodule mode: false and rendered 269 demo nodes from the template's own content/. After the fix, it reports:

    
  [generate-manifest] Submodule mode: true
  [generate-manifest] Repo: kbexplorer-cli  
  [generate-manifest] Content: 23 files
    

and the explorer renders the host's authored knowledge base correctly.