### PR TITLE
F1: Open node-type foundation — JSON-LD nodes + registries (#148)

### DIFF
--- a/content/node-types.md
+++ b/content/node-types.md
@@ -1,0 +1,84 @@
+---
+id: "node-types"
+title: "Open Node-Type Foundation"
+emoji: "Shapes"
+cluster: engine
+derived: true
+connections: []
+---
+
+The node-type foundation (issue [#148](https://github.com/anokye-labs/kbexplorer-template/issues/148)) turns kbexplorer into an **open, data-driven node-type engine**. New node types — a person, a team, a service — register themselves at runtime instead of forcing edits to the core [type contract](identity). Every change is **additive and backward-compatible**: a node that omits the new fields behaves exactly as before.
+
+## JSON-LD on `KBNode`
+
+Each `KBNode` may carry three optional, additive fields:
+
+```typescript
+interface KBNode {
+  // …existing fields…
+  entityType?: string;               // open registry key, e.g. 'person' | 'team'
+  jsonld?: JsonLd;                   // { '@context', '@id', '@type', …LD props }
+  data?: Record<string, unknown>;    // free-form structured-data bag
+}
+```
+
+`@id` reuses the node's canonical `identity` URN so representations of the same real-world entity line up across providers, and `@type` is the open node-type discriminator — it is **never derived from a file path**. Build an envelope with `buildJsonLd(node, type, data?, context?)`, which defaults `@context` to `https://schema.org` and falls back to a `kg://node/<id>` `@id` when the node has no identity.
+
+## Open unions
+
+`DisplayMode` and `EdgeType` are **open** unions — `KnownDisplayMode | (string & {})` — so new render modes and structural edge kinds keep editor autocomplete for known values while allowing arbitrary new ones. `'entity'` is the display-mode escape hatch that routes a node to a viewer.
+
+`NodeSource` is opened differently, on purpose: rather than widening it (which would break the exhaustive `switch` narrowing in `SourceBadge` and the identity system), it gains **one** generic variant:
+
+```typescript
+| { type: 'structured'; entityType: string; ref?: string }
+```
+
+A brand-new node type therefore never adds a `NodeSource` variant — it uses `source: { type: 'structured', entityType: 'person' }` and identifies itself through the node-type registry.
+
+## Relation taxonomy
+
+Edges carry an optional, open `relation` label (on both `KBEdge` and `Connection`) that is orthogonal to the structural `type`. The six core relations are `leads`, `staffs`, `reports-to`, `structural`, `derived`, and `deprecated`. Styling is centralised so the [graph renderer](graph-engine) and the legend never drift apart:
+
+- `getEdgeStyle(edge)` — relation (known → `RELATION_STYLES`; unknown → default style + humanized label) → `type` → `related`.
+- `getEdgeLegendKey(edge)` — the relation when present, else the type.
+- `getEdgeWeight(type)` — open-safe layout weight lookup.
+
+The HUD legend is rendered data-drivenly from the relations/types actually present in the visible graph.
+
+## Node-type registry
+
+`src/engine/node-types` is the registry that makes types data-driven:
+
+```typescript
+registerType({ id: 'person', layer: 'work', cluster: 'org', viewer: 'person' });
+resolveType(id); hasType(id); getRegisteredTypes();
+resolveNodeLayer(node); resolveTypeCluster(node); resetNodeTypeRegistry();
+```
+
+`getNodeLayer()` delegates to `resolveNodeLayer` (precedence: `entityType` definition → `source.type` definition → `'file'`). Built-in source types are pre-registered with their historical layer mapping, so existing graphs classify identically.
+
+## Viewer registry
+
+`src/views/viewers` maps an `entityType` (or JSON-LD `@type`) to a React renderer:
+
+```typescript
+registerViewer('person', PersonView);
+const Viewer = resolveViewer(node);   // PersonView, or the generic fallback
+```
+
+`resolveViewer` resolves by `entityType` first, then JSON-LD `@type`, and finally the mandatory `GenericStructuredView` — which renders any `data`/`jsonld` object as a nested table/tree, so coverage is never zero. In `ReadingView`, `display: 'entity'` resolves a viewer and `SourceBadge` renders the `structured` source.
+
+## Adding a new node type (the F2/F3 recipe)
+
+1. `registerType({ id: 'service', layer: 'work', cluster: 'infra', viewer: 'service' })`.
+2. Emit nodes with `source: { type: 'structured', entityType: 'service' }`, `display: 'entity'`, and a `jsonld`/`data` payload (use `buildJsonLd`).
+3. Optionally `registerViewer('service', ServiceView)` — otherwise the generic viewer is used.
+4. Connect nodes with `relation`-tagged edges from the taxonomy.
+
+No edits to the core unions or render switches are required.
+
+## Operational notes
+
+- `CACHE_VERSION` in `src/api/github.ts` is bumped whenever the cached node/edge shape changes (the JSON-LD fields bumped it to **13**); stale caches self-clear on load.
+- An off-by-default demo seam, `injectDemoEntities()` (enabled via `?demo=entities` or `localStorage['kbe-demo-entities']`), seeds person/team entities and `leads`/`staffs`/`reports-to` edges for end-to-end verification without polluting real graphs.

--- a/e2e/entity-nodes.spec.ts
+++ b/e2e/entity-nodes.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test';
+
+// Exercises the open node-type foundation end-to-end via the off-by-default
+// demo-entities seam (?demo=entities): the entity viewer registry (T1.4),
+// ReadingView display:'entity' + structured SourceBadge (T1.6/#158), and the
+// stale-cache clean render after the CACHE_VERSION bump (#159).
+
+test.describe('Entity nodes (open node-type foundation)', () => {
+  test('person entity resolves the bespoke PersonView', async ({ page }) => {
+    await page.goto('/?demo=entities#/node/demo-person-ada', { timeout: 60000 });
+    await page.waitForTimeout(3000);
+
+    const view = page.locator('.kb-person-view');
+    await expect(view).toBeVisible({ timeout: 10000 });
+    await expect(view).toContainText('Ada Okonkwo');
+    await expect(view).toContainText('Engineering Lead');
+    await expect(view.locator('a[href^="mailto:"]')).toHaveAttribute('href', 'mailto:ada@example.com');
+
+    // SourceBadge handles the structured source
+    await expect(page.getByText(/Entity · Person/i).first()).toBeVisible({ timeout: 10000 });
+  });
+
+  test('team entity falls back to the generic structured viewer', async ({ page }) => {
+    await page.goto('/?demo=entities#/node/demo-team-atlas', { timeout: 60000 });
+    await page.waitForTimeout(3000);
+
+    const view = page.locator('.kb-structured-view');
+    await expect(view).toBeVisible({ timeout: 10000 });
+    // humanized keys + values from the data bag
+    await expect(view).toContainText('Mission');
+    await expect(view).toContainText('Owns the knowledge-graph engine');
+    // JSON-LD @id surfaced in the header
+    await expect(view).toContainText('kg://team/demo-team-atlas');
+  });
+
+  test('renders cleanly when stale (older-version) cache is present', async ({ page }) => {
+    // Seed a previous-version cache entry to exercise the real cached-data flow.
+    await page.addInitScript(() => {
+      try {
+        localStorage.setItem('kbe:version', '12');
+        localStorage.setItem('kbe:stale-junk', JSON.stringify({ shape: 'old', t: 0 }));
+      } catch { /* ignore */ }
+    });
+
+    const errors: string[] = [];
+    page.on('console', msg => {
+      if (msg.type() === 'error' && !msg.text().includes('@griffel')) errors.push(msg.text());
+    });
+
+    await page.goto('/#/node/readme', { timeout: 60000 });
+    await expect(page.locator('.kb-prose')).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('.kb-prose')).toContainText('kbexplorer');
+
+    await page.waitForTimeout(1500);
+    const appErrors = errors.filter(e => !e.includes('403') && !e.includes('rate limit'));
+    expect(appErrors).toHaveLength(0);
+  });
+});

--- a/src/api/github.ts
+++ b/src/api/github.ts
@@ -8,7 +8,7 @@ import type { SourceConfig } from '../types';
 
 const CACHE_PREFIX = 'kbe:';
 const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
-const CACHE_VERSION = 12; // bump to invalidate all cached data
+const CACHE_VERSION = 13; // bump to invalidate all cached data (13: KBNode JSON-LD fields + KBEdge.relation)
 
 // Clear stale cache from older versions
 try {

--- a/src/components/HUD.tsx
+++ b/src/components/HUD.tsx
@@ -32,8 +32,8 @@ import {
   PanelRightRegular,
   PanelTopExpandRegular,
 } from '@fluentui/react-icons';
-import type { KBGraph, KBConfig, KBNode, Theme, EdgeType } from '../types';
-import { EDGE_TYPE_STYLES, BUILT_IN_VIEWS, filterGraphToView, collapseGraphClusters, trimGraphToLimits } from '../types';
+import type { KBGraph, KBConfig, KBNode, Theme } from '../types';
+import { getEdgeStyle, getEdgeLegendKey, BUILT_IN_VIEWS, filterGraphToView, collapseGraphClusters, trimGraphToLimits } from '../types';
 import type { TrimResult } from '../types';
 import { NodeVisual, FLUENT_ICONS, isFluentIconName } from './NodeVisual';
 import { createGraphNetwork, computeGraphPositions } from '../engine/createGraphNetwork';
@@ -672,14 +672,27 @@ export function HUD({ graph, config, currentNodeId, theme, onThemeChange, onColl
     return viewGraph.clusters.filter(c => (counts.get(c.id) ?? 0) >= 2);
   }, [graph, activeView]);
 
-  // Active edge types present in the graph
-  const activeEdgeTypes = React.useMemo(() => {
-    const types = new Set<EdgeType>();
-    for (const e of filteredGraph.edges) if (e.type) types.add(e.type);
-    return Array.from(types).sort((a, b) => {
-      const order: EdgeType[] = ['contains', 'derived_from', 'imports', 'references', 'cross_references', 'frontmatter', 'closes', 'modifies', 'mentions', 'related'];
-      return order.indexOf(a) - order.indexOf(b);
-    });
+  // Active edge/relation styles present in the graph — data-driven from the
+  // edges themselves so relation types (leads/staffs/reports-to/…) and any
+  // custom relations appear in the legend without code edits.
+  const activeEdgeStyles = React.useMemo(() => {
+    const seen = new Map<string, { key: string; label: string; style: ReturnType<typeof getEdgeStyle> }>();
+    for (const e of filteredGraph.edges) {
+      const key = getEdgeLegendKey(e);
+      if (seen.has(key)) continue;
+      const style = getEdgeStyle(e);
+      seen.set(key, { key, label: style.label, style });
+    }
+    // Relations first (in taxonomy order), then structural edge types.
+    const relationOrder = ['leads', 'staffs', 'reports-to', 'structural', 'derived', 'deprecated'];
+    const typeOrder = ['contains', 'derived_from', 'imports', 'references', 'cross_references', 'frontmatter', 'closes', 'modifies', 'mentions', 'related'];
+    const rank = (key: string) => {
+      const r = relationOrder.indexOf(key);
+      if (r >= 0) return r;
+      const t = typeOrder.indexOf(key);
+      return 100 + (t >= 0 ? t : typeOrder.length);
+    };
+    return Array.from(seen.values()).sort((a, b) => rank(a.key) - rank(b.key));
   }, [filteredGraph]);
 
   const navigateTo = useCallback((hash: string) => {
@@ -843,19 +856,18 @@ export function HUD({ graph, config, currentNodeId, theme, onThemeChange, onColl
                   </div>
                 );
               })}
-              {activeEdgeTypes.length > 0 && (
+              {activeEdgeStyles.length > 0 && (
                 <>
                   <div style={{ borderTop: `1px solid ${tokens.colorNeutralStroke2}`, margin: '4px 12px' }} />
-                  {activeEdgeTypes.map(t => {
-                    const s = EDGE_TYPE_STYLES[t];
+                  {activeEdgeStyles.map(({ key, label, style: s }) => {
                     return (
-                      <div key={t} style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '2px 12px' }}>
+                      <div key={key} style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '2px 12px' }}>
                         <svg width={18} height={8} style={{ flexShrink: 0 }}>
                           <line x1={0} y1={4} x2={18} y2={4}
                             stroke={s.color} strokeWidth={Math.max(s.width, 1.2)}
                             strokeDasharray={Array.isArray(s.dashes) ? s.dashes.join(',') : undefined} />
                         </svg>
-                        <Caption1>{s.label}</Caption1>
+                        <Caption1>{label}</Caption1>
                       </div>
                     );
                   })}
@@ -1027,19 +1039,18 @@ export function HUD({ graph, config, currentNodeId, theme, onThemeChange, onColl
                         </div>
                       );
                     })}
-                    {activeEdgeTypes.length > 0 && (
+                    {activeEdgeStyles.length > 0 && (
                       <>
                         <div style={{ borderTop: `1px solid ${tokens.colorNeutralStroke2}`, margin: '4px 0' }} />
-                        {activeEdgeTypes.map(t => {
-                          const s = EDGE_TYPE_STYLES[t];
+                        {activeEdgeStyles.map(({ key, label, style: s }) => {
                           return (
-                            <div key={t} style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
+                            <div key={key} style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
                               <svg width={14} height={7} style={{ flexShrink: 0 }}>
                                 <line x1={0} y1={3.5} x2={14} y2={3.5}
                                   stroke={s.color} strokeWidth={Math.max(s.width, 1)}
                                   strokeDasharray={Array.isArray(s.dashes) ? s.dashes.join(',') : undefined} />
                               </svg>
-                              <span style={{ color: tokens.colorNeutralForeground3 }}>{s.label}</span>
+                              <span style={{ color: tokens.colorNeutralForeground3 }}>{label}</span>
                             </div>
                           );
                         })}

--- a/src/engine/__tests__/demo-entities.test.ts
+++ b/src/engine/__tests__/demo-entities.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { isDemoEntitiesEnabled, injectDemoEntities } from '../demo-entities';
+import { resetNodeTypeRegistry } from '../node-types';
+import { getEdgeStyle } from '../../types';
+import type { KBGraph, KBNode } from '../../types';
+
+function makeNode(id: string, overrides: Partial<KBNode> = {}): KBNode {
+  return {
+    id,
+    title: id,
+    cluster: 'default',
+    content: '',
+    rawContent: '',
+    connections: [],
+    source: { type: 'authored', file: `content/${id}.md` },
+    ...overrides,
+  };
+}
+
+function baseGraph(): KBGraph {
+  return {
+    nodes: [makeNode('readme', { source: { type: 'readme' } })],
+    edges: [],
+    clusters: [{ id: 'default', name: 'Default', color: '#ccc' }],
+    related: {},
+  };
+}
+
+afterEach(() => {
+  resetNodeTypeRegistry();
+});
+
+describe('demo-entities seam', () => {
+  it('is disabled by default (no window in node env)', () => {
+    expect(isDemoEntitiesEnabled()).toBe(false);
+  });
+
+  it('appends person/team entity nodes without mutating the original graph', () => {
+    const graph = baseGraph();
+    const originalNodeCount = graph.nodes.length;
+    const result = injectDemoEntities(graph);
+
+    expect(graph.nodes).toHaveLength(originalNodeCount); // original untouched
+    expect(result.nodes.length).toBe(originalNodeCount + 3);
+
+    const ids = result.nodes.map(n => n.id);
+    expect(ids).toContain('demo-team-atlas');
+    expect(ids).toContain('demo-person-ada');
+    expect(ids).toContain('demo-person-ben');
+  });
+
+  it('marks entity nodes with display=entity, structured source, jsonld and data', () => {
+    const result = injectDemoEntities(baseGraph());
+    const ada = result.nodes.find(n => n.id === 'demo-person-ada')!;
+    expect(ada.display).toBe('entity');
+    expect(ada.entityType).toBe('person');
+    expect(ada.source.type).toBe('structured');
+    expect(ada.jsonld?.['@type']).toBe('Person');
+    expect(ada.jsonld?.['@id']).toBe(ada.identity);
+    expect(ada.data?.role).toBe('Engineering Lead');
+  });
+
+  it('wires the relation taxonomy (leads/staffs/reports-to) and anchors to the hub', () => {
+    const result = injectDemoEntities(baseGraph());
+    const relations = result.edges.map(e => e.relation).filter(Boolean);
+    expect(relations).toContain('leads');
+    expect(relations).toContain('staffs');
+    expect(relations).toContain('reports-to');
+    expect(relations).toContain('structural'); // hub anchor
+
+    // every relation edge resolves to a concrete style
+    for (const e of result.edges) {
+      if (e.relation) expect(getEdgeStyle(e).color).toBeTruthy();
+    }
+
+    // anchored to readme hub
+    expect(result.edges.some(e => e.from === 'readme' && e.to === 'demo-team-atlas')).toBe(true);
+  });
+
+  it('adds an "org" cluster exactly once', () => {
+    const result = injectDemoEntities(baseGraph());
+    expect(result.clusters.filter(c => c.id === 'org')).toHaveLength(1);
+  });
+});

--- a/src/engine/__tests__/demo-entities.test.ts
+++ b/src/engine/__tests__/demo-entities.test.ts
@@ -81,4 +81,21 @@ describe('demo-entities seam', () => {
     const result = injectDemoEntities(baseGraph());
     expect(result.clusters.filter(c => c.id === 'org')).toHaveLength(1);
   });
+
+  it('is collision-safe: returns the graph unchanged if a demo id already exists', () => {
+    const graph = baseGraph();
+    graph.nodes.push(makeNode('demo-person-ada', { entityType: 'person' }));
+    const before = graph.nodes.length;
+    const result = injectDemoEntities(graph);
+    // no duplicate ids appended; graph returned unchanged
+    expect(result.nodes).toHaveLength(before);
+    expect(result.nodes.filter(n => n.id === 'demo-person-ada')).toHaveLength(1);
+  });
+
+  it('double-injection is idempotent (no duplicate demo nodes)', () => {
+    const once = injectDemoEntities(baseGraph());
+    const twice = injectDemoEntities(once);
+    expect(twice.nodes.filter(n => n.id === 'demo-person-ben')).toHaveLength(1);
+    expect(twice.nodes).toHaveLength(once.nodes.length);
+  });
 });

--- a/src/engine/createGraphNetwork.ts
+++ b/src/engine/createGraphNetwork.ts
@@ -6,8 +6,8 @@ import { Network } from 'vis-network/standalone';
 import { DataSet } from 'vis-data';
 import { createNodeRenderer } from './nodeRenderer';
 import { getNodeDegrees } from './graph';
-import type { KBGraph, EdgeType } from '../types';
-import { EDGE_TYPE_STYLES } from '../types';
+import type { KBGraph } from '../types';
+import { getEdgeStyle } from '../types';
 
 const EDGE_COLOR = '#505050';
 const EDGE_HOVER_COLOR = '#5c5c5c';
@@ -152,11 +152,12 @@ export function createGraphNetwork(options: GraphNetworkOptions): GraphNetworkRe
   const EDGE_FADED_COLOR = 'rgba(80,80,80,0.08)';
 
   /** Resolve the visual style for an edge type */
-  const edgeStyle = (type: EdgeType | undefined) => EDGE_TYPE_STYLES[type ?? 'related'] ?? EDGE_TYPE_STYLES.related;
+  /** Resolve the visual style for an edge (relation-aware, data-driven). */
+  const edgeStyle = (e: { type?: string; relation?: string }) => getEdgeStyle(e);
 
   const baseSpringLength = 250;
   const edgeData = graph.edges.map((e, i) => {
-    const style = edgeStyle(e.type);
+    const style = edgeStyle(e);
     const faded = effectiveEmphasis && !emphasizedIds.has(e.from) && !emphasizedIds.has(e.to);
     const nearFaded = effectiveEmphasis && !(emphasizedIds.has(e.from) && emphasizedIds.has(e.to));
     return {
@@ -179,7 +180,7 @@ export function createGraphNetwork(options: GraphNetworkOptions): GraphNetworkRe
   const edges = new DataSet(edgeData);
 
   // Build an edge lookup for fast emphasis updates
-  const edgesByIndex = graph.edges.map((e, i) => ({ id: `e${i}`, from: e.from, to: e.to, type: e.type }));
+  const edgesByIndex = graph.edges.map((e, i) => ({ id: `e${i}`, from: e.from, to: e.to, type: e.type, relation: e.relation }));
 
   /** Dynamically update neighborhood emphasis without rebuilding the network. */
   const setEmphasis = (nodeId: string | null) => {
@@ -243,7 +244,7 @@ export function createGraphNetwork(options: GraphNetworkOptions): GraphNetworkRe
     // Tier 3: distant → nearly invisible
     const edgeUpdates: Record<string, unknown>[] = [];
     for (const ei of edgesByIndex) {
-      const style = edgeStyle(ei.type);
+      const style = edgeStyle(ei);
       if (!active) {
         // No focus — all edges at full style
         edgeUpdates.push({

--- a/src/engine/demo-entities.ts
+++ b/src/engine/demo-entities.ts
@@ -97,6 +97,13 @@ function relationEdge(from: string, to: string, relation: string, description: s
 export function injectDemoEntities(graph: KBGraph): KBGraph {
   registerDemoEntityTypes();
 
+  const DEMO_IDS = ['demo-team-atlas', 'demo-person-ada', 'demo-person-ben'];
+  // Guard against collisions / double-injection: if any fixed demo id already
+  // exists in the graph, skip injection and return it unchanged.
+  if (graph.nodes.some(n => DEMO_IDS.includes(n.id))) {
+    return graph;
+  }
+
   const team = entityNode(
     'demo-team-atlas',
     'Team Atlas',

--- a/src/engine/demo-entities.ts
+++ b/src/engine/demo-entities.ts
@@ -1,0 +1,151 @@
+/**
+ * Demo-entities seam (off by default).
+ *
+ * Injects a small set of `person` / `team` entity nodes — wired with the
+ * relation taxonomy (leads | staffs | reports-to) — so the open node-type
+ * foundation can be exercised end-to-end (entity viewer, SourceBadge, relation
+ * legend) without polluting real knowledge graphs.
+ *
+ * Enabled by `?demo=entities` in the URL or `localStorage['kbe-demo-entities']`
+ * set to `'1'` / `'true'`. When disabled the graph is returned unchanged.
+ */
+import type { KBGraph, KBNode, KBEdge, Cluster } from '../types';
+import { buildJsonLd } from '../types';
+import { registerType } from './node-types';
+import { registerViewer } from '../views/viewers';
+import { PersonView } from '../views/viewers/PersonView';
+
+const DEMO_CLUSTER: Cluster = { id: 'org', name: 'Organization', color: '#c0a3ff' };
+
+/** Whether the demo-entities seam is enabled for this session. */
+export function isDemoEntitiesEnabled(): boolean {
+  try {
+    if (typeof window !== 'undefined') {
+      const params = new URLSearchParams(window.location.search);
+      if (params.get('demo') === 'entities') return true;
+      const hash = window.location.hash;
+      const qIndex = hash.indexOf('?');
+      if (qIndex >= 0) {
+        const hp = new URLSearchParams(hash.slice(qIndex + 1));
+        if (hp.get('demo') === 'entities') return true;
+      }
+      const flag = window.localStorage?.getItem('kbe-demo-entities');
+      if (flag === '1' || flag === 'true') return true;
+    }
+  } catch {
+    /* access to window/localStorage may be denied; treat as disabled */
+  }
+  return false;
+}
+
+/** Register the `person` / `team` node types + the bespoke person viewer. Idempotent. */
+export function registerDemoEntityTypes(): void {
+  registerType({
+    id: 'person',
+    label: 'Person',
+    layer: 'work',
+    cluster: DEMO_CLUSTER.id,
+    relations: ['reports-to', 'leads'],
+    viewer: 'person',
+    description: 'An individual contributor or manager.',
+  });
+  registerType({
+    id: 'team',
+    label: 'Team',
+    layer: 'work',
+    cluster: DEMO_CLUSTER.id,
+    relations: ['staffs', 'leads'],
+    description: 'A squad / team that staffs people and is led by a person.',
+  });
+  registerViewer('person', PersonView);
+}
+
+function entityNode(
+  id: string,
+  title: string,
+  entityType: string,
+  data: Record<string, unknown>,
+  ldType: string,
+): KBNode {
+  const identity = `kg://${entityType}/${id}`;
+  return {
+    id,
+    title,
+    cluster: DEMO_CLUSTER.id,
+    content: '',
+    rawContent: '',
+    display: 'entity',
+    connections: [],
+    identity,
+    source: { type: 'structured', entityType },
+    entityType,
+    provider: 'demo-entities',
+    data,
+    jsonld: buildJsonLd({ id, identity }, ldType, data),
+  };
+}
+
+function relationEdge(from: string, to: string, relation: string, description: string): KBEdge {
+  return { from, to, type: 'related', relation, description, source: 'inferred', weight: 1 };
+}
+
+/**
+ * Return a new graph with demo entity nodes + relation edges appended. The
+ * original graph is not mutated. A `team` node is linked to an existing hub node
+ * (readme/home/first) so the demo subgraph is reachable.
+ */
+export function injectDemoEntities(graph: KBGraph): KBGraph {
+  registerDemoEntityTypes();
+
+  const team = entityNode(
+    'demo-team-atlas',
+    'Team Atlas',
+    'team',
+    { name: 'Team Atlas', mission: 'Owns the knowledge-graph engine', size: 4 },
+    'Organization',
+  );
+  const lead = entityNode(
+    'demo-person-ada',
+    'Ada Okonkwo',
+    'person',
+    { name: 'Ada Okonkwo', role: 'Engineering Lead', email: 'ada@example.com', team: 'Team Atlas' },
+    'Person',
+  );
+  const ic = entityNode(
+    'demo-person-ben',
+    'Ben Carter',
+    'person',
+    { name: 'Ben Carter', role: 'Software Engineer', email: 'ben@example.com', team: 'Team Atlas' },
+    'Person',
+  );
+
+  const newNodes: KBNode[] = [team, lead, ic];
+
+  const newEdges: KBEdge[] = [
+    relationEdge(lead.id, team.id, 'leads', 'Ada leads Team Atlas'),
+    relationEdge(team.id, lead.id, 'staffs', 'Team Atlas staffs Ada'),
+    relationEdge(team.id, ic.id, 'staffs', 'Team Atlas staffs Ben'),
+    relationEdge(ic.id, lead.id, 'reports-to', 'Ben reports to Ada'),
+  ];
+
+  // Anchor the demo subgraph to an existing hub so it is reachable in the graph.
+  const hub =
+    graph.nodes.find(n => n.id === 'readme') ??
+    graph.nodes.find(n => n.id === 'home') ??
+    graph.nodes.find(n => n.id === 'overview') ??
+    graph.nodes[0];
+  if (hub) {
+    newEdges.push(relationEdge(hub.id, team.id, 'structural', `${hub.title} → Team Atlas`));
+  }
+
+  const clusters = graph.clusters.some(c => c.id === DEMO_CLUSTER.id)
+    ? graph.clusters
+    : [...graph.clusters, DEMO_CLUSTER];
+
+  return {
+    nodes: [...graph.nodes, ...newNodes],
+    edges: [...graph.edges, ...newEdges],
+    clusters,
+    related: graph.related,
+  };
+}

--- a/src/engine/graph.ts
+++ b/src/engine/graph.ts
@@ -3,7 +3,7 @@
  * Builds edges, clusters, related nodes, and layout positions.
  */
 import type { KBNode, KBGraph, KBEdge, Cluster, EdgeType } from '../types';
-import { EDGE_TYPE_WEIGHTS } from '../types';
+import { EDGE_TYPE_WEIGHTS, getEdgeWeight } from '../types';
 
 /** Build the full knowledge graph from a list of nodes and cluster definitions. */
 export function buildGraph(nodes: KBNode[], clusters: Cluster[]): KBGraph {
@@ -62,7 +62,8 @@ function buildEdges(
             type: edgeType,
             description: conn.description,
             source: conn.source ?? 'frontmatter',
-            weight: conn.weight ?? EDGE_TYPE_WEIGHTS[edgeType] ?? 1,
+            weight: conn.weight ?? getEdgeWeight(edgeType),
+            ...(conn.relation ? { relation: conn.relation } : {}),
           });
         }
       }

--- a/src/engine/node-types/__tests__/registry.test.ts
+++ b/src/engine/node-types/__tests__/registry.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  registerType,
+  resolveType,
+  hasType,
+  getRegisteredTypes,
+  resolveNodeLayer,
+  resolveTypeCluster,
+  resetNodeTypeRegistry,
+} from '../registry';
+import type { KBNode } from '../../../types';
+
+function makeNode(overrides: Partial<KBNode> & Pick<KBNode, 'id' | 'source'>): KBNode {
+  return {
+    title: overrides.id,
+    cluster: 'default',
+    content: '',
+    rawContent: '',
+    connections: [],
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  resetNodeTypeRegistry();
+});
+
+describe('node-type registry (T1.2/T1.5)', () => {
+  it('registers the built-in source types on import', () => {
+    expect(hasType('file')).toBe(true);
+    expect(hasType('authored')).toBe(true);
+    expect(hasType('issue')).toBe(true);
+    expect(resolveType('issue')?.layer).toBe('work');
+  });
+
+  it('preserves the historical layer mapping for every built-in source', () => {
+    const cases: Array<[KBNode['source'], string]> = [
+      [{ type: 'file', path: 'a.ts' }, 'file'],
+      [{ type: 'external', provider: 'wikipedia' }, 'file'],
+      [{ type: 'authored', file: 'content/x.md' }, 'content'],
+      [{ type: 'readme' }, 'content'],
+      [{ type: 'derived', generator: 'g' }, 'content'],
+      [{ type: 'section', parentSource: { type: 'authored', file: 'x.md' } }, 'content'],
+      [{ type: 'issue', number: 1, state: 'open', labels: [] }, 'work'],
+      [{ type: 'pull_request', number: 2, state: 'open' }, 'work'],
+      [{ type: 'commit', sha: 'abc' }, 'work'],
+      [{ type: 'branch', name: 'main', protected: true }, 'work'],
+      [{ type: 'workflow', path: '.github/workflows/ci.yml' }, 'work'],
+      [{ type: 'repository', owner: 'o', repo: 'r' }, 'work'],
+    ];
+    for (const [source, layer] of cases) {
+      expect(resolveNodeLayer(makeNode({ id: 't', source }))).toBe(layer);
+    }
+  });
+
+  it('resolves entityType layer ahead of source.type', () => {
+    registerType({ id: 'person', layer: 'work', cluster: 'org' });
+    const node = makeNode({
+      id: 'p1',
+      entityType: 'person',
+      source: { type: 'structured', entityType: 'person' },
+    });
+    expect(resolveNodeLayer(node)).toBe('work');
+  });
+
+  it('falls back to "file" for an unknown source and no entityType', () => {
+    const node = makeNode({ id: 'u1', source: { type: 'mystery' } as unknown as KBNode['source'] });
+    expect(resolveNodeLayer(node)).toBe('file');
+  });
+
+  it('registerType is discoverable via getRegisteredTypes and resolveType', () => {
+    registerType({ id: 'team', label: 'Team', layer: 'work', cluster: 'org', relations: ['staffs'] });
+    expect(hasType('team')).toBe(true);
+    expect(resolveType('team')?.relations).toContain('staffs');
+    expect(getRegisteredTypes().some(t => t.id === 'team')).toBe(true);
+  });
+
+  it('resolveTypeCluster prefers entityType cluster then source.type cluster', () => {
+    registerType({ id: 'person', layer: 'work', cluster: 'people' });
+    expect(
+      resolveTypeCluster({ entityType: 'person', source: { type: 'structured' } }),
+    ).toBe('people');
+    expect(
+      resolveTypeCluster({ entityType: undefined, source: { type: 'file' } }),
+    ).toBeUndefined();
+  });
+
+  it('resetNodeTypeRegistry drops custom types but keeps built-ins', () => {
+    registerType({ id: 'person', layer: 'work' });
+    expect(hasType('person')).toBe(true);
+    resetNodeTypeRegistry();
+    expect(hasType('person')).toBe(false);
+    expect(hasType('file')).toBe(true);
+  });
+});

--- a/src/engine/node-types/index.ts
+++ b/src/engine/node-types/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Public API for the node-type engine.
+ *
+ * Importing this module guarantees the built-in node types are registered.
+ * Custom types can be added at runtime via {@link registerType} without
+ * touching the core discriminated unions.
+ */
+export type { NodeTypeDefinition } from './registry';
+export {
+  registerType,
+  resolveType,
+  hasType,
+  getRegisteredTypes,
+  registerBuiltInNodeTypes,
+  resetNodeTypeRegistry,
+  resolveNodeLayer,
+  resolveTypeCluster,
+} from './registry';

--- a/src/engine/node-types/registry.ts
+++ b/src/engine/node-types/registry.ts
@@ -1,0 +1,135 @@
+/**
+ * Node-type registry — the open, data-driven core of the node-type engine.
+ *
+ * Each node type declares how it participates in the graph: its layer, default
+ * cluster, the relations it tends to emit, and which viewer renders it. The
+ * registry is consulted by {@link getNodeLayer} (via {@link resolveNodeLayer})
+ * and by cluster/legend logic, so adding a brand-new node type requires only a
+ * `registerType` call — no edits to the core discriminated unions or render
+ * switches.
+ *
+ * Implementation note: this module imports from `../../types` **type-only**, so
+ * there is no runtime import cycle even though `types/index.ts` imports
+ * {@link resolveNodeLayer} from here at runtime.
+ */
+import type { KBNode, NodeLayer } from '../../types';
+
+/** A registered node type and how it participates in the graph. */
+export interface NodeTypeDefinition {
+  /** Type id — matches a node's `entityType` or, for built-ins, its `source.type`. */
+  id: string;
+  /** Human-readable label (defaults to a humanized id). */
+  label?: string;
+  /** Graph layer this type belongs to. Defaults to `'file'` when unset. */
+  layer?: NodeLayer;
+  /** Default cluster id for nodes of this type (used when a node omits its cluster). */
+  cluster?: string;
+  /** Relation kinds this type commonly emits (informational; surfaced to the legend). */
+  relations?: string[];
+  /**
+   * Viewer key used to resolve a renderer from the viewer registry. Defaults to
+   * the type `id`. The viewer registry falls back to the generic viewer when no
+   * component is registered for the key.
+   */
+  viewer?: string;
+  /** Short description of the type (documentation aid). */
+  description?: string;
+  /**
+   * Optional discovery hook — given raw upstream records, decide which become
+   * nodes of this type. Reserved for content-model ingestion (F2/F3); the
+   * foundation only stores it.
+   */
+  discover?: (records: unknown[]) => unknown[];
+  /**
+   * Optional mapping hook — turn a single upstream record into a partial node.
+   * Reserved for ingestion (F2/F3); the foundation only stores it.
+   */
+  map?: (record: unknown) => Partial<KBNode>;
+}
+
+const registry = new Map<string, NodeTypeDefinition>();
+
+/**
+ * Built-in source types and their historical layer mapping. Registering these
+ * keeps {@link getNodeLayer} byte-identical to the previous hardcoded switch.
+ */
+const BUILT_IN_NODE_TYPES: NodeTypeDefinition[] = [
+  { id: 'authored', layer: 'content', label: 'Authored' },
+  { id: 'readme', layer: 'content', label: 'README' },
+  { id: 'derived', layer: 'content', label: 'Derived' },
+  { id: 'section', layer: 'content', label: 'Section' },
+  { id: 'structured', layer: 'content', label: 'Structured' },
+  { id: 'issue', layer: 'work', label: 'Issue' },
+  { id: 'pull_request', layer: 'work', label: 'Pull Request' },
+  { id: 'commit', layer: 'work', label: 'Commit' },
+  { id: 'branch', layer: 'work', label: 'Branch' },
+  { id: 'workflow', layer: 'work', label: 'Workflow' },
+  { id: 'repository', layer: 'work', label: 'Repository' },
+  { id: 'file', layer: 'file', label: 'File' },
+  { id: 'external', layer: 'file', label: 'External' },
+];
+
+/** Register (or replace) a node type. */
+export function registerType(def: NodeTypeDefinition): void {
+  registry.set(def.id, def);
+}
+
+/** Resolve a node type by id. Returns `undefined` for unknown ids. */
+export function resolveType(id: string | undefined): NodeTypeDefinition | undefined {
+  if (!id) return undefined;
+  return registry.get(id);
+}
+
+/** Whether a node type id is registered. */
+export function hasType(id: string): boolean {
+  return registry.has(id);
+}
+
+/** All registered node types. */
+export function getRegisteredTypes(): NodeTypeDefinition[] {
+  return [...registry.values()];
+}
+
+/** (Re)register the built-in source types. Idempotent. */
+export function registerBuiltInNodeTypes(): void {
+  for (const def of BUILT_IN_NODE_TYPES) {
+    if (!registry.has(def.id)) registry.set(def.id, def);
+  }
+}
+
+/** Clear the registry back to just the built-ins. Intended for tests. */
+export function resetNodeTypeRegistry(): void {
+  registry.clear();
+  registerBuiltInNodeTypes();
+}
+
+/**
+ * Resolve a node's graph layer via the registry.
+ *
+ * Precedence: the node's `entityType` definition → its `source.type`
+ * definition → `'file'`. This preserves the historical mapping for built-in
+ * source types while letting registered entity types override the layer.
+ */
+export function resolveNodeLayer(node: KBNode): NodeLayer {
+  const byEntity = node.entityType ? registry.get(node.entityType) : undefined;
+  if (byEntity?.layer) return byEntity.layer;
+  const bySource = registry.get(node.source.type);
+  if (bySource?.layer) return bySource.layer;
+  return 'file';
+}
+
+/**
+ * Resolve the default cluster for a node from its type, when the node does not
+ * already declare one. Returns `undefined` when nothing is registered.
+ */
+export function resolveTypeCluster(
+  node: Pick<KBNode, 'entityType'> & { source: { type: string } },
+): string | undefined {
+  const byEntity = node.entityType ? registry.get(node.entityType) : undefined;
+  if (byEntity?.cluster) return byEntity.cluster;
+  return registry.get(node.source.type)?.cluster;
+}
+
+// Register built-ins on first import so resolution works before any caller
+// registers custom types.
+registerBuiltInNodeTypes();

--- a/src/hooks/useKnowledgeBase.ts
+++ b/src/hooks/useKnowledgeBase.ts
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import type { KBGraph, KBConfig, SourceConfig } from '../types';
 import { detectLocalMode, loadLocalKnowledgeBase } from '../engine/local-loader';
 import { loadRemoteKnowledgeBase } from '../engine/remote-loader';
+import { isDemoEntitiesEnabled, injectDemoEntities } from '../engine/demo-entities';
 
 export type LoadingState =
   | { status: 'loading' }
@@ -33,7 +34,8 @@ export function useKnowledgeBase(sourceOverride?: SourceConfig): LoadingState {
                 error: 'No content found in local manifest. Run `npm run prebuild` to regenerate.',
               });
             } else {
-              setState({ status: 'ready', graph, config });
+              const finalGraph = isDemoEntitiesEnabled() ? injectDemoEntities(graph) : graph;
+              setState({ status: 'ready', graph: finalGraph, config });
             }
           }
           return;
@@ -48,7 +50,8 @@ export function useKnowledgeBase(sourceOverride?: SourceConfig): LoadingState {
               error: 'No content loaded. The GitHub API may be rate-limited — try again in a minute, or check your network.',
             });
           } else {
-            setState({ status: 'ready', graph, config });
+            const finalGraph = isDemoEntitiesEnabled() ? injectDemoEntities(graph) : graph;
+            setState({ status: 'ready', graph: finalGraph, config });
           }
         }
       } catch (err) {

--- a/src/styles/reading.css
+++ b/src/styles/reading.css
@@ -204,6 +204,114 @@
   font-size: var(--prose-font-size, 14px);
 }
 
+/* ── Structured / entity viewer (generic fallback) ───── */
+
+.kb-structured-view {
+  max-width: var(--prose-max-width, 75%);
+  width: 100%;
+  margin: 0 auto;
+  font-size: var(--prose-font-size, 14px);
+  line-height: 1.5;
+  color: var(--colorNeutralForeground1);
+}
+
+.kb-structured-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1.25rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid var(--colorNeutralStroke2);
+}
+
+.kb-structured-type {
+  font-weight: 600;
+  font-size: 0.85em;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 0.2em 0.6em;
+  border-radius: 4px;
+  background: var(--colorBrandBackground2, var(--colorNeutralBackground3));
+  color: var(--colorBrandForeground1, var(--colorNeutralForeground1));
+}
+
+.kb-structured-id {
+  font-family: 'Cascadia Code', 'Cascadia Mono', Consolas, monospace;
+  font-size: 0.82em;
+  color: var(--colorNeutralForeground3);
+}
+
+.kb-structured-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.kb-structured-table .kb-structured-table {
+  margin: 0;
+}
+
+.kb-structured-key,
+.kb-structured-value {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--colorNeutralStroke2);
+  text-align: left;
+  vertical-align: top;
+}
+
+.kb-structured-key {
+  width: 30%;
+  font-weight: 600;
+  background: var(--colorNeutralBackground3);
+  color: var(--colorNeutralForeground2);
+}
+
+.kb-structured-list {
+  margin: 0;
+  padding-left: 1.25em;
+}
+
+.kb-structured-list li {
+  margin-bottom: 0.2rem;
+}
+
+.kb-structured-array {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.kb-structured-array-item {
+  border-left: 3px solid var(--colorNeutralStroke2);
+  padding-left: 0.6rem;
+}
+
+.kb-structured-link {
+  color: var(--colorBrandForegroundLink);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  word-break: break-all;
+}
+
+.kb-structured-link:hover {
+  color: var(--colorBrandForegroundLinkHover);
+}
+
+.kb-structured-code {
+  font-family: 'Cascadia Code', 'Cascadia Mono', Consolas, monospace;
+  font-size: 0.85em;
+  padding: 0.1em 0.35em;
+  background: var(--colorNeutralBackground3);
+  border: 1px solid var(--colorNeutralStroke2);
+  border-radius: 4px;
+  word-break: break-all;
+}
+
+.kb-structured-empty {
+  color: var(--colorNeutralForeground4);
+  font-style: italic;
+}
+
 /* ── Responsive layout ───────────────────────────────── */
 @media (min-width: 1025px) {
   .kb-prose {

--- a/src/types/__tests__/jsonld-contract.test.ts
+++ b/src/types/__tests__/jsonld-contract.test.ts
@@ -57,6 +57,23 @@ describe('KBNode JSON-LD fields (T1.1)', () => {
     expect(ld['@type']).toEqual(['Person', 'Employee']);
   });
 
+  it('buildJsonLd: data cannot override the reserved LD keys (@id/@type/@context)', () => {
+    const ld = buildJsonLd(
+      { id: 'p1', identity: 'kg://person/p1' },
+      'Person',
+      {
+        '@id': 'kg://evil/override',
+        '@type': 'Robot',
+        '@context': 'https://evil.example',
+        name: 'Ada',
+      },
+    );
+    expect(ld['@id']).toBe('kg://person/p1');
+    expect(ld['@type']).toBe('Person');
+    expect(ld['@context']).toBe('https://schema.org');
+    expect(ld.name).toBe('Ada'); // non-reserved data still merges
+  });
+
   it('a node without the new fields behaves exactly as before', () => {
     const node = makeNode({ id: 'f1', source: { type: 'file', path: 'a.ts' } });
     expect(node.entityType).toBeUndefined();
@@ -107,8 +124,17 @@ describe('edge relation styling (T1.3)', () => {
     expect(getEdgeStyle({ type: 'imports' })).toEqual(EDGE_TYPE_STYLES.imports);
   });
 
-  it('falls back to "related" for unknown type and no relation', () => {
-    expect(getEdgeStyle({ type: 'mystery' })).toEqual(EDGE_TYPE_STYLES.related);
+  it('keeps the "related" visual style but a distinct humanized label for an unknown open type', () => {
+    const style = getEdgeStyle({ type: 'mystery' });
+    expect(style.color).toBe(EDGE_TYPE_STYLES.related.color);
+    expect(style.dashes).toEqual(EDGE_TYPE_STYLES.related.dashes);
+    expect(style.width).toBe(EDGE_TYPE_STYLES.related.width);
+    // label preserves the actual type so the legend can distinguish new edges
+    expect(style.label).toBe('Mystery');
+  });
+
+  it('an empty edge ({}) resolves to the plain "related" style', () => {
+    expect(getEdgeStyle({})).toEqual(EDGE_TYPE_STYLES.related);
   });
 
   it('legend key prefers relation, else type', () => {

--- a/src/types/__tests__/jsonld-contract.test.ts
+++ b/src/types/__tests__/jsonld-contract.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildJsonLd,
+  getEdgeStyle,
+  getEdgeLegendKey,
+  getEdgeWeight,
+  getNodeLayer,
+  RELATION_STYLES,
+  EDGE_TYPE_STYLES,
+  EDGE_TYPE_WEIGHTS,
+} from '../index';
+import type { KBNode, DisplayMode, EdgeType, JsonLd } from '../index';
+
+function makeNode(overrides: Partial<KBNode> & Pick<KBNode, 'id' | 'source'>): KBNode {
+  return {
+    title: overrides.id,
+    cluster: 'default',
+    content: '',
+    rawContent: '',
+    connections: [],
+    ...overrides,
+  };
+}
+
+// ── T1.1 JSON-LD fields ────────────────────────────────────
+
+describe('KBNode JSON-LD fields (T1.1)', () => {
+  it('carries entityType, jsonld and data additively', () => {
+    const node = makeNode({
+      id: 'p1',
+      source: { type: 'structured', entityType: 'person' },
+      entityType: 'person',
+      identity: 'kg://person/p1',
+      jsonld: { '@id': 'kg://person/p1', '@type': 'Person', name: 'Ada' },
+      data: { name: 'Ada', role: 'Lead' },
+    });
+    expect(node.entityType).toBe('person');
+    expect(node.jsonld?.['@type']).toBe('Person');
+    expect(node.data?.name).toBe('Ada');
+  });
+
+  it('buildJsonLd reuses identity as @id and merges data', () => {
+    const ld: JsonLd = buildJsonLd(
+      { id: 'p1', identity: 'kg://person/p1' },
+      'Person',
+      { name: 'Ada' },
+    );
+    expect(ld['@id']).toBe('kg://person/p1');
+    expect(ld['@type']).toBe('Person');
+    expect(ld['@context']).toBe('https://schema.org');
+    expect(ld.name).toBe('Ada');
+  });
+
+  it('buildJsonLd falls back to a kg:// node URN when identity is absent', () => {
+    const ld = buildJsonLd({ id: 'x9' }, ['Person', 'Employee']);
+    expect(ld['@id']).toBe('kg://node/x9');
+    expect(ld['@type']).toEqual(['Person', 'Employee']);
+  });
+
+  it('a node without the new fields behaves exactly as before', () => {
+    const node = makeNode({ id: 'f1', source: { type: 'file', path: 'a.ts' } });
+    expect(node.entityType).toBeUndefined();
+    expect(node.jsonld).toBeUndefined();
+    expect(node.data).toBeUndefined();
+    expect(getNodeLayer(node)).toBe('file');
+  });
+});
+
+// ── T1.2 open unions ───────────────────────────────────────
+
+describe('open DisplayMode / EdgeType (T1.2/T1.3)', () => {
+  it('accepts both known and custom display modes (type-level)', () => {
+    const known: DisplayMode = 'entity';
+    const custom: DisplayMode = 'org-chart-3d';
+    expect([known, custom]).toEqual(['entity', 'org-chart-3d']);
+  });
+
+  it('accepts both known and custom edge types (type-level)', () => {
+    const known: EdgeType = 'contains';
+    const custom: EdgeType = 'collaborates-with';
+    expect([known, custom]).toEqual(['contains', 'collaborates-with']);
+  });
+});
+
+// ── T1.3 relation taxonomy + edge styling ──────────────────
+
+describe('edge relation styling (T1.3)', () => {
+  it('styles each known relation from RELATION_STYLES', () => {
+    for (const relation of Object.keys(RELATION_STYLES)) {
+      const style = getEdgeStyle({ relation });
+      expect(style).toEqual(RELATION_STYLES[relation as keyof typeof RELATION_STYLES]);
+    }
+  });
+
+  it('relation takes precedence over type', () => {
+    const style = getEdgeStyle({ type: 'contains', relation: 'leads' });
+    expect(style).toEqual(RELATION_STYLES.leads);
+  });
+
+  it('unknown relation gets a default style with a humanized label', () => {
+    const style = getEdgeStyle({ relation: 'mentors-junior' });
+    expect(style.label).toBe('Mentors Junior');
+    expect(style.color).toBeTruthy();
+  });
+
+  it('falls back to type style when no relation', () => {
+    expect(getEdgeStyle({ type: 'imports' })).toEqual(EDGE_TYPE_STYLES.imports);
+  });
+
+  it('falls back to "related" for unknown type and no relation', () => {
+    expect(getEdgeStyle({ type: 'mystery' })).toEqual(EDGE_TYPE_STYLES.related);
+  });
+
+  it('legend key prefers relation, else type', () => {
+    expect(getEdgeLegendKey({ type: 'contains', relation: 'leads' })).toBe('leads');
+    expect(getEdgeLegendKey({ type: 'contains' })).toBe('contains');
+    expect(getEdgeLegendKey({})).toBe('related');
+  });
+
+  it('getEdgeWeight is open-safe', () => {
+    expect(getEdgeWeight('contains')).toBe(5.0);
+    expect(getEdgeWeight('unknown-edge')).toBe(1);
+    expect(getEdgeWeight(undefined)).toBe(EDGE_TYPE_WEIGHTS.related);
+  });
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,29 @@
 /** Core data types for the kbexplorer knowledge graph. */
 
-export type DisplayMode = 'prose' | 'code' | 'file-list' | 'tree' | 'table' | 'diagram' | 'homepage' | 'gallery' | 'icon-detail' | 'repository';
+import { resolveNodeLayer } from '../engine/node-types/registry';
+
+/**
+ * How a node's content should be rendered.
+ *
+ * This is an **open** union: the listed values keep editor autocomplete, while
+ * `(string & {})` allows new display modes (and registry-driven `'entity'`
+ * viewers) to be introduced without editing this core type. `'entity'` is the
+ * escape hatch that routes a node to a viewer resolved from the viewer registry
+ * by its `entityType` / JSON-LD `@type`.
+ */
+export type KnownDisplayMode =
+  | 'prose'
+  | 'code'
+  | 'file-list'
+  | 'tree'
+  | 'table'
+  | 'diagram'
+  | 'homepage'
+  | 'gallery'
+  | 'icon-detail'
+  | 'repository'
+  | 'entity';
+export type DisplayMode = KnownDisplayMode | (string & {});
 
 /** A single entry in nodemap.yaml */
 export interface NodeMapEntry {
@@ -31,6 +54,22 @@ export interface NodeMap {
   nodes: NodeMapEntry[];
 }
 
+/**
+ * A JSON-LD envelope carried by a typed / structured node.
+ *
+ * `@id` should reuse the node's canonical `identity` URN so representations of
+ * the same real-world entity line up across providers. `@type` is the open
+ * node-type discriminator (a registry key such as `'person'` or `'team'`) and
+ * is NEVER derived from a file path. Additional LD properties may be carried as
+ * arbitrary keys.
+ */
+export interface JsonLd {
+  '@context'?: string | Record<string, unknown> | Array<string | Record<string, unknown>>;
+  '@id': string;
+  '@type': string | string[];
+  [key: string]: unknown;
+}
+
 /** A node in the knowledge graph. */
 export interface KBNode {
   id: string;
@@ -54,9 +93,38 @@ export interface KBNode {
   source: NodeSource;
   /** Which provider created this node */
   provider?: string;
+  /**
+   * Open node-type identifier — the registry key that selects this node's
+   * graph layer, default cluster and viewer (e.g. `'person'`, `'team'`).
+   * Additive: when absent the node behaves exactly as before.
+   */
+  entityType?: string;
+  /** JSON-LD envelope: `@context` / `@id` / `@type` plus arbitrary LD properties. */
+  jsonld?: JsonLd;
+  /** Arbitrary structured-data bag rendered by typed (or the generic) viewers. */
+  data?: Record<string, unknown>;
 }
 
-export type EdgeType =
+/**
+ * Build a JSON-LD envelope for a node, reusing its `identity` URN as `@id`.
+ * Additive helper — does not mutate the node.
+ */
+export function buildJsonLd(
+  node: Pick<KBNode, 'id' | 'identity'>,
+  type: string | string[],
+  data: Record<string, unknown> = {},
+  context: JsonLd['@context'] = 'https://schema.org',
+): JsonLd {
+  return {
+    '@context': context,
+    '@id': node.identity ?? `kg://node/${node.id}`,
+    '@type': type,
+    ...data,
+  };
+}
+
+/** Built-in edge types produced by the engine's structural/content analysis. */
+export type KnownEdgeType =
   | 'contains'
   | 'derived_from'
   | 'imports'
@@ -68,10 +136,35 @@ export type EdgeType =
   | 'closes'
   | 'related';
 
+/**
+ * Edge type discriminator.
+ *
+ * Open union: known types keep autocomplete while `(string & {})` lets new
+ * structural edge kinds exist without editing this core type. Visual styling
+ * and weights for arbitrary edges/relations are resolved via {@link getEdgeStyle}
+ * and {@link getEdgeWeight} rather than direct record lookups.
+ */
+export type EdgeType = KnownEdgeType | (string & {});
+
 export type EdgeSource = 'inline' | 'frontmatter' | 'inferred';
 
+/**
+ * The open relationship taxonomy carried by {@link KBEdge.relation}.
+ *
+ * These six relations come from the content model and are rendered in the
+ * legend data-drivenly. `relation` is an open string — unknown relations still
+ * render with a sensible default style.
+ */
+export type KnownRelation =
+  | 'leads'
+  | 'staffs'
+  | 'reports-to'
+  | 'structural'
+  | 'derived'
+  | 'deprecated';
+
 /** Default weights per edge type — higher = tighter layout clustering */
-export const EDGE_TYPE_WEIGHTS: Record<EdgeType, number> = {
+export const EDGE_TYPE_WEIGHTS: Record<KnownEdgeType, number> = {
   contains: 5.0,
   derived_from: 3.0,
   imports: 2.0,
@@ -92,7 +185,7 @@ export interface EdgeTypeStyle {
   label: string;
 }
 
-export const EDGE_TYPE_STYLES: Record<EdgeType, EdgeTypeStyle> = {
+export const EDGE_TYPE_STYLES: Record<KnownEdgeType, EdgeTypeStyle> = {
   contains:         { color: '#a0adb8', dashes: false,      width: 2,   label: 'Contains' },
   derived_from:     { color: '#e8a854', dashes: false,      width: 2,   label: 'Derived from' },
   imports:          { color: '#a78bfa', dashes: false,      width: 1.5, label: 'Imports' },
@@ -105,6 +198,53 @@ export const EDGE_TYPE_STYLES: Record<EdgeType, EdgeTypeStyle> = {
   related:          { color: '#8b949e', dashes: [3, 3],     width: 1.2, label: 'Related' },
 };
 
+/** Visual styles for the relation taxonomy (rendered data-drivenly in the legend). */
+export const RELATION_STYLES: Record<KnownRelation, EdgeTypeStyle> = {
+  leads:        { color: '#f0883e', dashes: false,     width: 2.5, label: 'Leads' },
+  staffs:       { color: '#3fb950', dashes: false,     width: 1.5, label: 'Staffs' },
+  'reports-to': { color: '#a371f7', dashes: false,     width: 1.8, label: 'Reports to' },
+  structural:   { color: '#a0adb8', dashes: false,     width: 2,   label: 'Structural' },
+  derived:      { color: '#e8a854', dashes: [6, 4],    width: 1.5, label: 'Derived' },
+  deprecated:   { color: '#8b949e', dashes: [2, 3],    width: 1.2, label: 'Deprecated' },
+};
+
+const DEFAULT_RELATION_STYLE: EdgeTypeStyle = { color: '#79c0ff', dashes: [2, 2], width: 1.5, label: 'Related' };
+
+/** Title-case an arbitrary relation/edge key for display in the legend. */
+function humanizeKey(key: string): string {
+  return key
+    .replace(/[-_]+/g, ' ')
+    .replace(/\b\w/g, c => c.toUpperCase());
+}
+
+/**
+ * Resolve the visual style for an edge, data-drivenly.
+ *
+ * Precedence: explicit `relation` (taxonomy → known style; otherwise a default
+ * style with a humanized label) → known `type` style → `related` fallback.
+ * This is the single source of truth used by both the graph renderer and the
+ * legend so new relations show up without code edits.
+ */
+export function getEdgeStyle(edge: { type?: EdgeType; relation?: string }): EdgeTypeStyle {
+  if (edge.relation) {
+    const known = RELATION_STYLES[edge.relation as KnownRelation];
+    if (known) return known;
+    return { ...DEFAULT_RELATION_STYLE, label: humanizeKey(edge.relation) };
+  }
+  const t = (edge.type ?? 'related') as KnownEdgeType;
+  return EDGE_TYPE_STYLES[t] ?? EDGE_TYPE_STYLES.related;
+}
+
+/** The legend key for an edge — its relation when present, else its type. */
+export function getEdgeLegendKey(edge: { type?: EdgeType; relation?: string }): string {
+  return edge.relation ?? (edge.type as string) ?? 'related';
+}
+
+/** Resolve the layout weight for an edge type (open-safe). */
+export function getEdgeWeight(type: EdgeType | undefined): number {
+  return EDGE_TYPE_WEIGHTS[(type ?? 'related') as KnownEdgeType] ?? 1;
+}
+
 export type NodeLayer = 'file' | 'content' | 'work';
 
 export const NODE_LAYER_META: Record<NodeLayer, { label: string; color: string }> = {
@@ -113,13 +253,16 @@ export const NODE_LAYER_META: Record<NodeLayer, { label: string; color: string }
   work:    { label: 'Work',    color: '#d29922' },
 };
 
-/** Classify a node into a graph layer based on its source. */
+/**
+ * Classify a node into a graph layer.
+ *
+ * Registry-driven: resolution delegates to the node-type registry
+ * ({@link resolveNodeLayer}), which honors `entityType` first, then the
+ * `source.type`, falling back to `'file'`. Built-in source types are registered
+ * with their historical layer mapping so existing graphs classify identically.
+ */
 export function getNodeLayer(node: KBNode): NodeLayer {
-  const t = node.source.type;
-  if (t === 'authored' || t === 'readme' || t === 'derived') return 'content';
-  if (t === 'section') return 'content';
-  if (t === 'issue' || t === 'pull_request' || t === 'commit' || t === 'branch' || t === 'workflow' || t === 'repository') return 'work';
-  return 'file';
+  return resolveNodeLayer(node);
 }
 
 /** Check if a file node is a redundant content/ tree entry (has an authored counterpart). */
@@ -530,6 +673,8 @@ export interface Connection {
   description: string;
   source?: EdgeSource;
   weight?: number;
+  /** Optional relationship label from the relation taxonomy (carried onto the edge). */
+  relation?: string;
 }
 
 export interface Cluster {
@@ -553,6 +698,13 @@ export interface KBEdge {
   description: string;
   source: EdgeSource;
   weight: number;
+  /**
+   * Open relationship label from the relation taxonomy
+   * (leads | staffs | reports-to | structural | derived | deprecated, or any
+   * custom string). Drives legend + edge styling via {@link getEdgeStyle} when
+   * present; orthogonal to the structural `type`.
+   */
+  relation?: string;
 }
 
 /** Visual identity mode. */
@@ -582,7 +734,15 @@ export type NodeSource =
   | { type: 'external'; provider: string }
   | { type: 'branch'; name: string; protected: boolean }
   | { type: 'workflow'; path: string }
-  | { type: 'repository'; owner: string; repo: string };
+  | { type: 'repository'; owner: string; repo: string }
+  /**
+   * Generic, registry-driven source for typed/structured nodes. This is the
+   * open escape hatch: new node types reuse `structured` and identify
+   * themselves via `entityType` (a node-type registry key) instead of each
+   * requiring a bespoke `NodeSource` variant. `ref` optionally records the
+   * upstream record id the node was mapped from.
+   */
+  | { type: 'structured'; entityType: string; ref?: string };
 
 /** Configuration for an external provider plugin */
 export interface ExternalProviderConfig {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -108,6 +108,11 @@ export interface KBNode {
 /**
  * Build a JSON-LD envelope for a node, reusing its `identity` URN as `@id`.
  * Additive helper — does not mutate the node.
+ *
+ * The reserved LD keys (`@context` / `@id` / `@type`) are written LAST so that
+ * arbitrary `data` properties can never override them — this preserves the
+ * contract guarantee that `@id` reuses the identity URN and `@type` is never
+ * path-derived.
  */
 export function buildJsonLd(
   node: Pick<KBNode, 'id' | 'identity'>,
@@ -116,10 +121,10 @@ export function buildJsonLd(
   context: JsonLd['@context'] = 'https://schema.org',
 ): JsonLd {
   return {
+    ...data,
     '@context': context,
     '@id': node.identity ?? `kg://node/${node.id}`,
     '@type': type,
-    ...data,
   };
 }
 
@@ -221,9 +226,11 @@ function humanizeKey(key: string): string {
  * Resolve the visual style for an edge, data-drivenly.
  *
  * Precedence: explicit `relation` (taxonomy → known style; otherwise a default
- * style with a humanized label) → known `type` style → `related` fallback.
- * This is the single source of truth used by both the graph renderer and the
- * legend so new relations show up without code edits.
+ * style with a humanized label) → known `type` style → for an unknown (open)
+ * `type`, the neutral `related` visual style but with the actual type string
+ * humanized as the label so new edge kinds still render distinctly in the
+ * legend. This is the single source of truth used by both the graph renderer
+ * and the legend so new relations show up without code edits.
  */
 export function getEdgeStyle(edge: { type?: EdgeType; relation?: string }): EdgeTypeStyle {
   if (edge.relation) {
@@ -232,7 +239,12 @@ export function getEdgeStyle(edge: { type?: EdgeType; relation?: string }): Edge
     return { ...DEFAULT_RELATION_STYLE, label: humanizeKey(edge.relation) };
   }
   const t = (edge.type ?? 'related') as KnownEdgeType;
-  return EDGE_TYPE_STYLES[t] ?? EDGE_TYPE_STYLES.related;
+  const known = EDGE_TYPE_STYLES[t];
+  if (known) return known;
+  // Open/unknown edge type: keep the neutral `related` visual treatment but
+  // preserve the actual type string as a humanized label so F2/F3 relations are
+  // distinguishable in the data-driven legend.
+  return { ...EDGE_TYPE_STYLES.related, label: humanizeKey(edge.type as string) };
 }
 
 /** The legend key for an edge — its relation when present, else its type. */

--- a/src/views/ReadingView.tsx
+++ b/src/views/ReadingView.tsx
@@ -17,6 +17,7 @@ import { NodeVisual } from '../components/NodeVisual';
 import { HomePageWidgets } from '../components/HomePageWidgets';
 import { ConstellationHero } from '../components/ConstellationHero';
 import { IconGallery } from '../components/IconGallery';
+import { resolveViewer } from './viewers';
 
 interface ReadingViewProps {
   graph: KBGraph;
@@ -305,9 +306,27 @@ function renderContent(node: KBNode, linkedHtml: string, graph?: KBGraph, config
           <IconGallery />
         </div>
       );
+    case 'entity': {
+      const Viewer = resolveViewer(node);
+      return (
+        <div>
+          <Viewer node={node} />
+          {node.content?.trim() && (
+            <div className="kb-prose" style={{ marginTop: '1.5rem' }} dangerouslySetInnerHTML={{ __html: linkedHtml }} />
+          )}
+        </div>
+      );
+    }
     default:
       return <div className="kb-prose" dangerouslySetInnerHTML={{ __html: linkedHtml }} />;
   }
+}
+
+function humanizeEntityType(t: string): string {
+  return t
+    .replace(/[-_]+/g, ' ')
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/\b\w/g, c => c.toUpperCase());
 }
 
 /** Describes where a node comes from — shown as a badge next to the cluster */
@@ -366,6 +385,10 @@ function SourceBadge({ node, config }: { node: KBNode; config: KBConfig }) {
     case 'section':
       label = 'Section'
       color = '#8b949e'
+      break
+    case 'structured':
+      label = `Entity · ${humanizeEntityType(s.entityType)}`
+      color = '#c0a3ff'
       break
     default:
       return null

--- a/src/views/viewers/GenericStructuredView.tsx
+++ b/src/views/viewers/GenericStructuredView.tsx
@@ -1,0 +1,138 @@
+import type { KBNode } from '../../types';
+
+/**
+ * A viewer renders a typed node. Viewers are registered against an
+ * `entityType` (or JSON-LD `@type`) and resolved from the viewer registry, with
+ * {@link GenericStructuredView} as the mandatory fallback for unknown types.
+ */
+export type ViewerComponent = (props: ViewerProps) => React.ReactNode;
+
+export interface ViewerProps {
+  node: KBNode;
+}
+
+/** Reserved JSON-LD keys that are surfaced separately from free-form data. */
+const LD_RESERVED = new Set(['@context', '@id', '@type']);
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+function humanizeKey(key: string): string {
+  return key
+    .replace(/^@/, '')
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[-_]+/g, ' ')
+    .replace(/\b\w/g, c => c.toUpperCase());
+}
+
+/** Render a leaf scalar value. */
+function ScalarValue({ value }: { value: unknown }) {
+  if (value === null || value === undefined) {
+    return <span className="kb-structured-empty">—</span>;
+  }
+  if (typeof value === 'boolean') {
+    return <span className="kb-structured-scalar">{value ? 'true' : 'false'}</span>;
+  }
+  if (typeof value === 'string') {
+    const isUrl = /^https?:\/\//i.test(value);
+    const isUrn = /^[a-z][a-z0-9+.-]*:\/\//i.test(value);
+    if (isUrl) {
+      return (
+        <a className="kb-structured-link" href={value} target="_blank" rel="noopener">
+          {value}
+        </a>
+      );
+    }
+    if (isUrn) return <code className="kb-structured-code">{value}</code>;
+    return <span className="kb-structured-scalar">{value}</span>;
+  }
+  return <span className="kb-structured-scalar">{String(value)}</span>;
+}
+
+/** Recursively render any value as a tree of key/value rows and nested tables. */
+function ValueTree({ value, depth = 0 }: { value: unknown; depth?: number }) {
+  if (Array.isArray(value)) {
+    if (value.length === 0) return <span className="kb-structured-empty">[]</span>;
+    const allScalar = value.every(v => !isPlainObject(v) && !Array.isArray(v));
+    if (allScalar) {
+      return (
+        <ul className="kb-structured-list">
+          {value.map((item, i) => (
+            <li key={i}><ScalarValue value={item} /></li>
+          ))}
+        </ul>
+      );
+    }
+    return (
+      <div className="kb-structured-array">
+        {value.map((item, i) => (
+          <div key={i} className="kb-structured-array-item">
+            <ValueTree value={item} depth={depth + 1} />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (isPlainObject(value)) {
+    const entries = Object.entries(value);
+    if (entries.length === 0) return <span className="kb-structured-empty">{'{}'}</span>;
+    return (
+      <table className="kb-structured-table">
+        <tbody>
+          {entries.map(([k, v]) => (
+            <tr key={k}>
+              <th scope="row" className="kb-structured-key">{humanizeKey(k)}</th>
+              <td className="kb-structured-value"><ValueTree value={v} depth={depth + 1} /></td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    );
+  }
+
+  return <ScalarValue value={value} />;
+}
+
+/**
+ * Generic structured-data viewer — the mandatory fallback for any node type
+ * without a bespoke viewer. Renders `node.data` (and any non-reserved JSON-LD
+ * properties) as a key/value + nested table/tree, plus a JSON-LD header when
+ * present. Works for arbitrary nested objects so coverage is never zero.
+ */
+export function GenericStructuredView({ node }: ViewerProps) {
+  const ld = node.jsonld;
+  const ldType = ld?.['@type'];
+  const typeLabel = Array.isArray(ldType) ? ldType.join(', ') : (ldType ?? node.entityType);
+
+  // Prefer the explicit data bag; otherwise fall back to non-reserved LD props.
+  const data: Record<string, unknown> = node.data
+    ? node.data
+    : ld
+      ? Object.fromEntries(Object.entries(ld).filter(([k]) => !LD_RESERVED.has(k)))
+      : {};
+
+  const hasData = Object.keys(data).length > 0;
+
+  return (
+    <div className="kb-structured-view">
+      {(typeLabel || ld?.['@id']) && (
+        <div className="kb-structured-header">
+          {typeLabel && (
+            <span className="kb-structured-type" title="JSON-LD @type">{typeLabel}</span>
+          )}
+          {ld?.['@id'] && (
+            <code className="kb-structured-id" title="JSON-LD @id">{ld['@id']}</code>
+          )}
+        </div>
+      )}
+
+      {hasData ? (
+        <ValueTree value={data} />
+      ) : (
+        <p className="kb-structured-empty">No structured data for this node.</p>
+      )}
+    </div>
+  );
+}

--- a/src/views/viewers/PersonView.tsx
+++ b/src/views/viewers/PersonView.tsx
@@ -1,0 +1,42 @@
+import type { ViewerProps } from './GenericStructuredView';
+
+/**
+ * Example bespoke viewer for `person` entities — demonstrates that a registered
+ * `entityType` resolves to a custom renderer (vs. the generic fallback). Used by
+ * the demo-entities seam; className-styled so it is SSR-safe for tests.
+ */
+export function PersonView({ node }: ViewerProps) {
+  const d = (node.data ?? {}) as Record<string, unknown>;
+  const name = (d.name as string) ?? node.title;
+  const role = d.role as string | undefined;
+  const email = d.email as string | undefined;
+  const team = d.team as string | undefined;
+
+  return (
+    <div className="kb-structured-view kb-person-view">
+      <div className="kb-structured-header">
+        <span className="kb-structured-type" title="JSON-LD @type">Person</span>
+        {node.jsonld?.['@id'] && (
+          <code className="kb-structured-id">{node.jsonld['@id']}</code>
+        )}
+      </div>
+      <h2 className="kb-person-name">{name}</h2>
+      {role && <p className="kb-person-role">{role}</p>}
+      <table className="kb-structured-table">
+        <tbody>
+          {team && (
+            <tr><th scope="row" className="kb-structured-key">Team</th><td className="kb-structured-value">{team}</td></tr>
+          )}
+          {email && (
+            <tr>
+              <th scope="row" className="kb-structured-key">Email</th>
+              <td className="kb-structured-value">
+                <a className="kb-structured-link" href={`mailto:${email}`}>{email}</a>
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/views/viewers/__tests__/viewer-registry.test.ts
+++ b/src/views/viewers/__tests__/viewer-registry.test.ts
@@ -51,6 +51,28 @@ describe('viewer registry (T1.4)', () => {
     expect(resolveViewer(node)).toBe(PersonView);
   });
 
+  it('tries each @type array entry in order; the first registered viewer wins', () => {
+    registerViewer('person', PersonView);
+    const node = makeNode({
+      id: 'p',
+      source: { type: 'structured', entityType: 'x' },
+      jsonld: { '@id': 'kg://p', '@type': ['unregistered-a', 'person', 'unregistered-b'] },
+    });
+    expect(resolveViewer(node)).toBe(PersonView);
+  });
+
+  it('rejects empty / whitespace-only keys', () => {
+    registerViewer('   ', PersonView);
+    registerViewer('', PersonView);
+    expect(getRegisteredViewers()).toHaveLength(0);
+    const node = makeNode({
+      id: 'w',
+      source: { type: 'structured', entityType: '   ' },
+      entityType: '   ',
+    });
+    expect(resolveViewer(node)).toBe(GenericStructuredView);
+  });
+
   it('matches keys case-insensitively', () => {
     registerViewer('Person', PersonView);
     const node = makeNode({ id: 'p', source: { type: 'structured', entityType: 'PERSON' }, entityType: 'PERSON' });

--- a/src/views/viewers/__tests__/viewer-registry.test.ts
+++ b/src/views/viewers/__tests__/viewer-registry.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import {
+  registerViewer,
+  resolveViewer,
+  hasViewer,
+  getRegisteredViewers,
+  resetViewerRegistry,
+  GenericStructuredView,
+} from '../index';
+import { PersonView } from '../PersonView';
+import type { KBNode } from '../../../types';
+
+function makeNode(overrides: Partial<KBNode> & Pick<KBNode, 'id' | 'source'>): KBNode {
+  return {
+    title: overrides.id,
+    cluster: 'default',
+    content: '',
+    rawContent: '',
+    connections: [],
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  resetViewerRegistry();
+});
+
+describe('viewer registry (T1.4)', () => {
+  it('falls back to GenericStructuredView for unknown types', () => {
+    const node = makeNode({ id: 'x', source: { type: 'structured', entityType: 'whatever' }, entityType: 'whatever' });
+    expect(resolveViewer(node)).toBe(GenericStructuredView);
+  });
+
+  it('resolves a registered viewer by entityType', () => {
+    registerViewer('person', PersonView);
+    const node = makeNode({ id: 'p', source: { type: 'structured', entityType: 'person' }, entityType: 'person' });
+    expect(resolveViewer(node)).toBe(PersonView);
+    expect(hasViewer('person')).toBe(true);
+    expect(getRegisteredViewers()).toContain('person');
+  });
+
+  it('resolves by JSON-LD @type when entityType is absent', () => {
+    registerViewer('person', PersonView);
+    const node = makeNode({
+      id: 'p',
+      source: { type: 'structured', entityType: 'x' },
+      jsonld: { '@id': 'kg://p', '@type': ['Thing', 'person'] },
+    });
+    expect(resolveViewer(node)).toBe(PersonView);
+  });
+
+  it('matches keys case-insensitively', () => {
+    registerViewer('Person', PersonView);
+    const node = makeNode({ id: 'p', source: { type: 'structured', entityType: 'PERSON' }, entityType: 'PERSON' });
+    expect(resolveViewer(node)).toBe(PersonView);
+  });
+
+  it('last registration wins (override)', () => {
+    const A = () => null;
+    const B = () => null;
+    registerViewer('thing', A);
+    registerViewer('thing', B);
+    const node = makeNode({ id: 't', source: { type: 'structured', entityType: 'thing' }, entityType: 'thing' });
+    expect(resolveViewer(node)).toBe(B);
+  });
+});
+
+describe('GenericStructuredView render', () => {
+  it('renders nested data and a JSON-LD header', () => {
+    const node = makeNode({
+      id: 'p',
+      source: { type: 'structured', entityType: 'person' },
+      entityType: 'person',
+      jsonld: { '@id': 'kg://person/p', '@type': 'Person' },
+      data: { name: 'Ada', skills: ['ts', 'graphs'], manager: { name: 'Lin' } },
+    });
+    const html = renderToStaticMarkup(createElement(GenericStructuredView, { node }));
+    expect(html).toContain('kb-structured-view');
+    expect(html).toContain('Ada');
+    expect(html).toContain('Skills');
+    expect(html).toContain('Manager');
+    expect(html).toContain('Lin');
+    expect(html).toContain('kg://person/p');
+  });
+
+  it('renders an empty-state message when there is no data', () => {
+    const node = makeNode({ id: 'e', source: { type: 'structured', entityType: 't' }, entityType: 't' });
+    const html = renderToStaticMarkup(createElement(GenericStructuredView, { node }));
+    expect(html).toContain('No structured data');
+  });
+});
+
+describe('PersonView render', () => {
+  it('renders the person name, role and email link', () => {
+    const node = makeNode({
+      id: 'p',
+      source: { type: 'structured', entityType: 'person' },
+      entityType: 'person',
+      jsonld: { '@id': 'kg://person/p', '@type': 'Person' },
+      data: { name: 'Ada Okonkwo', role: 'Engineering Lead', email: 'ada@example.com' },
+    });
+    const html = renderToStaticMarkup(createElement(PersonView, { node }));
+    expect(html).toContain('Ada Okonkwo');
+    expect(html).toContain('Engineering Lead');
+    expect(html).toContain('mailto:ada@example.com');
+  });
+});

--- a/src/views/viewers/index.ts
+++ b/src/views/viewers/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Public API for the viewer registry (T1.4).
+ *
+ * Import this barrel to register or resolve viewers. {@link GenericStructuredView}
+ * is the mandatory fallback for any node type without a bespoke viewer.
+ *
+ * @example
+ * ```ts
+ * import { registerViewer, resolveViewer } from './views/viewers';
+ * registerViewer('person', PersonView);
+ * const Viewer = resolveViewer(node); // PersonView, or GenericStructuredView
+ * ```
+ */
+export {
+  registerViewer,
+  resolveViewer,
+  hasViewer,
+  getRegisteredViewers,
+  resetViewerRegistry,
+} from './registry';
+
+export {
+  GenericStructuredView,
+  type ViewerComponent,
+  type ViewerProps,
+} from './GenericStructuredView';

--- a/src/views/viewers/registry.ts
+++ b/src/views/viewers/registry.ts
@@ -1,0 +1,60 @@
+import type { KBNode } from '../../types';
+import { GenericStructuredView, type ViewerComponent } from './GenericStructuredView';
+
+/**
+ * Viewer registry — maps an `entityType` (or JSON-LD `@type`) to a React
+ * renderer. This is the open seam that lets a "person" or "team/squad" node get
+ * a rich custom view without editing the core. Unknown types resolve to
+ * {@link GenericStructuredView}, so coverage is never zero.
+ *
+ * Keys are matched case-insensitively. Registering the same key twice replaces
+ * the prior viewer (last registration wins) so downstream packages can override
+ * built-ins.
+ */
+const registry = new Map<string, ViewerComponent>();
+
+function normalizeKey(key: string): string {
+  return key.trim().toLowerCase();
+}
+
+/** Register a viewer for an `entityType` / JSON-LD `@type`. */
+export function registerViewer(entityType: string, viewer: ViewerComponent): void {
+  if (!entityType) return;
+  registry.set(normalizeKey(entityType), viewer);
+}
+
+/** True if a bespoke viewer is registered for the given type. */
+export function hasViewer(entityType: string | undefined | null): boolean {
+  if (!entityType) return false;
+  return registry.has(normalizeKey(entityType));
+}
+
+/** List the registered entity-type keys (excluding the generic fallback). */
+export function getRegisteredViewers(): string[] {
+  return [...registry.keys()];
+}
+
+/** Remove all registered viewers — primarily for tests. */
+export function resetViewerRegistry(): void {
+  registry.clear();
+}
+
+/**
+ * Resolve a viewer for a node. Resolution precedence:
+ * 1. `node.entityType`
+ * 2. JSON-LD `@type` (first entry when it is an array)
+ * 3. {@link GenericStructuredView} fallback.
+ */
+export function resolveViewer(node: Pick<KBNode, 'entityType' | 'jsonld'>): ViewerComponent {
+  const candidates: string[] = [];
+  if (node.entityType) candidates.push(node.entityType);
+  const ldType = node.jsonld?.['@type'];
+  if (Array.isArray(ldType)) candidates.push(...ldType);
+  else if (ldType) candidates.push(ldType);
+
+  for (const candidate of candidates) {
+    const viewer = registry.get(normalizeKey(candidate));
+    if (viewer) return viewer;
+  }
+  return GenericStructuredView;
+}

--- a/src/views/viewers/registry.ts
+++ b/src/views/viewers/registry.ts
@@ -19,8 +19,9 @@ function normalizeKey(key: string): string {
 
 /** Register a viewer for an `entityType` / JSON-LD `@type`. */
 export function registerViewer(entityType: string, viewer: ViewerComponent): void {
-  if (!entityType) return;
-  registry.set(normalizeKey(entityType), viewer);
+  const key = normalizeKey(entityType ?? '');
+  if (!key) return; // reject empty / whitespace-only keys
+  registry.set(key, viewer);
 }
 
 /** True if a bespoke viewer is registered for the given type. */
@@ -42,7 +43,8 @@ export function resetViewerRegistry(): void {
 /**
  * Resolve a viewer for a node. Resolution precedence:
  * 1. `node.entityType`
- * 2. JSON-LD `@type` (first entry when it is an array)
+ * 2. JSON-LD `@type` — when it is an array each entry is tried in order and the
+ *    first entry with a registered viewer wins.
  * 3. {@link GenericStructuredView} fallback.
  */
 export function resolveViewer(node: Pick<KBNode, 'entityType' | 'jsonld'>): ViewerComponent {


### PR DESCRIPTION
## Feature F1 — Open node-type foundation (JSON-LD nodes + registries)

Foundational feature of Epic #147: turns kbexplorer into an open, data-driven node-type engine. **F2 (#149), F3 (#150) and the cli repo's F8 (#18) are blocked-by this surface** — the contract is also published as a comment on #148 for early consumption.

All changes are **additive and backward-compatible**: a node/edge/provider that omits the new fields behaves exactly as before.

### What landed

| Task | Sub-issue | Summary |
|---|---|---|
| T1.1 | #154 | `KBNode.entityType` / `jsonld` (`@context`/`@id`/`@type` + LD props) / `data` bag; `buildJsonLd()` helper (`@id` reuses identity URN; `@type` never path-derived). |
| T1.2 | #155 | Open `DisplayMode` (`KnownDisplayMode \| (string & {})`, `'entity'` escape hatch); `NodeSource` gains a clean `{ type:'structured'; entityType; ref? }` variant; node-type registry. |
| T1.3 | #156 | Open `EdgeType`; `KBEdge.relation` / `Connection.relation`; 6-relation taxonomy (`leads\|staffs\|reports-to\|structural\|derived\|deprecated`) with `getEdgeStyle`/`getEdgeLegendKey`/`getEdgeWeight`; data-driven HUD legend. |
| T1.4 | #157 | Viewer registry (`src/views/viewers`): `registerViewer`/`resolveViewer` + mandatory `GenericStructuredView` fallback; `PersonView` example. |
| T1.5 | #155 | `getNodeLayer` is now registry-driven via `resolveNodeLayer` (built-ins pre-registered → byte-identical layer output). |
| T1.6 | #158/#159 | `ReadingView` `display:'entity'` resolves a viewer; `SourceBadge` handles `structured`; `CACHE_VERSION` 12 → 13; `content/node-types.md` contract doc; 33 new unit tests. |

### Design decisions
- **`NodeSource` opened via a clean `structured` variant** instead of `(string & {})`, to preserve exhaustive narrowing in `SourceBadge`/identity. New node types reuse `structured` + a registry `entityType` and never edit the core union.
- **Single styling source of truth** (`getEdgeStyle`) shared by the graph renderer and the legend, so they can't drift.
- **No runtime import cycle**: `types/index.ts` imports `resolveNodeLayer` (value) from the registry, which imports types **type-only**.
- **Off-by-default demo seam** `injectDemoEntities()` (`?demo=entities` / `localStorage['kbe-demo-entities']`) seeds person/team entities + relation edges for e2e evidence without polluting real graphs.

### Validation
- ✅ `npm test` — **209 unit tests passing** (33 new: JSON-LD/edge contract, node-type registry, viewer registry incl. SSR render, demo seam).
- ✅ `npx vite build` green (default + `VITE_KB_LOCAL` local build).
- ✅ Playwright (chromium): new `e2e/entity-nodes.spec.ts` (3) — PersonView resolution, generic fallback for the team entity, structured SourceBadge, **clean render with stale v12 cache present** — plus existing smoke/display-modes/navigation/layer-views (16) all green.
- Repo rules honored: no pixel layout sizing (viewer CSS uses rem/%/tokens; 1px borders only); `CACHE_VERSION` bumped for the new cached shape.

### Assumptions (resolved autonomously)
1. `content-model.md` is not present in this repo (likely a sibling-worktree artifact) → sub-issues #154–#159 treated as authoritative, adopting the 6-relation taxonomy + `kg://` `@id` + "@type never from path" rules from the brief.
2. `NodeSource` opened via the clean `structured` variant (narrowing safety).
3. Added the off-by-default demo seam to produce Playwright evidence.

Closes #148
Closes #154
Closes #155
Closes #156
Closes #157
Closes #158
Closes #159

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
