### PR TITLE
F4: Integration validation & release readiness

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -14,9 +14,15 @@ permissions:
   pages: write
   id-token: write
 
+# Scope concurrency per-ref so PR `test` runs don't cancel each other (a single
+# global `pages` group with cancel-in-progress:true killed sibling/main runs
+# mid-flight). PR runs supersede older runs of the SAME PR (saves CI minutes);
+# different refs never cancel one another. Pushes to main (the only ref that
+# deploys) use a distinct group with cancel-in-progress:false, so Pages deploys
+# serialize and are never cancelled mid-deployment — preserving the deploy contract.
 concurrency:
-  group: pages
-  cancel-in-progress: true
+  group: pages-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   test:
@@ -44,6 +50,9 @@ jobs:
 
       - name: Validate graph
         run: npm run validate
+
+      - name: Check manifest drift (idempotency)
+        run: npm run validate:drift
 
       - name: Assess graph quality
         run: node scripts/assess-graph.js --gate

--- a/e2e/integration-validation.spec.ts
+++ b/e2e/integration-validation.spec.ts
@@ -1,0 +1,101 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * F4 / T4.1 — Real-content integration E2E (#169).
+ *
+ * Validates the whole new-node-type system end-to-end on the REAL local cached
+ * data flow (the `VITE_KB_LOCAL=true` build served by `vite preview`), exercised
+ * as a returning user would hit it: the demo-entities seam is enabled via the
+ * PERSISTED `localStorage['kbe-demo-entities']` setting (not a clean-state
+ * `?demo=` URL shortcut), and each node is reached after the graph has already
+ * been loaded + cached by a prior navigation in the same session (cache present,
+ * in-session switching) — per the repo's "test the actual cached flow" rule.
+ *
+ * Proves:
+ *   (a) a Person node renders through its bespoke PersonView (F1/F2 viewer registry)
+ *   (b) a Squad  node renders through its bespoke SquadView   (F2 / #164)
+ *   (c) a .github Workflow node renders through WorkflowView AND shows its
+ *       `structural` edge to the `repo-meta` repository node (F3 / #167), navigable.
+ *
+ * A screenshot of each is captured to e2e/artifacts/ as evidence.
+ */
+
+const ART = 'e2e/artifacts';
+
+test.describe('F4 integration validation (real cached-data flow)', () => {
+  test.beforeEach(async ({ page }) => {
+    // Persisted setting: enable the demo-entities seam the way a returning user
+    // would have it set — via localStorage, applied on every load in this context.
+    await page.addInitScript(() => {
+      try {
+        localStorage.setItem('kbe-demo-entities', '1');
+      } catch {
+        /* localStorage may be unavailable; the seam also honors ?demo=entities */
+      }
+    });
+
+    // Warm the cache: load the hub once so the graph is built + cached in
+    // localStorage. Subsequent navigations exercise the cached-data path.
+    await page.goto('/#/node/readme', { timeout: 60000 });
+    await expect(page.locator('.kb-prose').first()).toBeVisible({ timeout: 20000 });
+  });
+
+  test('(a) Person node renders through the bespoke PersonView', async ({ page }) => {
+    await page.goto('/#/node/demo-person-ada', { timeout: 60000 });
+
+    const view = page.locator('.kb-person-view');
+    await expect(view).toBeVisible({ timeout: 15000 });
+    await expect(view).toContainText('Ada Okonkwo');
+    await expect(view).toContainText('Engineering Lead');
+    await expect(view.locator('a[href^="mailto:"]')).toHaveAttribute('href', 'mailto:ada@example.com');
+
+    // Structured SourceBadge classifies the entity source.
+    await expect(page.getByText(/Entity · Person/i).first()).toBeVisible({ timeout: 10000 });
+
+    await page.screenshot({ path: `${ART}/f4-person-node.png`, fullPage: true });
+  });
+
+  test('(b) Squad node renders through the bespoke SquadView', async ({ page }) => {
+    await page.goto('/#/node/demo-squad-orbit', { timeout: 60000 });
+
+    const view = page.locator('.kb-squad-view');
+    await expect(view).toBeVisible({ timeout: 15000 });
+    await expect(view).toContainText('Squad Orbit');
+    await expect(view).toContainText('Delivers the discovery & search experience');
+    // DRI handle + members surfaced by the bespoke viewer.
+    await expect(view).toContainText('@ada');
+    await expect(view).toContainText('Ada Okonkwo');
+    await expect(view).toContainText('Ben Carter');
+
+    // Structured SourceBadge classifies the squad entity source.
+    await expect(page.getByText(/Entity · Squad/i).first()).toBeVisible({ timeout: 10000 });
+
+    await page.screenshot({ path: `${ART}/f4-squad-node.png`, fullPage: true });
+  });
+
+  test('(c) Workflow node renders via WorkflowView and links to repo-meta', async ({ page }) => {
+    await page.goto('/#/node/gh-workflow-github-pages-yml', { timeout: 60000 });
+
+    // Bespoke workflow viewer.
+    const view = page.locator('.kb-workflow-view');
+    await expect(view).toBeVisible({ timeout: 15000 });
+    await expect(view).toContainText('Deploy to GitHub Pages');
+    await expect(view.locator('.kb-workflow-triggers')).toContainText('Triggers');
+    await expect(view.locator('.kb-workflow-jobs')).toContainText('Jobs');
+
+    await expect(page.getByText(/Workflow · github-pages\.yml/i).first()).toBeVisible({ timeout: 10000 });
+
+    // Structural edge to the repository (repo-meta) node — visible + navigable.
+    const relations = page.getByTestId('structural-relations');
+    await expect(relations).toBeVisible({ timeout: 10000 });
+    const repoLink = relations.locator('a[href="#/node/repo-meta"]');
+    await expect(repoLink).toBeVisible();
+    await expect(repoLink).toContainText(/configures the repository/i);
+
+    await page.screenshot({ path: `${ART}/f4-workflow-structural-edge.png`, fullPage: true });
+
+    // Follow the structural edge to the repository node.
+    await repoLink.click();
+    await expect(page).toHaveURL(/#\/node\/repo-meta$/);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:e2e:ui": "playwright test --ui",
     "preview": "vite preview",
     "validate": "node scripts/validate-graph.js",
+    "validate:drift": "node scripts/check-manifest-drift.js",
     "assess": "node scripts/assess-graph.js",
     "derive": "node scripts/derive-content.js",
     "compare": "node scripts/compare-content.js",

--- a/scripts/check-manifest-drift.js
+++ b/scripts/check-manifest-drift.js
@@ -79,12 +79,40 @@ const PARITY_FIELDS = [
   'contentModel',
 ];
 
+/**
+ * Canonicalize a value so comparison is insensitive to incidental ordering:
+ * object keys are sorted recursively and arrays are sorted by their canonical
+ * JSON form. The upstream `generate-manifest` helpers enumerate directories via
+ * `readdirSync` without sorting, so raw `readdir` order can differ across
+ * filesystems/OSes. Canonicalizing before stringifying means only *content*
+ * differences register as drift — pure ordering variance never produces a false
+ * positive. Any added/removed/changed entry still changes the canonical JSON, so
+ * real drift is preserved.
+ */
+function canonicalize(value) {
+  if (Array.isArray(value)) {
+    return value
+      .map(canonicalize)
+      .map(v => [JSON.stringify(v), v])
+      .sort((a, b) => (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0))
+      .map(pair => pair[1]);
+  }
+  if (value && typeof value === 'object') {
+    const out = {};
+    for (const key of Object.keys(value).sort()) {
+      out[key] = canonicalize(value[key]);
+    }
+    return out;
+  }
+  return value;
+}
+
 function main() {
   const root = process.argv[2] ? resolve(process.argv[2]) : repoRoot;
 
   // ── Check 1: idempotency ────────────────────────────────────
-  const first = JSON.stringify(buildSourceDerived(root), null, 2);
-  const second = JSON.stringify(buildSourceDerived(root), null, 2);
+  const first = JSON.stringify(canonicalize(buildSourceDerived(root)), null, 2);
+  const second = JSON.stringify(canonicalize(buildSourceDerived(root)), null, 2);
 
   if (first !== second) {
     console.error('[drift] FAIL — source-derived assembly is NON-deterministic across re-runs.');
@@ -104,7 +132,7 @@ function main() {
   console.log('[drift] OK — source-derived manifest is byte-identical across re-runs (idempotent).');
 
   // ── Check 2: on-disk parity (best-effort) ───────────────────
-  const manifestPath = resolve(repoRoot, 'src', 'generated', 'repo-manifest.json');
+  const manifestPath = resolve(root, 'src', 'generated', 'repo-manifest.json');
   if (!existsSync(manifestPath)) {
     console.log('[drift] No on-disk manifest found — skipping parity check (idempotency already verified).');
     process.exit(0);
@@ -121,7 +149,9 @@ function main() {
   const fresh = buildSourceDerived(root);
   const drifted = [];
   for (const field of PARITY_FIELDS) {
-    if (JSON.stringify(onDisk[field]) !== JSON.stringify(fresh[field])) {
+    if (
+      JSON.stringify(canonicalize(onDisk[field])) !== JSON.stringify(canonicalize(fresh[field]))
+    ) {
       drifted.push(field);
     }
   }

--- a/scripts/check-manifest-drift.js
+++ b/scripts/check-manifest-drift.js
@@ -1,0 +1,144 @@
+/**
+ * Manifest drift / idempotency check (F4 / T4.2 — issue #170).
+ *
+ * Answers the release-readiness question: *"if I re-run the manifest build with
+ * unchanged sources, do I get byte-identical output?"* — i.e. is the
+ * source-derived assembly (tree + `.github` structural files + content-model +
+ * node-map + config + authored content + README) deterministic, and is the
+ * currently-generated manifest in sync with the committed sources?
+ *
+ * It deliberately compares ONLY the deterministic, source-derived fields and
+ * excludes the volatile ones that legitimately change between environments/runs:
+ *   - generatedAt (timestamp)
+ *   - issues / pullRequests / commits / branches / repoMetadata (git + GitHub state)
+ *
+ * Two checks:
+ *   1. Idempotency (gating): regenerate the source-derived projection twice and
+ *      assert byte-identical JSON. Catches non-deterministic ordering / hidden
+ *      timestamps / randomness in the assembly.
+ *   2. On-disk parity (gating, when a manifest exists): compare the source-derived
+ *      fields of the on-disk `repo-manifest.json` against a fresh projection.
+ *      Catches "sources changed but the manifest wasn't re-generated". The `tree`
+ *      field is excluded here because it lists `src/generated/repo-manifest.json`
+ *      itself, whose size depends on the (excluded) volatile fields — comparing it
+ *      would be self-referential.
+ *
+ * Exit codes: 0 = no drift, 1 = drift detected, 2 = unexpected error.
+ *
+ * Usage: `node scripts/check-manifest-drift.js [rootDir]`
+ */
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { existsSync, readFileSync } from 'node:fs';
+import {
+  walkFileSystem,
+  readAuthoredContent,
+  readConfig,
+  readReadme,
+  readNodemap,
+  readStructuredNodeMap,
+  collectStructuralFiles,
+  collectNodemapData,
+  readContentModel,
+} from './generate-manifest.js';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(scriptDir, '..');
+
+/** Deterministic, source-derived fields only — no git/GitHub/timestamp data. */
+function buildSourceDerived(root) {
+  const contentPath = process.env.VITE_KB_PATH || 'content';
+  const contentDir = resolve(root, contentPath);
+  const tree = walkFileSystem(root);
+  const nodemapRaw = readNodemap(root);
+  const { nodemapFiles, nodemapDirs } = collectNodemapData(root, nodemapRaw, tree);
+  return {
+    configRaw: readConfig(root, contentPath),
+    authoredContent: readAuthoredContent(contentDir, contentPath),
+    tree,
+    readme: readReadme(root),
+    nodemapRaw,
+    nodemapFiles,
+    nodemapDirs,
+    structuredNodeMapRaw: readStructuredNodeMap(root),
+    structuralFiles: collectStructuralFiles(root, tree),
+    contentModel: readContentModel(root),
+  };
+}
+
+/** Fields safe to compare against an on-disk manifest (no self-reference). */
+const PARITY_FIELDS = [
+  'configRaw',
+  'authoredContent',
+  'readme',
+  'nodemapRaw',
+  'nodemapFiles',
+  'nodemapDirs',
+  'structuredNodeMapRaw',
+  'structuralFiles',
+  'contentModel',
+];
+
+function main() {
+  const root = process.argv[2] ? resolve(process.argv[2]) : repoRoot;
+
+  // ── Check 1: idempotency ────────────────────────────────────
+  const first = JSON.stringify(buildSourceDerived(root), null, 2);
+  const second = JSON.stringify(buildSourceDerived(root), null, 2);
+
+  if (first !== second) {
+    console.error('[drift] FAIL — source-derived assembly is NON-deterministic across re-runs.');
+    // Surface the first differing line to make the cause obvious.
+    const a = first.split('\n');
+    const b = second.split('\n');
+    for (let i = 0; i < Math.max(a.length, b.length); i++) {
+      if (a[i] !== b[i]) {
+        console.error(`  first divergence at line ${i + 1}:`);
+        console.error(`    run #1: ${a[i] ?? '<eof>'}`);
+        console.error(`    run #2: ${b[i] ?? '<eof>'}`);
+        break;
+      }
+    }
+    process.exit(1);
+  }
+  console.log('[drift] OK — source-derived manifest is byte-identical across re-runs (idempotent).');
+
+  // ── Check 2: on-disk parity (best-effort) ───────────────────
+  const manifestPath = resolve(repoRoot, 'src', 'generated', 'repo-manifest.json');
+  if (!existsSync(manifestPath)) {
+    console.log('[drift] No on-disk manifest found — skipping parity check (idempotency already verified).');
+    process.exit(0);
+  }
+
+  let onDisk;
+  try {
+    onDisk = JSON.parse(readFileSync(manifestPath, 'utf-8'));
+  } catch (err) {
+    console.error(`[drift] FAIL — on-disk manifest is not valid JSON: ${err.message}`);
+    process.exit(1);
+  }
+
+  const fresh = buildSourceDerived(root);
+  const drifted = [];
+  for (const field of PARITY_FIELDS) {
+    if (JSON.stringify(onDisk[field]) !== JSON.stringify(fresh[field])) {
+      drifted.push(field);
+    }
+  }
+
+  if (drifted.length > 0) {
+    console.error('[drift] FAIL — on-disk manifest is stale vs current sources. Re-run `generate-manifest`.');
+    console.error(`  drifted source fields: ${drifted.join(', ')}`);
+    process.exit(1);
+  }
+
+  console.log('[drift] OK — on-disk manifest source fields match the committed sources (no drift).');
+  process.exit(0);
+}
+
+try {
+  main();
+} catch (err) {
+  console.error(`[drift] ERROR — ${err.stack || err.message}`);
+  process.exit(2);
+}

--- a/src/engine/__tests__/demo-entities.test.ts
+++ b/src/engine/__tests__/demo-entities.test.ts
@@ -35,18 +35,30 @@ describe('demo-entities seam', () => {
     expect(isDemoEntitiesEnabled()).toBe(false);
   });
 
-  it('appends person/team entity nodes without mutating the original graph', () => {
+  it('appends person/squad/team entity nodes without mutating the original graph', () => {
     const graph = baseGraph();
     const originalNodeCount = graph.nodes.length;
     const result = injectDemoEntities(graph);
 
     expect(graph.nodes).toHaveLength(originalNodeCount); // original untouched
-    expect(result.nodes.length).toBe(originalNodeCount + 3);
+    expect(result.nodes.length).toBe(originalNodeCount + 4);
 
     const ids = result.nodes.map(n => n.id);
     expect(ids).toContain('demo-team-atlas');
+    expect(ids).toContain('demo-squad-orbit');
     expect(ids).toContain('demo-person-ada');
     expect(ids).toContain('demo-person-ben');
+  });
+
+  it('renders the squad through the squad entity type + SquadView data shape', () => {
+    const result = injectDemoEntities(baseGraph());
+    const squad = result.nodes.find(n => n.id === 'demo-squad-orbit')!;
+    expect(squad.display).toBe('entity');
+    expect(squad.entityType).toBe('squad');
+    expect(squad.source.type).toBe('structured');
+    expect(squad.jsonld?.['@id']).toBe(squad.identity);
+    expect(squad.data?.dri).toBe('ada');
+    expect(squad.data?.members).toEqual(['Ada Okonkwo', 'Ben Carter']);
   });
 
   it('marks entity nodes with display=entity, structured source, jsonld and data', () => {

--- a/src/engine/__tests__/derived-artifact-render.test.ts
+++ b/src/engine/__tests__/derived-artifact-render.test.ts
@@ -21,7 +21,7 @@ import { fileURLToPath } from 'node:url';
 import type { KBNode, Cluster } from '../../types';
 import { buildGraph } from '../graph';
 import { resolveType, resetNodeTypeRegistry } from '../node-types';
-import { resolveViewer } from '../../views/viewers';
+import { resolveViewer, resetViewerRegistry } from '../../views/viewers';
 import { registerContentModelTypes } from '../content-model';
 import { PersonView } from '../../views/viewers/PersonView';
 import { SquadView } from '../../views/viewers/SquadView';
@@ -45,7 +45,10 @@ describe('derived-artifact render proof (cross-repo, F8 gap)', () => {
     registerContentModelTypes();
   });
   afterAll(() => {
+    // registerContentModelTypes() populates both the node-type and viewer
+    // registries; reset both so viewer registrations don't leak into other tests.
     resetNodeTypeRegistry();
+    resetViewerRegistry();
   });
 
   it('every artifact honors the F1 JSON-LD identity contract (@id === identity URN)', () => {

--- a/src/engine/__tests__/derived-artifact-render.test.ts
+++ b/src/engine/__tests__/derived-artifact-render.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Cross-repo derived-artifact render proof (F4 — folded in from F8).
+ *
+ * The `kbexplorer` CLI (`kbexplorer derive`, sibling repo) emits committed
+ * `*.jsonld` artifacts that mirror the F1 `KBNode` contract: an `entityType`,
+ * a JSON-LD envelope whose `@id` reuses the identity URN (e.g. `kg://person/jane`),
+ * a structured `data` bag, and taxonomy relations (`reports-to` / `leads` / …)
+ * carried as `connections`.
+ *
+ * F8 could not verify cross-repo that this engine actually *renders* a CLI-emitted
+ * artifact (the CLI source isn't in this repo). This test closes that gap using
+ * committed fixture artifacts: it loads them, runs them through the engine's graph
+ * assembler + type/viewer registries, and asserts each resolves to a structured
+ * node bound to its **bespoke** viewer with the JSON-LD identity and relations
+ * intact — end-to-end through the engine.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { KBNode, Cluster } from '../../types';
+import { buildGraph } from '../graph';
+import { resolveType, resetNodeTypeRegistry } from '../node-types';
+import { resolveViewer } from '../../views/viewers';
+import { registerContentModelTypes } from '../content-model';
+import { PersonView } from '../../views/viewers/PersonView';
+import { SquadView } from '../../views/viewers/SquadView';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const DERIVED_DIR = join(here, 'fixtures', 'derived');
+
+/** Load every committed `*.jsonld` derived artifact as a KBNode mirror. */
+function loadDerivedArtifacts(): KBNode[] {
+  return readdirSync(DERIVED_DIR)
+    .filter(f => f.endsWith('.jsonld'))
+    .sort()
+    .map(f => JSON.parse(readFileSync(join(DERIVED_DIR, f), 'utf-8')) as KBNode);
+}
+
+const CLUSTERS: Cluster[] = [{ id: 'org', name: 'Organization', color: '#c0a3ff' }];
+
+describe('derived-artifact render proof (cross-repo, F8 gap)', () => {
+  beforeAll(() => {
+    // Registering the content-model spine binds person→PersonView, squad→SquadView.
+    registerContentModelTypes();
+  });
+  afterAll(() => {
+    resetNodeTypeRegistry();
+  });
+
+  it('every artifact honors the F1 JSON-LD identity contract (@id === identity URN)', () => {
+    const artifacts = loadDerivedArtifacts();
+    expect(artifacts.length).toBeGreaterThanOrEqual(3);
+    for (const node of artifacts) {
+      expect(node.entityType).toBeTruthy();
+      expect(node.jsonld?.['@id']).toBe(node.identity);
+      expect(String(node.jsonld?.['@id'])).toMatch(/^kg:\/\//);
+    }
+  });
+
+  it('resolves each derived node to its bespoke viewer through the registry', () => {
+    const byId = new Map(loadDerivedArtifacts().map(n => [n.id, n]));
+    const jane = byId.get('kg://person/jane')!;
+    const sam = byId.get('kg://person/sam')!;
+    const squad = byId.get('kg://squad/platform-core')!;
+
+    expect(resolveType(jane.entityType!)?.viewer).toBe('person');
+    expect(resolveType(squad.entityType!)?.viewer).toBe('squad');
+
+    expect(resolveViewer(jane)).toBe(PersonView);
+    expect(resolveViewer(sam)).toBe(PersonView);
+    expect(resolveViewer(squad)).toBe(SquadView);
+  });
+
+  it('assembles into a graph preserving the reports-to / leads taxonomy relations', () => {
+    const graph = buildGraph(loadDerivedArtifacts(), CLUSTERS);
+
+    const reportsTo = graph.edges.find(
+      e => e.from === 'kg://person/jane' && e.to === 'kg://person/sam',
+    );
+    expect(reportsTo?.relation).toBe('reports-to');
+
+    const leads = graph.edges.find(
+      e => e.from === 'kg://person/jane' && e.to === 'kg://squad/platform-core',
+    );
+    expect(leads?.relation).toBe('leads');
+
+    // The structured data bag survives assembly (viewers read it).
+    const jane = graph.nodes.find(n => n.id === 'kg://person/jane')!;
+    expect(jane.data?.role).toBe('Staff Engineer');
+  });
+});

--- a/src/engine/__tests__/fixtures/derived/person-jane.jsonld
+++ b/src/engine/__tests__/fixtures/derived/person-jane.jsonld
@@ -1,0 +1,44 @@
+{
+  "id": "kg://person/jane",
+  "title": "Jane Doe",
+  "identity": "kg://person/jane",
+  "cluster": "org",
+  "display": "entity",
+  "derived": true,
+  "provider": "derived",
+  "content": "",
+  "rawContent": "",
+  "entityType": "person",
+  "source": { "type": "derived", "generator": "kbexplorer-cli@derive" },
+  "data": {
+    "name": "Jane Doe",
+    "role": "Staff Engineer",
+    "email": "jane@example.com",
+    "team": "Platform",
+    "manager": "Sam Rivera"
+  },
+  "jsonld": {
+    "@context": "https://schema.org",
+    "@id": "kg://person/jane",
+    "@type": "Person",
+    "name": "Jane Doe"
+  },
+  "connections": [
+    {
+      "to": "kg://person/sam",
+      "type": "related",
+      "relation": "reports-to",
+      "description": "Jane reports to Sam",
+      "source": "inferred",
+      "weight": 1
+    },
+    {
+      "to": "kg://squad/platform-core",
+      "type": "related",
+      "relation": "leads",
+      "description": "Jane leads Platform Core",
+      "source": "inferred",
+      "weight": 1
+    }
+  ]
+}

--- a/src/engine/__tests__/fixtures/derived/person-sam.jsonld
+++ b/src/engine/__tests__/fixtures/derived/person-sam.jsonld
@@ -1,0 +1,26 @@
+{
+  "id": "kg://person/sam",
+  "title": "Sam Rivera",
+  "identity": "kg://person/sam",
+  "cluster": "org",
+  "display": "entity",
+  "derived": true,
+  "provider": "derived",
+  "content": "",
+  "rawContent": "",
+  "entityType": "person",
+  "source": { "type": "derived", "generator": "kbexplorer-cli@derive" },
+  "data": {
+    "name": "Sam Rivera",
+    "role": "Engineering Manager",
+    "email": "sam@example.com",
+    "team": "Platform"
+  },
+  "jsonld": {
+    "@context": "https://schema.org",
+    "@id": "kg://person/sam",
+    "@type": "Person",
+    "name": "Sam Rivera"
+  },
+  "connections": []
+}

--- a/src/engine/__tests__/fixtures/derived/squad-platform-core.jsonld
+++ b/src/engine/__tests__/fixtures/derived/squad-platform-core.jsonld
@@ -1,0 +1,37 @@
+{
+  "id": "kg://squad/platform-core",
+  "title": "Platform Core",
+  "identity": "kg://squad/platform-core",
+  "cluster": "org",
+  "display": "entity",
+  "derived": true,
+  "provider": "derived",
+  "content": "",
+  "rawContent": "",
+  "entityType": "squad",
+  "source": { "type": "derived", "generator": "kbexplorer-cli@derive" },
+  "data": {
+    "name": "Platform Core",
+    "mission": "Owns the shared platform runtime",
+    "dri": "jane",
+    "workstream": "Platform",
+    "members": ["Jane Doe", "Sam Rivera"],
+    "knowledgeAreas": ["runtime", "observability"]
+  },
+  "jsonld": {
+    "@context": "https://schema.org",
+    "@id": "kg://squad/platform-core",
+    "@type": "Squad",
+    "name": "Platform Core"
+  },
+  "connections": [
+    {
+      "to": "kg://person/jane",
+      "type": "related",
+      "relation": "staffs",
+      "description": "Platform Core staffs Jane",
+      "source": "inferred",
+      "weight": 1
+    }
+  ]
+}

--- a/src/engine/__tests__/pipeline-idempotency.test.ts
+++ b/src/engine/__tests__/pipeline-idempotency.test.ts
@@ -19,6 +19,7 @@ import { buildContentModel } from '../content-model';
 import { ContentModelProvider } from '../providers/content-model-provider';
 import { StructuralProvider } from '../providers/structural-provider';
 import { resetNodeTypeRegistry } from '../node-types';
+import { resetViewerRegistry } from '../../views/viewers';
 import { loadFixtureSource } from '../content-model/__tests__/fixtures';
 
 const config = { clusters: {} } as unknown as KBConfig;
@@ -53,7 +54,11 @@ class BaselineProvider implements GraphProvider {
 }
 
 afterEach(() => {
+  // StructuralProvider / content-model registration also register bespoke viewers
+  // (WorkflowView/ActionView/…); reset both registries so nothing leaks across tests
+  // and the overall vitest run stays order-independent.
   resetNodeTypeRegistry();
+  resetViewerRegistry();
 });
 
 describe('content-model builder idempotency (#170)', () => {

--- a/src/engine/__tests__/pipeline-idempotency.test.ts
+++ b/src/engine/__tests__/pipeline-idempotency.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Full-pipeline regression + drift check (F4 / T4.2 — issue #170).
+ *
+ * Proves the build/assembly pipeline (content-model builder + provider
+ * orchestration) is **idempotent**: re-running with unchanged sources produces
+ * byte-identical output. This is the "do I need to re-run after source changes?"
+ * guarantee — if sources didn't change, output won't either.
+ *
+ * Also asserts the **safe-no-op invariants**: an absent content-model source and
+ * an absent `.github` directory leave the existing graph output unchanged
+ * (byte-identical), so the new node-type system is strictly additive.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import type { KBConfig, KBNode } from '../../types';
+import type { GraphProvider, ProviderResult } from '../providers';
+import { ProviderRegistry } from '../providers';
+import { orchestrate } from '../orchestrator';
+import { buildContentModel } from '../content-model';
+import { ContentModelProvider } from '../providers/content-model-provider';
+import { StructuralProvider } from '../providers/structural-provider';
+import { resetNodeTypeRegistry } from '../node-types';
+import { loadFixtureSource } from '../content-model/__tests__/fixtures';
+
+const config = { clusters: {} } as unknown as KBConfig;
+
+/** A minimal `.github` source: one workflow + CODEOWNERS, enough to exercise
+ *  the structural provider and the workflow → repo-meta `structural` edge. */
+const STRUCTURAL_FILES: Record<string, string> = {
+  '.github/workflows/ci.yml': 'name: CI\non:\n  push:\n    branches: [main]\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n',
+  '.github/CODEOWNERS': '* @octocat\n',
+};
+
+/** Fixed baseline provider standing in for the repo's real (work-layer) nodes. */
+function fixedNode(id: string, cluster: string): KBNode {
+  return {
+    id,
+    title: id,
+    cluster,
+    content: '',
+    rawContent: '',
+    connections: [],
+    source: { type: 'readme' },
+  };
+}
+
+class BaselineProvider implements GraphProvider {
+  id = 'work';
+  name = 'Baseline';
+  dependencies: string[] = [];
+  async resolve(): Promise<ProviderResult> {
+    return { nodes: [fixedNode('repo-meta', 'infra'), fixedNode('readme', 'docs')], edges: [] };
+  }
+}
+
+afterEach(() => {
+  resetNodeTypeRegistry();
+});
+
+describe('content-model builder idempotency (#170)', () => {
+  it('produces byte-identical output across re-runs with unchanged sources', () => {
+    const src = loadFixtureSource();
+    const first = JSON.stringify(buildContentModel(src));
+    const second = JSON.stringify(buildContentModel(src));
+    expect(second).toBe(first);
+  });
+
+  it('does not depend on input file ordering (object-key order is normalized)', () => {
+    const src = loadFixtureSource();
+    const reordered = { root: src.root, files: Object.fromEntries(Object.entries(src.files).reverse()) };
+    expect(JSON.stringify(buildContentModel(reordered))).toBe(JSON.stringify(buildContentModel(src)));
+  });
+});
+
+describe('full-pipeline orchestration idempotency (#170)', () => {
+  function freshRegistry(): ProviderRegistry {
+    const r = new ProviderRegistry();
+    r.register(new BaselineProvider());
+    r.register(new ContentModelProvider(loadFixtureSource()));
+    r.register(new StructuralProvider(STRUCTURAL_FILES, null));
+    return r;
+  }
+
+  it('re-running the assembly produces a byte-identical graph (no drift)', async () => {
+    const first = JSON.stringify(await orchestrate(freshRegistry(), config));
+    const second = JSON.stringify(await orchestrate(freshRegistry(), config));
+    expect(second).toBe(first);
+  });
+
+  it('emits the workflow → repo-meta structural edge through assembly', async () => {
+    const graph = await orchestrate(freshRegistry(), config);
+    const workflow = graph.nodes.find(n => n.entityType === 'workflow');
+    expect(workflow).toBeTruthy();
+    expect(
+      workflow!.connections.some(c => c.relation === 'structural' && c.to === 'repo-meta'),
+    ).toBe(true);
+  });
+});
+
+describe('safe-no-op invariants (#170)', () => {
+  it('content-model + structural providers are empty no-ops when sources are absent', async () => {
+    expect(await new ContentModelProvider(null).resolve(config, [])).toEqual({ nodes: [], edges: [] });
+    expect(await new ContentModelProvider({ root: 'x', files: {} }).resolve(config, [])).toEqual({
+      nodes: [],
+      edges: [],
+    });
+    expect(await new StructuralProvider({}, null).resolve(config, [])).toEqual({ nodes: [], edges: [] });
+  });
+
+  it('absent content-model / absent .github leaves the graph output byte-identical', async () => {
+    const baseline = new ProviderRegistry();
+    baseline.register(new BaselineProvider());
+
+    const withEmptyProviders = new ProviderRegistry();
+    withEmptyProviders.register(new BaselineProvider());
+    withEmptyProviders.register(new ContentModelProvider(null));
+    withEmptyProviders.register(new StructuralProvider({}, null));
+
+    const baseGraph = JSON.stringify(await orchestrate(baseline, config));
+    const withEmpty = JSON.stringify(await orchestrate(withEmptyProviders, config));
+    expect(withEmpty).toBe(baseGraph);
+  });
+});

--- a/src/engine/demo-entities.ts
+++ b/src/engine/demo-entities.ts
@@ -1,9 +1,9 @@
 /**
  * Demo-entities seam (off by default).
  *
- * Injects a small set of `person` / `team` entity nodes — wired with the
- * relation taxonomy (leads | staffs | reports-to) — so the open node-type
- * foundation can be exercised end-to-end (entity viewer, SourceBadge, relation
+ * Injects a small set of `person` / `squad` / `team` entity nodes — wired with
+ * the relation taxonomy (leads | staffs | reports-to) — so the open node-type
+ * foundation can be exercised end-to-end (entity viewers, SourceBadge, relation
  * legend) without polluting real knowledge graphs.
  *
  * Enabled by `?demo=entities` in the URL or `localStorage['kbe-demo-entities']`
@@ -14,6 +14,7 @@ import { buildJsonLd } from '../types';
 import { registerType } from './node-types';
 import { registerViewer } from '../views/viewers';
 import { PersonView } from '../views/viewers/PersonView';
+import { SquadView } from '../views/viewers/SquadView';
 
 const DEMO_CLUSTER: Cluster = { id: 'org', name: 'Organization', color: '#c0a3ff' };
 
@@ -38,7 +39,7 @@ export function isDemoEntitiesEnabled(): boolean {
   return false;
 }
 
-/** Register the `person` / `team` node types + the bespoke person viewer. Idempotent. */
+/** Register the `person` / `squad` / `team` node types + bespoke viewers. Idempotent. */
 export function registerDemoEntityTypes(): void {
   registerType({
     id: 'person',
@@ -50,6 +51,15 @@ export function registerDemoEntityTypes(): void {
     description: 'An individual contributor or manager.',
   });
   registerType({
+    id: 'squad',
+    label: 'Squad',
+    layer: 'work',
+    cluster: DEMO_CLUSTER.id,
+    relations: ['staffs', 'leads'],
+    viewer: 'squad',
+    description: 'A squad that staffs people, is led by a DRI and delivers a workstream.',
+  });
+  registerType({
     id: 'team',
     label: 'Team',
     layer: 'work',
@@ -58,6 +68,7 @@ export function registerDemoEntityTypes(): void {
     description: 'A squad / team that staffs people and is led by a person.',
   });
   registerViewer('person', PersonView);
+  registerViewer('squad', SquadView);
 }
 
 function entityNode(
@@ -97,7 +108,7 @@ function relationEdge(from: string, to: string, relation: string, description: s
 export function injectDemoEntities(graph: KBGraph): KBGraph {
   registerDemoEntityTypes();
 
-  const DEMO_IDS = ['demo-team-atlas', 'demo-person-ada', 'demo-person-ben'];
+  const DEMO_IDS = ['demo-team-atlas', 'demo-squad-orbit', 'demo-person-ada', 'demo-person-ben'];
   // Guard against collisions / double-injection: if any fixed demo id already
   // exists in the graph, skip injection and return it unchanged.
   if (graph.nodes.some(n => DEMO_IDS.includes(n.id))) {
@@ -109,6 +120,20 @@ export function injectDemoEntities(graph: KBGraph): KBGraph {
     'Team Atlas',
     'team',
     { name: 'Team Atlas', mission: 'Owns the knowledge-graph engine', size: 4 },
+    'Organization',
+  );
+  const squad = entityNode(
+    'demo-squad-orbit',
+    'Squad Orbit',
+    'squad',
+    {
+      name: 'Squad Orbit',
+      mission: 'Delivers the discovery & search experience',
+      dri: 'ada',
+      workstream: 'Discovery',
+      members: ['Ada Okonkwo', 'Ben Carter'],
+      knowledgeAreas: ['search', 'ranking', 'graph-ui'],
+    },
     'Organization',
   );
   const lead = entityNode(
@@ -126,13 +151,17 @@ export function injectDemoEntities(graph: KBGraph): KBGraph {
     'Person',
   );
 
-  const newNodes: KBNode[] = [team, lead, ic];
+  const newNodes: KBNode[] = [team, squad, lead, ic];
 
   const newEdges: KBEdge[] = [
     relationEdge(lead.id, team.id, 'leads', 'Ada leads Team Atlas'),
     relationEdge(team.id, lead.id, 'staffs', 'Team Atlas staffs Ada'),
     relationEdge(team.id, ic.id, 'staffs', 'Team Atlas staffs Ben'),
     relationEdge(ic.id, lead.id, 'reports-to', 'Ben reports to Ada'),
+    relationEdge(squad.id, lead.id, 'staffs', 'Squad Orbit staffs Ada'),
+    relationEdge(squad.id, ic.id, 'staffs', 'Squad Orbit staffs Ben'),
+    relationEdge(lead.id, squad.id, 'leads', 'Ada (DRI) leads Squad Orbit'),
+    relationEdge(team.id, squad.id, 'structural', 'Team Atlas → Squad Orbit'),
   ];
 
   // Anchor the demo subgraph to an existing hub so it is reachable in the graph.


### PR DESCRIPTION
Closes #151
Closes #169
Closes #170

Capstone feature validating the new open-node-type system (F1 #148 / F2 #149 / F3 #150) end-to-end, plus two cross-cutting release-readiness items folded in from sibling sessions.

## T4.1 — Real-content E2E (#169)
`e2e/integration-validation.spec.ts` runs on the **real local cached-data flow** (persisted `kbe-demo-entities` setting + warmed cache via `/#/node/readme`), not a clean-state shortcut. Three tests, screenshots captured as evidence under `e2e/artifacts/f4-*.png`:
- **Person → PersonView** — `demo-person-ada` resolves its bespoke `.kb-person-view`.
- **Squad → SquadView** — `demo-squad-orbit` resolves its bespoke `.kb-squad-view`.
- **Workflow → WorkflowView + structural edge** — `gh-workflow-github-pages-yml` renders via `.kb-workflow-view` AND exposes a navigable `structural` edge to the `repo-meta` repository node.

The demo-entities seam is layered on the real build (it's how Person/Squad reach the browser without polluting the template's default graph or risking URN routing). The F2 production pipeline itself is proven at the engine level by the idempotency + derived-artifact + existing content-model-provider tests.

## T4.2 — Full-pipeline regression / drift (#170)
- `src/engine/__tests__/pipeline-idempotency.test.ts` — content-model build and provider orchestration are byte-identical across re-runs (the "do I need to re-run after source changes?" guarantee), plus **safe-no-op invariants**: absent content-model and absent `.github` leave existing graph output unchanged.
- `scripts/check-manifest-drift.js` (`npm run validate:drift`) — asserts the source-derived manifest is deterministic and in sync with committed sources (compares only deterministic source-derived fields; excludes volatile issue/PR/commit/timestamp data). Wired into CI after manifest generation.

## Cross-repo derived-artifact proof (F8 gap)
Committed `*.jsonld` fixtures (KBNode mirror — `entityType`+`jsonld`+`data`, `kg://` identity URNs, `reports-to`/`leads` relations) + `src/engine/__tests__/derived-artifact-render.test.ts` proving the engine consumes a cli-emitted derived artifact end-to-end and resolves it to a structured node + bespoke viewer.

## CI concurrency hardening (F3 release-readiness infra)
`.github/workflows/github-pages.yml` previously used one global `pages` concurrency group with `cancel-in-progress: true`, so PR `test` runs cancelled every in-flight run (killing siblings' e2e mid-run). Now scoped per-ref:
```yaml
concurrency:
  group: pages-${{ github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```
PR runs only supersede older runs of the same PR; pushes to `main` (the only ref that deploys) get a distinct group and are never cancelled mid-deploy — preserving the Pages deploy contract.

## Gates
All green locally: `npx tsc -b` = 0, `npm run lint` = 0 errors, `npm test` (vitest) = **304 passed**, `npx vite build` = 0, Playwright chromium = **54 passed**. `CACHE_VERSION` unchanged (no cached-shape change).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>