### PR TITLE
Add wbs-builder skill: GitHub Epic/Feature/Task WBS builder

### DIFF
--- a/.agents/skills/wbs-builder/SKILL.md
+++ b/.agents/skills/wbs-builder/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: wbs-builder
+description: >-
+  This skill should be used when the user asks to "create a WBS",
+  "create a work breakdown structure", "break this epic into issues",
+  "scaffold GitHub issues", "create epics, features and tasks",
+  "set up the issue hierarchy", "plan this program in GitHub",
+  "create the Epic → Feature → Task hierarchy", or wants real GitHub issues
+  with native issue TYPES, parent/child sub-issues, and blocked-by dependency
+  edges created via the GraphQL API before implementation begins. Provides a
+  resumable runner plus authoring conventions for materializing a typed,
+  dependency-aware work-breakdown structure across one or more repos.
+version: 0.1.0
+---
+
+# wbs-builder — GitHub Work-Breakdown Structure builder
+
+Materialize an **Epic → Feature → Task** hierarchy as *real* GitHub issues —
+with native issue **types**, parent/child **sub-issues**, and **blocked-by**
+dependency edges — via the GitHub GraphQL API, **before any implementation
+begins**. The output is a typed, navigable, dependency-aware backlog that maps
+cleanly onto parallel work (e.g. one child session per Feature).
+
+Use this when a program is large, parallelizable, or spans repos and you want
+the plan modeled as *typed issues with structure*, not labels or title-tags.
+
+## What you get
+
+- **Native issue types** (Epic / Feature / Task / Bug) via `createIssue(issueTypeId)`,
+  not labels.
+- **Sub-issue tree** (Epic ⊃ Feature ⊃ Task) via `addSubIssue` — the real
+  parent/child relationship GitHub renders in the issue UI.
+- **Dependency edges** (`blocked-by` / `blocking`) via `addBlockedBy`, including
+  best-effort **cross-repo** edges with a prose-link fallback.
+- A **resumable** run: every created issue + link is journaled to `wbs-map.json`,
+  so re-running any phase skips completed work.
+
+## The hierarchy model
+
+| Level | Issue type | Purpose | Body shape |
+| --- | --- | --- | --- |
+| **Epic** | Epic | The "north star" outcome for a program | What / Why / Adopted model / Scope boundaries / Success definition / Children |
+| **Feature** | Feature | One ownable slice (≈ a PR or a focused session) | Parent epic / What / Why / Scope / Acceptance |
+| **Task** | Task | One concrete change | Parent feature / **Scope** / **Validation criteria** / **Evidence-based completion criteria** |
+
+Every **Task** must carry *evidence-based* completion criteria — named, checkable
+proof (a passing test name, a screenshot, a build-log line, a readback) — so
+"done" is never a judgment call. See `references/wbs-authoring.md` for full body
+templates and the metadata model.
+
+## ⚠️ Never assume the org — discover IDs at runtime
+
+Issue-type node IDs are **org-scoped**: they differ per organization, may be
+renamed/customized, and **user-owned repos may have none at all**. This skill's
+runner **discovers** repository IDs and issue-type IDs fresh, per `owner/repo`,
+by **name** — and refuses to run if a required type is missing (telling you what
+it found). **Never hardcode a node ID copied from another org.** If a target repo
+has no issue types, stop and ask the user to enable/define them in org settings
+(or adjust `KIND_TYPE_NAMES` to match the org's actual type names) before
+proceeding.
+
+## How to use
+
+1. **Author the WBS.** Copy `scripts/wbs-data.example.mjs` to
+   `scripts/wbs-data.mjs` and fill in:
+   - `REPOS` — logical keys → `{ owner, name }` (one or many; cross-repo OK).
+   - `KIND_TYPE_NAMES` — map `epic/feature/task/bug` to the org's actual type names.
+   - `ITEMS` — the Epics/Features/Tasks (each with `key`, `kind`, `repo`,
+     `parent`, `title`, `body`). Use the `task()` helper for task bodies.
+   - `DEPS` — `[key, blockedByKey]` blocked-by edges.
+
+2. **Preflight (no writes).** Confirm the runner can see every repo and resolve
+   every required type:
+   ```bash
+   cd .agents/skills/wbs-builder/scripts
+   node create-wbs.mjs discover
+   node create-wbs.mjs all --dry-run   # full plan, mutates nothing
+   ```
+
+3. **Create.** Run the three phases (or `all`). Each is idempotent + resumable:
+   ```bash
+   node create-wbs.mjs create   # issues with type + body
+   node create-wbs.mjs sub      # parent → child sub-issue links
+   node create-wbs.mjs deps     # blocked-by dependency edges
+   ```
+   Results are journaled to `wbs-map.json` (key → `{id, number, url}`). Re-run any
+   phase safely; completed work is skipped.
+
+Auth: the runner uses `$GITHUB_TOKEN` / `$GH_TOKEN`, else `gh auth token`. A
+classic **`repo`** scope (or fine-grained Issues: read & write) is enough — issue
+types, sub-issues, and dependencies do **not** need `read:org`.
+
+## Files
+
+- `scripts/create-wbs.mjs` — the resumable runner (`discover|create|sub|deps|all`,
+  `--dry-run`, `--data`, `--map`). No hardcoded IDs; discovers everything.
+- `scripts/wbs-data.example.mjs` — copy → `wbs-data.mjs`; the WBS definition
+  (REPOS / KIND_TYPE_NAMES / ITEMS / DEPS) + the `task()` body helper.
+- `references/wbs-authoring.md` — full guide: hierarchy + body templates, the
+  native-metadata model, GraphQL mechanics, per-owner discovery rules, and
+  idempotent execution discipline.
+
+## Notes
+
+- `wbs-data.mjs` and `wbs-map.json` are *your program's* data — generate them per
+  use; don't commit another program's WBS back into the skill.
+- Cross-repo `addSubIssue` / `addBlockedBy` may be rejected by GitHub; the runner
+  records the failure so you can add a prose **"Relates to `owner/repo#N`"** link
+  to the issue body instead (no loss of traceability).

--- a/.agents/skills/wbs-builder/references/wbs-authoring.md
+++ b/.agents/skills/wbs-builder/references/wbs-authoring.md
@@ -1,0 +1,216 @@
+# WBS authoring guide
+
+This is the full reference for building a typed, dependency-aware
+**Epic → Feature → Task** work-breakdown structure in GitHub, before any
+implementation begins. It is also the prompt you can hand to another agent: it
+covers *what* to create, *how to author* the work items, the *native metadata
+model*, the *GraphQL mechanics*, and the *execution discipline*.
+
+---
+
+## 1. The hierarchy model
+
+Model the whole program as **typed GitHub issues** first, then fan out
+implementation. Three levels:
+
+- **Epic** — the north-star outcome. One per major program thread. Spans many
+  Features and (often) more than one repo.
+- **Feature** — one ownable slice, roughly a single PR or one focused work
+  session. A child session can own a Feature end-to-end from its body alone.
+- **Task** — one concrete change with an explicit validation gate and named
+  evidence for "done".
+
+Relationships are **native GitHub structure**, never labels or `[Epic]` title
+prefixes:
+
+- Epic ⊃ Feature ⊃ Task as **sub-issues** (`addSubIssue`).
+- **blocked-by / blocking** dependency edges between issues (`addBlockedBy`),
+  including cross-repo where allowed.
+- Cross-repo Epic↔Epic and contract links via body references plus an attempted
+  dependency edge.
+
+---
+
+## 2. Body-authoring conventions
+
+Bodies are the durable spec. Write them so a reader needs nothing else.
+
+### Epic body
+
+```
+## What
+Current state → target state, concretely.
+
+## Why
+The forcing function / rationale (e.g. a source system is being sunset).
+
+## Adopted model / approach
+The key design decisions taken as given for the whole program.
+
+## Scope boundaries
+- In:  what this Epic owns.
+- Out: deferred work — name the backlog Feature or sibling Epic that owns it.
+
+## Success definition
+The end-to-end, demoable acceptance bar.
+
+## Children
+List child Features. Link sibling Epics: "Relates to owner/repo#N".
+```
+
+### Feature body
+
+```
+**Parent epic:** E# — <title>
+
+## What
+The slice delivered (≈ one PR / one session).
+
+## Why
+Why it exists and what it unblocks.
+
+## Scope
+In-scope work; call out anything deliberately deferred to a backlog Feature.
+
+## Acceptance
+Observable criteria that make the Feature "done".
+
+**Blocked by:** F# (mirror each GraphQL dependency edge in prose too).
+```
+
+### Task body — the most important shape
+
+Every Task uses **Scope / Validation criteria / Evidence-based completion
+criteria**. The `task()` helper in `wbs-data.example.mjs` emits exactly this:
+
+```
+**Parent feature:** F# — <title>
+
+## Scope
+Exactly what to change, and in which files / areas.
+
+## Validation criteria
+How correctness is judged — the gate (vitest / lint / build / Playwright / readback).
+
+## Evidence-based completion criteria
+- [ ] A concrete, checkable artifact that proves done (named passing test, screenshot,
+      build-log line, a CACHE_VERSION diff, a rendered node, a GraphQL readback).
+- [ ] A second proof item.
+```
+
+**No task is "done" without named evidence.** "Validation" is *how you test*;
+"evidence" is *the artifact that proves it* — keep them distinct.
+
+---
+
+## 3. The native metadata model
+
+Use GitHub's first-class fields, not conventions-on-top-of-text:
+
+| Concept | Use | Do NOT use |
+| --- | --- | --- |
+| Epic / Feature / Task | native **issue type** (`issueTypeId`) | a `type:` label or title prefix |
+| Parent / child | **sub-issue** (`addSubIssue`) | "Part of #12" prose only |
+| Dependency | **blocked-by** (`addBlockedBy`) | a `blocked` label |
+| Cross-repo link | body reference + attempted cross-repo edge | nothing |
+
+Why: typed issues + sub-issues + dependencies render as real structure in the
+GitHub UI, drive project boards/insights, and let a fan-out reliably compute "what
+is unblocked now".
+
+---
+
+## 4. ⚠️ Discover all IDs in the TARGET repo/org first (MANDATORY)
+
+**Do not assume the same org.** Issue-type node IDs are **org-scoped**:
+
+- They differ between organizations.
+- They can be renamed or customized per org.
+- **User-owned repositories may have no issue types at all.**
+
+So **before creating anything**, discover — per `owner/repo`, by **name**:
+
+1. The **repository ID** (`repository.id`).
+2. The **issue-type IDs** (`repository.issueTypes(first:50){ nodes{ id name } }`),
+   matched to the type **names** the program uses.
+
+The runner (`create-wbs.mjs`) does this in its `discover` phase and **throws** if
+a required type name is absent — listing the names it did find. When that happens:
+
+- **Stop and ask the user** to enable/define the issue types in the org's settings
+  (Organization → Settings → Issue types), **or**
+- adjust `KIND_TYPE_NAMES` in the data file to match the org's *actual* type names
+  (e.g. some orgs use `Story` instead of `Feature`).
+
+**Never** hardcode a node ID copied from another org/program — it will silently
+target the wrong type or fail. Every ID in this skill is resolved at runtime.
+
+---
+
+## 5. GraphQL mechanics (proven)
+
+- Endpoint: `POST https://api.github.com/graphql`.
+- **Required header on every request:**
+  `GraphQL-Features: issue_types,sub_issues,issue_dependencies`.
+  Without it, the type / sub-issue / dependency fields and mutations do not exist.
+- Auth: a classic **`repo`** scope (or fine-grained Issues: read & write) is
+  sufficient. `read:org` is **not** required for types/sub-issues/dependencies.
+
+Discovery query:
+
+```graphql
+query($owner:String!,$name:String!){
+  repository(owner:$owner,name:$name){
+    id
+    owner{ __typename login }          # User vs Organization
+    issueTypes(first:50){ nodes{ id name } }
+  }
+}
+```
+
+Mutations:
+
+```graphql
+# create with a native type
+createIssue(input:{ repositoryId:$repo, title:$title, body:$body, issueTypeId:$type }){
+  issue{ id number url }
+}
+# parent → child (issueId = parent, subIssueId = child)
+addSubIssue(input:{ issueId:$parent, subIssueId:$child }){ issue{ number } }
+# dependency (issueId is BLOCKED; blockingIssueId BLOCKS it)
+addBlockedBy(input:{ issueId:$issue, blockingIssueId:$by }){ issue{ number } }
+```
+
+Read dependencies back via `Issue.blockedBy` / `Issue.blocking` to verify.
+
+**Creation order per node:** `createIssue` (with `issueTypeId`) → capture
+`id`/`number` → link sub-issues → wire `addBlockedBy` once *both* endpoints exist.
+
+---
+
+## 6. Idempotent, resumable execution discipline
+
+- **Journal everything.** After each create/link, persist
+  `key → { id, number, url, parentLinked }` (and a `__deps` set) to
+  `wbs-map.json`. The runner skips anything already recorded, so a re-run after a
+  rate-limit, network blip, or partial failure resumes cleanly.
+- **Phase the work:** `create` all issues first, then `sub` (needs both endpoints
+  to exist), then `deps` (same). Running `all` does them in order.
+- **Dry-run first.** `--dry-run` resolves IDs and prints the full plan without
+  mutating, so you can eyeball the structure and catch a missing type early.
+- **Cross-repo fallback.** `addSubIssue` / `addBlockedBy` across repos may be
+  rejected. Record the rejection and add a prose **"Relates to `owner/repo#N`"**
+  link to the body — traceability is preserved even when the native edge isn't
+  allowed.
+- **Verify with a readback.** After `deps`, query a sample issue's `blockedBy`
+  to confirm edges materialized as intended.
+
+---
+
+## 7. After Stage 0
+
+With the typed, linked backlog in place, fan out implementation: spin up one
+child session per **unblocked** Feature (respecting the `blocked-by` graph), and
+let each session use its Tasks' **evidence-based completion criteria** as the
+definition of done. Nothing in Stage 0 writes implementation code — it only
+creates issues and their metadata.

--- a/.agents/skills/wbs-builder/scripts/create-wbs.mjs
+++ b/.agents/skills/wbs-builder/scripts/create-wbs.mjs
@@ -1,0 +1,205 @@
+// WBS runner: materialize an Epic → Feature → Task work-breakdown structure as
+// real GitHub issues via the GraphQL API — with native issue TYPES, parent/child
+// sub-issue links, and blocked-by dependency edges.
+//
+// Design goals:
+//   • Idempotent + resumable: persists a key→{id,number,url} map to wbs-map.json
+//     and skips anything already done. Safe to re-run any phase.
+//   • NO hardcoded node IDs. Repository IDs and (org-scoped) issue-type IDs are
+//     DISCOVERED at runtime, per owner/repo, by NAME — never carried over from
+//     another org. Issue types differ per organization and may be absent on
+//     user-owned repos, so we resolve them fresh and fail loudly if missing.
+//
+// Usage (run from this scripts/ dir, or pass --data):
+//   node create-wbs.mjs discover            # preflight: print resolved repo + type IDs
+//   node create-wbs.mjs create              # phase 1: create issues (type + body)
+//   node create-wbs.mjs sub                 # phase 2: parent → child sub-issues
+//   node create-wbs.mjs deps                # phase 3: blocked-by dependency edges
+//   node create-wbs.mjs all                 # discover + create + sub + deps
+//   node create-wbs.mjs all --dry-run       # resolve + plan, mutate nothing
+//   node create-wbs.mjs all --data ./my-wbs-data.mjs --map ./my-map.json
+//
+// Auth: uses $GITHUB_TOKEN / $GH_TOKEN if set, else `gh auth token`.
+// A classic `repo` scope (or fine-grained Issues: read&write) is sufficient —
+// issue types, sub-issues, and dependencies do NOT require `read:org`.
+
+import { execSync } from 'node:child_process';
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { dirname, resolve as resolvePath } from 'node:path';
+
+const __dir = dirname(fileURLToPath(import.meta.url));
+
+// ── args ───────────────────────────────────────────────────────────────────
+const argv = process.argv.slice(2);
+const phase = argv.find((a) => !a.startsWith('--')) || 'all';
+const flag = (name) => {
+  const i = argv.indexOf(`--${name}`);
+  return i >= 0 ? (argv[i + 1] && !argv[i + 1].startsWith('--') ? argv[i + 1] : true) : undefined;
+};
+const DRY = Boolean(flag('dry-run'));
+const DATA_PATH = resolvePath(__dir, String(flag('data') || './wbs-data.mjs'));
+const MAP_PATH = resolvePath(__dir, String(flag('map') || './wbs-map.json'));
+
+// ── token ──────────────────────────────────────────────────────────────────
+const TOKEN =
+  process.env.GITHUB_TOKEN ||
+  process.env.GH_TOKEN ||
+  execSync('gh auth token', { encoding: 'utf8' }).trim();
+if (!TOKEN) {
+  console.error('No token: set $GITHUB_TOKEN/$GH_TOKEN or run `gh auth login`.');
+  process.exit(2);
+}
+
+async function gql(query, variables) {
+  const res = await fetch('https://api.github.com/graphql', {
+    method: 'POST',
+    headers: {
+      Authorization: `bearer ${TOKEN}`,
+      'Content-Type': 'application/json',
+      // Without this header the type/sub-issue/dependency fields + mutations do
+      // not exist. Keep all three opt-ins on every request.
+      'GraphQL-Features': 'issue_types,sub_issues,issue_dependencies',
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+  const json = await res.json();
+  if (json.errors) throw new Error(JSON.stringify(json.errors));
+  return json.data;
+}
+
+// ── load WBS definition + resumable id map ───────────────────────────────────
+if (!existsSync(DATA_PATH)) {
+  console.error(`WBS data file not found: ${DATA_PATH}\n(copy wbs-data.example.mjs and edit it)`);
+  process.exit(2);
+}
+const { REPOS, KIND_TYPE_NAMES, ITEMS, DEPS } = await import(pathToFileURL(DATA_PATH).href);
+const KIND_NAME = KIND_TYPE_NAMES || { epic: 'Epic', feature: 'Feature', task: 'Task', bug: 'Bug' };
+
+const map = existsSync(MAP_PATH) ? JSON.parse(readFileSync(MAP_PATH, 'utf8')) : {};
+const save = () => writeFileSync(MAP_PATH, JSON.stringify(map, null, 2));
+
+// ── mutations ────────────────────────────────────────────────────────────────
+const CREATE = `mutation($repo:ID!,$title:String!,$body:String!,$type:ID!){
+  createIssue(input:{repositoryId:$repo,title:$title,body:$body,issueTypeId:$type}){
+    issue{ id number url }
+  }
+}`;
+const ADD_SUB = `mutation($parent:ID!,$child:ID!){
+  addSubIssue(input:{issueId:$parent,subIssueId:$child}){ issue{ number } }
+}`;
+const ADD_BLOCKED = `mutation($issue:ID!,$by:ID!){
+  addBlockedBy(input:{issueId:$issue,blockingIssueId:$by}){ issue{ number } }
+}`;
+const DISCOVER = `query($owner:String!,$name:String!){
+  repository(owner:$owner,name:$name){
+    id
+    owner{ __typename login }
+    issueTypes(first:50){ nodes{ id name } }
+  }
+}`;
+
+// ── Phase 0: discover repo + issue-type IDs (per owner/repo, by name) ─────────
+// Populates `resolved[repoKey] = { repoId, owner, types: {Name: id} }`.
+const resolved = {};
+async function discover() {
+  for (const [repoKey, r] of Object.entries(REPOS)) {
+    const data = await gql(DISCOVER, { owner: r.owner, name: r.name });
+    const repo = data.repository;
+    if (!repo) throw new Error(`Repo not found / no access: ${r.owner}/${r.name}`);
+    const types = {};
+    for (const t of repo.issueTypes?.nodes || []) types[t.name] = t.id;
+    resolved[repoKey] = { repoId: repo.id, owner: r.owner, name: r.name, types };
+
+    const want = [...new Set(ITEMS.filter((i) => i.repo === repoKey).map((i) => KIND_NAME[i.kind]))];
+    const missing = want.filter((n) => !types[n]);
+    console.log(
+      `discovered ${r.owner}/${r.name} (${repo.owner.__typename}) — types: ` +
+        (Object.keys(types).join(', ') || '(none)')
+    );
+    if (missing.length) {
+      throw new Error(
+        `${r.owner}/${r.name} is missing required issue type(s): ${missing.join(', ')}. ` +
+          `Issue types are an ORG-level setting; a user-owned repo may have none. ` +
+          `Enable/define them in the org's settings, or adjust KIND_TYPE_NAMES to match ` +
+          `the org's actual type names (found: ${Object.keys(types).join(', ') || 'none'}).`
+      );
+    }
+  }
+}
+
+const typeIdFor = (item) => resolved[item.repo].types[KIND_NAME[item.kind]];
+const repoIdFor = (item) => resolved[item.repo].repoId;
+
+async function main() {
+  // discovery is a prerequisite for every mutating phase
+  if (['discover', 'create', 'sub', 'deps', 'all'].includes(phase)) await discover();
+  if (phase === 'discover') {
+    console.log(`\n== discovery OK for ${Object.keys(REPOS).length} repo(s) ==`);
+    return;
+  }
+
+  // ── Phase 1: create issues (type + body) ───────────────────────────────────
+  if (phase === 'all' || phase === 'create') {
+    for (const it of ITEMS) {
+      if (map[it.key]?.id) { console.log(`skip create ${it.key} (#${map[it.key].number})`); continue; }
+      if (DRY) { console.log(`DRY create ${it.key} -> ${it.repo} as ${KIND_NAME[it.kind]}`); continue; }
+      const data = await gql(CREATE, {
+        repo: repoIdFor(it), title: it.title, body: it.body, type: typeIdFor(it),
+      });
+      const issue = data.createIssue.issue;
+      map[it.key] = {
+        id: issue.id, number: issue.number, url: issue.url,
+        repo: it.repo, kind: it.kind, parent: it.parent || null,
+      };
+      save();
+      console.log(`created ${it.key} -> ${resolved[it.repo].owner}/${resolved[it.repo].name}#${issue.number}`);
+    }
+  }
+
+  // ── Phase 2: parent/child sub-issues ───────────────────────────────────────
+  if (phase === 'all' || phase === 'sub') {
+    for (const it of ITEMS) {
+      if (!it.parent) continue;
+      const child = map[it.key], parent = map[it.parent];
+      if (!child || !parent) { console.log(`MISS sub ${it.key} (create first)`); continue; }
+      if (child.parentLinked) { console.log(`skip sub ${it.key}`); continue; }
+      if (DRY) { console.log(`DRY sub ${it.parent} <- ${it.key}`); continue; }
+      try {
+        await gql(ADD_SUB, { parent: parent.id, child: child.id });
+        child.parentLinked = true; save();
+        console.log(`sub ${it.parent} <- ${it.key}`);
+      } catch (e) {
+        console.log(`ERR sub ${it.parent} <- ${it.key}: ${e.message}`);
+      }
+    }
+  }
+
+  // ── Phase 3: blocked-by dependencies ───────────────────────────────────────
+  if (phase === 'all' || phase === 'deps') {
+    map.__deps = map.__deps || {};
+    for (const [key, by] of DEPS || []) {
+      const tag = `${key}<-${by}`;
+      if (map.__deps[tag] === true || map.__deps[tag] === 'cross') { console.log(`skip dep ${tag}`); continue; }
+      const issue = map[key], blocker = map[by];
+      if (!issue || !blocker) { console.log(`MISS dep ${tag} (create first)`); continue; }
+      const crossRepo = issue.repo !== blocker.repo;
+      if (DRY) { console.log(`DRY dep ${key} blocked-by ${by}${crossRepo ? ' (cross-repo)' : ''}`); continue; }
+      try {
+        await gql(ADD_BLOCKED, { issue: issue.id, by: blocker.id });
+        map.__deps[tag] = crossRepo ? 'cross' : true; save();
+        console.log(`dep ${key} blocked-by ${by}${crossRepo ? ' (cross-repo)' : ''}`);
+      } catch (e) {
+        // Cross-repo edges may be rejected; record it and fall back to a prose
+        // "Relates to owner/repo#N" body link (see SKILL.md) by hand.
+        map.__deps[tag] = `ERR:${e.message.slice(0, 120)}`; save();
+        console.log(`ERR dep ${tag}: ${e.message.slice(0, 160)}`);
+      }
+    }
+  }
+
+  const created = ITEMS.filter((i) => map[i.key]?.id).length;
+  console.log(`\n== ${created}/${ITEMS.length} issues; map at ${MAP_PATH} ==`);
+}
+
+main().catch((e) => { console.error(e.message || e); process.exit(1); });

--- a/.agents/skills/wbs-builder/scripts/create-wbs.mjs
+++ b/.agents/skills/wbs-builder/scripts/create-wbs.mjs
@@ -63,7 +63,21 @@ async function gql(query, variables) {
     },
     body: JSON.stringify({ query, variables }),
   });
-  const json = await res.json();
+  // Surface HTTP-level failures (401/403, rate limits, 5xx/outage, HTML error
+  // pages) as concise errors instead of letting res.json() throw or return a
+  // non-GraphQL shape that fails confusingly downstream.
+  const text = await res.text();
+  if (!res.ok) {
+    const snippet = text.replace(/\s+/g, ' ').trim().slice(0, 200);
+    throw new Error(`GitHub GraphQL HTTP ${res.status} ${res.statusText}${snippet ? `: ${snippet}` : ''}`);
+  }
+  let json;
+  try {
+    json = JSON.parse(text);
+  } catch {
+    const snippet = text.replace(/\s+/g, ' ').trim().slice(0, 200);
+    throw new Error(`GitHub GraphQL returned non-JSON (HTTP ${res.status})${snippet ? `: ${snippet}` : ''}`);
+  }
   if (json.errors) throw new Error(JSON.stringify(json.errors));
   return json.data;
 }
@@ -75,6 +89,46 @@ if (!existsSync(DATA_PATH)) {
 }
 const { REPOS, KIND_TYPE_NAMES, ITEMS, DEPS } = await import(pathToFileURL(DATA_PATH).href);
 const KIND_NAME = KIND_TYPE_NAMES || { epic: 'Epic', feature: 'Feature', task: 'Task', bug: 'Bug' };
+
+// Validate the WBS definition upfront so misconfiguration fails with an
+// actionable message instead of a low-signal TypeError partway through a run.
+function validateWbs() {
+  const errs = [];
+  if (!REPOS || typeof REPOS !== 'object') errs.push('REPOS is missing or is not an object.');
+  if (!Array.isArray(ITEMS)) errs.push('ITEMS is missing or is not an array.');
+  const repoKeys = new Set(Object.keys(REPOS || {}));
+  const knownKinds = Object.keys(KIND_NAME).join(', ');
+  const itemKeys = new Set();
+
+  for (const [idx, it] of (Array.isArray(ITEMS) ? ITEMS : []).entries()) {
+    const where = `ITEMS[${idx}]${it && it.key ? ` (${it.key})` : ''}`;
+    if (!it || typeof it !== 'object') { errs.push(`${where}: not an object.`); continue; }
+    if (!it.key || typeof it.key !== 'string') errs.push(`${where}: missing string "key".`);
+    else if (itemKeys.has(it.key)) errs.push(`${where}: duplicate key "${it.key}".`);
+    else itemKeys.add(it.key);
+    if (!repoKeys.has(it.repo)) errs.push(`${where}: unknown repo "${it.repo}" (REPOS keys: ${[...repoKeys].join(', ') || 'none'}).`);
+    if (!KIND_NAME[it.kind]) errs.push(`${where}: unknown kind "${it.kind}" (KIND_TYPE_NAMES: ${knownKinds}).`);
+    if (typeof it.title !== 'string') errs.push(`${where}: "title" must be a string.`);
+    if (typeof it.body !== 'string') errs.push(`${where}: "body" must be a string.`);
+  }
+  for (const [idx, it] of (Array.isArray(ITEMS) ? ITEMS : []).entries()) {
+    if (it && it.parent && !itemKeys.has(it.parent)) {
+      errs.push(`ITEMS[${idx}]${it.key ? ` (${it.key})` : ''}: parent "${it.parent}" is not a known item key.`);
+    }
+  }
+  for (const [i, dep] of (Array.isArray(DEPS) ? DEPS : []).entries()) {
+    if (!Array.isArray(dep) || dep.length !== 2) { errs.push(`DEPS[${i}]: expected a [key, blockedByKey] pair.`); continue; }
+    const [key, by] = dep;
+    if (!itemKeys.has(key)) errs.push(`DEPS[${i}]: unknown item key "${key}".`);
+    if (!itemKeys.has(by)) errs.push(`DEPS[${i}]: unknown blocking key "${by}".`);
+  }
+
+  if (errs.length) {
+    console.error(`Invalid WBS data in ${DATA_PATH}:\n  - ${errs.join('\n  - ')}`);
+    process.exit(2);
+  }
+}
+validateWbs();
 
 const map = existsSync(MAP_PATH) ? JSON.parse(readFileSync(MAP_PATH, 'utf8')) : {};
 const save = () => writeFileSync(MAP_PATH, JSON.stringify(map, null, 2));
@@ -164,13 +218,19 @@ async function main() {
       const child = map[it.key], parent = map[it.parent];
       if (!child || !parent) { console.log(`MISS sub ${it.key} (create first)`); continue; }
       if (child.parentLinked) { console.log(`skip sub ${it.key}`); continue; }
+      if (child.subError) { console.log(`skip sub ${it.key} (prior error recorded; clear "subError" in ${MAP_PATH} to retry)`); continue; }
       if (DRY) { console.log(`DRY sub ${it.parent} <- ${it.key}`); continue; }
       try {
         await gql(ADD_SUB, { parent: parent.id, child: child.id });
+        delete child.subError;
         child.parentLinked = true; save();
         console.log(`sub ${it.parent} <- ${it.key}`);
       } catch (e) {
-        console.log(`ERR sub ${it.parent} <- ${it.key}: ${e.message}`);
+        // Cross-repo / permission rejections: persist a marker so we don't retry
+        // on every run, and add a prose "Part of #N" / "Relates to owner/repo#N"
+        // body link by hand instead (see SKILL.md). Clear "subError" to retry.
+        child.subError = `ERR:${e.message.slice(0, 120)}`; save();
+        console.log(`ERR sub ${it.parent} <- ${it.key}: ${e.message.slice(0, 160)} (recorded; clear subError to retry)`);
       }
     }
   }

--- a/.agents/skills/wbs-builder/scripts/wbs-data.example.mjs
+++ b/.agents/skills/wbs-builder/scripts/wbs-data.example.mjs
@@ -1,0 +1,150 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// WBS DEFINITION (example / template).
+//
+// Copy this file to `wbs-data.mjs`, then replace REPOS + ITEMS + DEPS with your
+// real program. `create-wbs.mjs` imports REPOS / KIND_TYPE_NAMES / ITEMS / DEPS
+// from here and resolves every repository ID and (org-scoped) issue-type ID at
+// runtime by NAME — so this file contains NO GitHub node IDs. Never hardcode IDs.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Logical repo keys → real owner/repo. Items reference these keys via `repo`.
+// `owner` may be an organization or a user, but issue TYPES are an org-level
+// feature: a user-owned repo will have none and the runner will refuse to run.
+export const REPOS = {
+  primary: { owner: 'your-org', name: 'your-repo' },
+  // secondary: { owner: 'your-org', name: 'companion-repo' },  // cross-repo program
+};
+
+// Maps each `kind` used below to the issue TYPE NAME defined in the target org's
+// settings. Adjust the right-hand values to match the org's actual type names
+// (the runner errors out, listing what it found, if a name doesn't exist).
+export const KIND_TYPE_NAMES = {
+  epic: 'Epic',
+  feature: 'Feature',
+  task: 'Task',
+  bug: 'Bug',
+};
+
+// Helper: every TASK body gets the same Scope / Validation / Evidence shape, so a
+// task can be executed and closed without re-reading the plan. Evidence items are
+// rendered as checkboxes.
+const task = (parent, scope, validation, evidence) =>
+  [
+    `**Parent feature:** ${parent}`,
+    ``,
+    `## Scope`,
+    scope.trim(),
+    ``,
+    `## Validation criteria`,
+    validation.trim(),
+    ``,
+    `## Evidence-based completion criteria`,
+    evidence.map((e) => `- [ ] ${e}`).join('\n'),
+  ].join('\n');
+
+// The full work-breakdown structure. Each item:
+//   key       — stable WBS handle (used by DEPS + the resumable id map)
+//   kind      — 'epic' | 'feature' | 'task' | 'bug' (mapped via KIND_TYPE_NAMES)
+//   repo      — a key from REPOS
+//   parent    — the parent item's `key` (null for an Epic). Drives sub-issue links.
+//   scheduled — true = work it now; false = explicitly-tracked backlog (issue
+//               created, but no work assigned). Informational; not sent to GitHub.
+//   title     — issue title (prefix with the level for scannability)
+//   body      — rich markdown (see references/wbs-authoring.md for templates)
+export const ITEMS = [
+  // ── EPIC ───────────────────────────────────────────────────────────────────
+  {
+    key: 'E1', kind: 'epic', repo: 'primary', parent: null, scheduled: true,
+    title: 'Epic: <program-level outcome>',
+    body: `## What
+Current state → target state, concretely.
+
+## Why
+The forcing function / business or technical rationale.
+
+## Adopted model / approach
+Key design decisions taken as given for the whole program.
+
+## Scope boundaries
+- In: the work this Epic owns.
+- Out: deferred work — name the backlog Feature (e.g. F3) or sibling Epic that owns it.
+
+## Success definition
+The end-to-end, demoable acceptance bar for the Epic.
+
+## Children
+Features F1–F2 below. Relates to \`your-org/companion-repo#NN\` (sibling Epic).`,
+  },
+
+  // ── FEATURES ─────────────────────────────────────────────────────────────────
+  {
+    key: 'F1', kind: 'feature', repo: 'primary', parent: 'E1', scheduled: true,
+    title: 'Feature: <foundational slice>',
+    body: `**Parent epic:** E1 — <program-level outcome>
+
+## What
+The slice delivered (≈ one PR / one focused work session).
+
+## Why
+Why it exists and what it unblocks.
+
+## Scope
+In-scope work; call out anything deliberately deferred.
+
+## Acceptance
+Observable criteria that make this Feature "done".`,
+  },
+  {
+    key: 'F2', kind: 'feature', repo: 'primary', parent: 'E1', scheduled: true,
+    title: 'Feature: <dependent slice>',
+    body: `**Parent epic:** E1 — <program-level outcome>
+
+## What
+A slice that builds on F1.
+
+## Why
+Rationale / what it unblocks.
+
+## Scope
+In-scope work.
+
+## Acceptance
+Observable "done" criteria.
+
+**Blocked by:** F1 (mirrors the GraphQL dependency edge in prose).`,
+  },
+
+  // ── TASKS ────────────────────────────────────────────────────────────────────
+  {
+    key: 'T1.1', kind: 'task', repo: 'primary', parent: 'F1', scheduled: true,
+    title: 'Task: <concrete unit of work>',
+    body: task(
+      'F1 — <foundational slice>',
+      `Exactly what to change, and in which files / areas.`,
+      `How correctness is judged (the gate).`,
+      [
+        'Concrete, checkable proof item (e.g. unit test passes)',
+        'Second proof item (e.g. command output / screenshot / readback)',
+      ]
+    ),
+  },
+  {
+    key: 'T2.1', kind: 'task', repo: 'primary', parent: 'F2', scheduled: true,
+    title: 'Task: <unit that depends on T1.1>',
+    body: task(
+      'F2 — <dependent slice>',
+      `What to change.`,
+      `Validation gate.`,
+      ['Proof item one', 'Proof item two']
+    ),
+  },
+];
+
+// Blocked-by edges: [key, blockedByKey] — "key is blocked by blockedByKey".
+// Feature-level edges gate fan-out; task-level edges sequence work within/across
+// Features. Cross-repo edges are attempted, and on rejection the runner records
+// the failure so you can add a prose "Relates to owner/repo#N" link instead.
+export const DEPS = [
+  ['F2', 'F1'],     // feature-level
+  ['T2.1', 'T1.1'], // task-level
+];

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,3 +63,9 @@ Before building or evolving any feature that touches an external service, read `
 ## Content Derivation
 The content in `content/` is machine-derived from the repo's systems of record.
 For the full evaluation pipeline (worktree experiment, quality assessment, comparison), read [`DERIVATION.md`](DERIVATION.md).
+
+## Skills
+
+Repo-local skills live under `.agents/skills/`.
+
+- **wbs-builder** ([`.agents/skills/wbs-builder/SKILL.md`](.agents/skills/wbs-builder/SKILL.md)) — when asked to plan a program in GitHub (e.g. "create a WBS", "break this epic into issues", "scaffold the Epic → Feature → Task hierarchy"), use this skill to materialize real GitHub issues with native issue **types**, parent/child **sub-issues**, and **blocked-by** dependency edges via the GraphQL API, before any implementation begins. It ships a resumable runner (`scripts/create-wbs.mjs`) and an authoring guide (`references/wbs-authoring.md`). **Issue-type IDs are org-scoped — the runner discovers repo and type IDs at runtime by name and never assumes another org's IDs.**


### PR DESCRIPTION
Closes #178.

Cherry-picks `9a2163b` onto `main`.

Adds a repo-local skill under `.agents/skills/wbs-builder/` that materializes an Epic → Feature → Task work-breakdown structure as real GitHub issues via the GraphQL API, with native issue types, parent/child sub-issues, and blocked-by dependency edges, before any implementation begins.

- `scripts/create-wbs.mjs`: resumable runner (`discover|create|sub|deps|all`, `--dry-run/--data/--map`). Discovers repository and org-scoped issue-type IDs at runtime by name per owner/repo; no hardcoded node IDs. Journals key→id/number/url to `wbs-map.json` for resume.
- `scripts/wbs-data.example.mjs`: template WBS definition (`REPOS`, `KIND_TYPE_NAMES`, `ITEMS`, `DEPS`) plus the `task()` body helper.
- `references/wbs-authoring.md`: hierarchy + body templates, native-metadata model, GraphQL mechanics, mandatory per-owner ID discovery, and idempotent execution discipline.
- `AGENTS.md`: document the skill under a new Skills section.

### Review hardening (follow-up commit)
- `gql()` now checks `res.ok` and parses defensively, surfacing concise HTTP/non-JSON errors.
- Added an upfront `validateWbs()` so unknown repo/kind, non-string title/body, duplicate keys, and bad parent/DEPS references fail with actionable messages.
- Sub-issue linking failures are now persisted to `wbs-map.json` and skipped on re-run until cleared, matching the dependency-edge behavior and the docs.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>