### PR TITLE
docs(content): document the open node-type engine and all new node types

### DIFF
--- a/content/content-model-ingestion.md
+++ b/content/content-model-ingestion.md
@@ -1,0 +1,130 @@
+---
+id: "content-model-ingestion"
+title: "Content-Model Ingestion"
+emoji: "Flow"
+cluster: engine
+derived: true
+connections:
+  - to: node-types
+    type: references
+    description: Emits nodes on the open node-type foundation
+  - to: providers-overview
+    type: references
+    description: Wrapped as a GraphProvider
+  - to: structural-nodes
+    type: references
+    description: Sibling data-driven provider
+  - to: identity
+    type: references
+    description: URN identity contract
+  - to: local-loader
+    type: references
+    description: Registered from the manifest
+  - to: manifest-generator
+    type: references
+    description: Reads the content-model source at build time
+---
+
+The **content-model ingestion** pipeline turns a *content-model source* — a set of YAML/JSON-LD schema files plus per-entity files — into typed, JSON-LD-backed graph nodes on top of the open [node-type foundation](node-types). It is the F2 layer (issue [#149](https://github.com/anokye-labs/kbexplorer-template/issues/149)) and is implemented as a five-pass builder in `src/engine/content-model/builder.ts`, wrapped as a [provider](providers-overview) in `src/engine/providers/content-model-provider.ts`.
+
+The defining rule: a node's **kind is its `@type`, never its file path**. Paths are opaque hierarchy; the [identity](identity) URN and the JSON-LD `@type` carry all the meaning.
+
+## Safe no-op by default
+
+A content-model source is "present" only when both the identity anchor `teamops.yaml` and the URN context `index/context.jsonld` exist — `hasContentModelSource()` in `src/engine/content-model/schema-reader.ts`. When either is missing, both `buildContentModel()` and the `ContentModelProvider` return empty results, so a repo *without* a content model (like this template) renders byte-identically. This is why the provider can always be registered in the [local loader](local-loader) unconditionally.
+
+## The five passes
+
+```mermaid
+%%{init: {'theme':'dark', 'themeVariables': {'primaryColor':'#1f2a37','primaryTextColor':'#e6edf3','primaryBorderColor':'#4A9CC8','lineColor':'#79c0ff','fontSize':'14px'}}}%%
+flowchart TD
+  S["Source<br/>{ root, files }"] --> P1
+  P1["1 · Schema<br/>readContentModelSchema()"] --> P2
+  P2["2 · Walk + index<br/>walkEntities() — detect org, build (kind,id) + alias maps"] --> P3
+  P3["3 · Emit nodes<br/>emitNode() — one JSON-LD KBNode per entity"] --> P4
+  P4["4 · Foreign keys<br/>scalar / array / composite / alias FKs"] --> P5
+  P5["5 · Derived + deprecated<br/>shared-target pairs · deprecated tags"] --> G["nodes + edges + diagnostics"]
+```
+
+Plain-text flow:
+
+```
+Source → Schema → Walk+Index → Emit JSON-LD nodes → Resolve FK edges → Derive + deprecate → Graph
+```
+
+1. **Schema** — `readContentModelSchema()` parses the five schema files (below) into a typed `ContentModelSchema`.
+2. **Walk + index** — `walkEntities()` discovers entity files (skipping schema/index files), parses each, detects its org from disk layout (flat file → default org; nested under `<org>/` → that org), builds the canonical URN, and indexes entries by `(kind, id)` plus an alias index for alias-FK resolution.
+3. **Emit nodes** — `emitNode()` produces one JSON-LD `KBNode` per entity: `display: 'entity'`, `entityType: <kind>`, `source: { type: 'structured', entityType, ref }`, `provider: 'content-model'`, and `data` set to the **verbatim** parsed record so the field → node mapping is reversible. The lifecycle band is surfaced on the `jsonld` envelope only, never inside `data`.
+4. **Foreign keys** — the `EdgeResolver` resolves the FK rules from `schema/edges.yaml`. Unresolved references become **stub nodes** (`data.unresolved: true`) plus a diagnostic, so a dangling reference never silently drops an edge.
+5. **Derived + deprecated** — `shared-target` rules pairwise-link entities that resolve to the same FK target (tagged `relation: 'derived'`); deprecated rules are resolved but tagged `relation: 'deprecated'`.
+
+## Edges ride on `connections`, not `edges`
+
+A subtle but load-bearing detail: the [orchestrator](orchestrator) ignores a provider's returned `edges` array — `buildGraph` derives every rendered edge from each node's `connections`. So the resolver attaches each relationship as a `relation`-tagged `Connection` on the **source node**, and the typed `edges` array is returned only for callers and unit tests. The relations come from the open taxonomy documented in [typed edges](typed-edges) — `leads`, `staffs`, `reports-to`, `structural`, `derived`, `deprecated`.
+
+## URN and CURIE resolution
+
+URN **bases come from the JSON-LD `@context` only** — they are never hardcoded. `buildUrn()` looks up `context.prefixes[kind]` and produces:
+
+- **org-scoped** kinds → `{base}{org}/{id}`
+- **authority-scoped** kinds → `{base}{id}`
+
+`resolveCurie()` expands a `prefix:local` CURIE to a URN (already-expanded `scheme://…` values pass through unchanged). The node's `id`, `identity`, and `@id` are all the same URN, and `buildJsonLd()` (in `src/types/index.ts`) writes the reserved keys `@context` / `@id` / `@type` **last** so entity `data` can never override them. This is the same identity contract described in [identity](identity).
+
+## The schema files
+
+`schema-reader.ts` reads exactly five files from the content-model root:
+
+| File | Purpose |
+|------|---------|
+| `teamops.yaml` | Identity anchor — authority + default (home) org |
+| `index/context.jsonld` | CURIE prefix → URN base (the **only** source of URN bases) |
+| `schema/conventions.yaml` | Per-kind storage: `path`, `orgScoped`, `aliasField`, `companionExt` |
+| `schema/edges.yaml` | FK / derived / deprecated edge rules |
+| `schema/lifecycle.yaml` | Kind → lifecycle band |
+
+## Spine node types and viewers
+
+Before emitting, the provider calls `registerContentModelTypes()` (`src/engine/content-model/register.ts`), which registers the seven **spine kinds** and binds each to a bespoke viewer:
+
+| Kind | Viewer | Notes |
+|------|--------|-------|
+| `person` | PersonView | Leaf of the org graph; `reports-to` relations |
+| `squad` | SquadView | `leads` / `staffs` / `structural` / `deprecated` |
+| `workstream` | WorkstreamView | Aligned to a priority |
+| `mission` | MissionView | Time-boxed, assigned to a cycle + squad |
+| `priority` | PriorityView | Ranked organizational priority |
+| `cycle` | CycleView | Planning time box |
+| `org` | OrgView | Organization with a charter |
+
+Anything without a bespoke viewer falls back to `GenericStructuredView`, so coverage is never zero. The viewer-registry mechanics are covered in [node types](node-types) and from the rendering side in [UI node types](ui-node-types).
+
+## Build wiring
+
+In local mode the source is baked into the manifest at build time:
+
+```
+content-model/  →  generate-manifest.js (readContentModel)  →  manifest.contentModel  →  local-loader → ContentModelProvider
+```
+
+- `scripts/generate-manifest.js` exposes `readContentModel(root)`, which walks a `content-model/` directory into a flat `{ root, files }` map (or `null` when the directory is absent/empty). The result is written as `manifest.contentModel`. See the [manifest generator](manifest-generator) and [build scripts](build-scripts).
+- The [local loader](local-loader) always registers `new ContentModelProvider(manifest.contentModel ?? null)`; the remote loader keeps a matching no-op seam until a remote fetch path lands.
+
+## The `content-model/` starter directory
+
+A starter `content-model/` directory documents the contract a real source must honour. Its shape mirrors the schema reader's expectations:
+
+```
+content-model/
+  teamops.yaml            # identity: authority + default org
+  index/context.jsonld    # CURIE prefix → URN base
+  schema/
+    conventions.yaml      # per-kind: path, orgScoped, aliasField, companionExt
+    edges.yaml            # FK / derived / deprecated rules
+    lifecycle.yaml        # kind → lifecycle band
+  people/ada.yaml         # entity files — kind comes from @type, NEVER the path
+  squads/<org>/<id>.yaml  # org-scoped kinds may nest under a per-org subdir
+  squads/<id>.md          # optional companion markdown merged into the body
+```
+
+Drop a directory shaped like this at the repo root, re-run the manifest generator, and the spine renders as typed nodes — with no engine changes, because every kind, viewer, and edge is data-driven. Repos that ship no such directory keep their existing graph untouched.

--- a/content/content-pipeline.md
+++ b/content/content-pipeline.md
@@ -16,7 +16,7 @@ Sources → Providers → Parser → Nodes → Graph Engine → KBGraph → View
 ```
 
 1. **Sources** — GitHub API, local manifest, authored markdown, `nodemap.yaml`
-2. **[Providers](providers-overview)** — [authored](authored-provider), [files](files-provider), [work](work-provider) adapters normalize sources into `KBNode[]`
+2. **[Providers](providers-overview)** — [authored](authored-provider), [files](files-provider), [work](work-provider), the [content-model](content-model-ingestion) and [structural](structural-nodes) adapters normalize sources into `KBNode[]`
 3. **[Parser](parser)** — extracts frontmatter, inline links, cross-references
 4. **[Graph Engine](graph-engine)** — computes edges, clusters, related nodes, degree maps
 5. **Views** — [overview](overview-view), [reading](reading-view), graph render the final `KBGraph`
@@ -40,6 +40,10 @@ Edges emerge from multiple points in the pipeline:
 - Parent-child containment (structural, from [graph engine](graph-engine))
 
 The [typed edges spec](typed-edges) categorizes and weights these edge sources.
+
+## Node types in the pipeline
+
+Providers don't just emit generic nodes — they emit **typed** ones. The open [node-type engine](node-types) lets a provider tag a `KBNode` with an `entityType` so it renders through a bespoke viewer. Two providers feed it today: [content-model ingestion](content-model-ingestion) turns a JSON-LD content model into the org spine (person, squad, workstream, …), and the [structural nodes](structural-nodes) provider maps `.github` config and the `skill` type into the graph. The [node types & sources](ui-node-types) page covers how each one is badged and rendered.
 
 ## Content Derivation
 

--- a/content/node-types.md
+++ b/content/node-types.md
@@ -120,7 +120,7 @@ The [repo-structural provider](structural-nodes) registers via `registerStructur
 |--------------|--------|--------|
 | `workflow` | WorkflowView | `.github/workflows/*.yml` |
 | `github-action` | ActionView | `action.yml` |
-| `skill` | SkillView | `SKILL.md` — *lands in [PR #180](https://github.com/anokye-labs/kbexplorer-template/pull/180); not yet registered on `main`* |
+| `skill` | SkillView | `SKILL.md` (newest addition) |
 | `issue-template` | generic | `.github/ISSUE_TEMPLATE/**` |
 | `pr-template` | generic | `PULL_REQUEST_TEMPLATE.md` |
 | `codeowners` | generic | `CODEOWNERS` |
@@ -128,7 +128,7 @@ The [repo-structural provider](structural-nodes) registers via `registerStructur
 | `funding-config` | generic | `.github/FUNDING.yml` |
 | `github-config` / `structured-config` | generic | other `.github` config / docs |
 
-Each row was added with a single `registerType()` + optional `registerViewer()` call — no new `DisplayMode`, `EdgeType`, or `NodeSource` variant was needed. `DisplayMode` and `EdgeType` are open unions (`Known… | (string & {})`), so they extend without a core edit; `NodeSource` is a *closed* discriminated union, but its generic `structured` variant (`{ type: 'structured'; entityType: string; ref?: string }`) is the shared escape hatch every typed node reuses — which is the whole point of the design. (The `skill` row above is documented here but registered by [PR #180](https://github.com/anokye-labs/kbexplorer-template/pull/180), not yet on `main`.)
+Each row was added with a single `registerType()` + optional `registerViewer()` call — no new `DisplayMode`, `EdgeType`, or `NodeSource` variant was needed. `DisplayMode` and `EdgeType` are open unions (`Known… | (string & {})`), so they extend without a core edit; `NodeSource` is a *closed* discriminated union, but its generic `structured` variant (`{ type: 'structured'; entityType: string; ref?: string }`) is the shared escape hatch every typed node reuses — which is the whole point of the design.
 
 ## Where to go next
 

--- a/content/node-types.md
+++ b/content/node-types.md
@@ -4,7 +4,22 @@ title: "Open Node-Type Foundation"
 emoji: "Shapes"
 cluster: engine
 derived: true
-connections: []
+connections:
+  - to: content-model-ingestion
+    type: references
+    description: The content-model spine registers its kinds here
+  - to: structural-nodes
+    type: references
+    description: The .github structural kinds register here
+  - to: ui-node-types
+    type: references
+    description: How typed nodes render in the reading view
+  - to: identity
+    type: references
+    description: "@id reuses the identity URN"
+  - to: type-system
+    type: references
+    description: KBNode JSON-LD fields
 ---
 
 The node-type foundation (issue [#148](https://github.com/anokye-labs/kbexplorer-template/issues/148)) turns kbexplorer into an **open, data-driven node-type engine**. New node types — a person, a team, a service — register themselves at runtime instead of forcing edits to the core [type contract](identity). Every change is **additive and backward-compatible**: a node that omits the new fields behaves exactly as before.
@@ -82,3 +97,39 @@ No edits to the core unions or render switches are required.
 
 - `CACHE_VERSION` in `src/api/github.ts` is bumped whenever the cached node/edge shape changes (the JSON-LD fields bumped it to **13**); stale caches self-clear on load.
 - An off-by-default demo seam, `injectDemoEntities()` (enabled via `?demo=entities` or `localStorage['kbe-demo-entities']`), seeds person/team entities and `leads`/`staffs`/`reports-to` edges for end-to-end verification without polluting real graphs.
+
+## The full registry today
+
+Two providers populate the registry at runtime, and the [viewer registry](ui-node-types) (`src/views/viewers/registry.ts`) maps each `entityType` — or, failing that, the JSON-LD `@type` — to a renderer. Resolution precedence is `entityType` → `@type` (array entries tried in order) → the mandatory `GenericStructuredView`, so coverage is never zero.
+
+The [content-model spine](content-model-ingestion) registers via `registerContentModelTypes()`:
+
+| `entityType` | Layer | Viewer |
+|--------------|-------|--------|
+| `person` | work | PersonView |
+| `squad` | work | SquadView |
+| `workstream` | work | WorkstreamView |
+| `mission` | work | MissionView |
+| `priority` | work | PriorityView |
+| `cycle` | work | CycleView |
+| `org` | work | OrgView |
+
+The [repo-structural provider](structural-nodes) registers via `registerStructuralTypes()`:
+
+| `entityType` | Viewer | Source |
+|--------------|--------|--------|
+| `workflow` | WorkflowView | `.github/workflows/*.yml` |
+| `github-action` | ActionView | `action.yml` |
+| `skill` | SkillView | `SKILL.md` (newest addition) |
+| `issue-template` | generic | `.github/ISSUE_TEMPLATE/**` |
+| `pr-template` | generic | `PULL_REQUEST_TEMPLATE.md` |
+| `codeowners` | generic | `CODEOWNERS` |
+| `dependabot-config` | generic | `.github/dependabot.yml` |
+| `funding-config` | generic | `.github/FUNDING.yml` |
+| `github-config` / `structured-config` | generic | other `.github` config / docs |
+
+Each row was added with a single `registerType()` + optional `registerViewer()` call — no edit to `DisplayMode`, `EdgeType`, or `NodeSource` was required, which is the whole point of keeping those unions open.
+
+## Where to go next
+
+The [content-model ingestion](content-model-ingestion) page traces how the spine kinds are built from a schema-driven source; [repo-structural nodes](structural-nodes) covers the `.github` kinds and their bespoke viewers; and [UI node types](ui-node-types) shows how `display: 'entity'` routes a node to its viewer in the reading view. The identity contract behind `@id` lives in [identity](identity), and the relation taxonomy these nodes connect with is detailed in [typed edges](typed-edges).

--- a/content/node-types.md
+++ b/content/node-types.md
@@ -120,7 +120,7 @@ The [repo-structural provider](structural-nodes) registers via `registerStructur
 |--------------|--------|--------|
 | `workflow` | WorkflowView | `.github/workflows/*.yml` |
 | `github-action` | ActionView | `action.yml` |
-| `skill` | SkillView | `SKILL.md` (newest addition) |
+| `skill` | SkillView | `SKILL.md` — *lands in [PR #180](https://github.com/anokye-labs/kbexplorer-template/pull/180); not yet registered on `main`* |
 | `issue-template` | generic | `.github/ISSUE_TEMPLATE/**` |
 | `pr-template` | generic | `PULL_REQUEST_TEMPLATE.md` |
 | `codeowners` | generic | `CODEOWNERS` |
@@ -128,7 +128,7 @@ The [repo-structural provider](structural-nodes) registers via `registerStructur
 | `funding-config` | generic | `.github/FUNDING.yml` |
 | `github-config` / `structured-config` | generic | other `.github` config / docs |
 
-Each row was added with a single `registerType()` + optional `registerViewer()` call — no edit to `DisplayMode`, `EdgeType`, or `NodeSource` was required, which is the whole point of keeping those unions open.
+Each row was added with a single `registerType()` + optional `registerViewer()` call — no new `DisplayMode`, `EdgeType`, or `NodeSource` variant was needed. `DisplayMode` and `EdgeType` are open unions (`Known… | (string & {})`), so they extend without a core edit; `NodeSource` is a *closed* discriminated union, but its generic `structured` variant (`{ type: 'structured'; entityType: string; ref?: string }`) is the shared escape hatch every typed node reuses — which is the whole point of the design. (The `skill` row above is documented here but registered by [PR #180](https://github.com/anokye-labs/kbexplorer-template/pull/180), not yet on `main`.)
 
 ## Where to go next
 

--- a/content/structural-nodes.md
+++ b/content/structural-nodes.md
@@ -41,13 +41,15 @@ Path classifiers in `structural-provider.ts` route each `.github` file to a per-
 |--------------|--------------|-----------------|--------|
 | `.github/workflows/*.yml` | `workflow` | `Workflow` | WorkflowView |
 | `**/action.yml` | `github-action` | `SoftwareApplication` | ActionView |
-| `.github/skills/**/SKILL.md`, `*.skill.md` | `skill` | `HowTo` | SkillView |
+| `.github/skills/**/SKILL.md`, `*.skill.md` | `skill` | `HowTo` | SkillView † |
 | `.github/ISSUE_TEMPLATE/**` | `issue-template` | `CreativeWork` | generic |
 | `PULL_REQUEST_TEMPLATE.md` | `pr-template` | `CreativeWork` | generic |
 | `CODEOWNERS` | `codeowners` | `StructuredConfig` | generic |
 | `.github/dependabot.yml` | `dependabot-config` | `DependabotConfig` | generic |
 | `.github/FUNDING.yml` | `funding-config` | `StructuredConfig` | generic |
 | other `.github` config / docs | `github-config` / `structured-config` | varies | generic |
+
+† The `skill` classifier and its `SkillView` are **not yet on `main`** — they ship with [PR #180](https://github.com/anokye-labs/kbexplorer-template/pull/180). This page documents them so it can land alongside that engine work; everything else in the table is live today.
 
 Anything that doesn't match a dedicated classifier falls through to `buildGenericConfigNode()`, which first tries the declarative [node map](node-mapping) (`node-map.yaml`) plus a heuristic structured mapper, then treats prose markdown (`SECURITY.md`, `SUPPORT.md`, …) as a documentation node.
 
@@ -57,7 +59,7 @@ flowchart TD
   R(("repo-meta")):::repo
   WF["workflow<br/>WorkflowView"] -- structural --> R
   AC["github-action<br/>ActionView"] -- structural --> R
-  SK["skill<br/>SkillView"] -- structural --> R
+  SK["skill (PR #180)<br/>SkillView"] -- structural --> R
   IT["issue-template"] -- structural --> R
   PR["pr-template"] -- structural --> R
   CO["codeowners"] -- structural --> R
@@ -66,13 +68,13 @@ flowchart TD
   classDef repo fill:#5A98A8,stroke:#79c0ff,color:#0d1117;
 ```
 
-## The new `skill` node
+## The `skill` node (lands in PR #180)
 
-The newest structural type is `skill` — a Copilot / agent `SKILL.md` discovered under `.github/skills/**` (or any `*.skill.md`). `buildSkillNode()` parses the file's frontmatter, derives the name from the `name` field or the skill's directory, renders the guidance body to safe HTML, and emits an `entityType: 'skill'` node with JSON-LD `@type: 'HowTo'`. Its bespoke `SkillView` (`src/views/viewers/SkillView.tsx`) leads with the skill's most load-bearing field — the **when-to-use trigger** (`description`) that tells an agent when to reach for it — followed by the rendered body. The type and viewer are wired in `registerStructuralTypes()` exactly like `workflow` and `github-action`, with no change to any core union.
+The next structural type is `skill` — a Copilot / agent `SKILL.md` discovered under `.github/skills/**` (or any `*.skill.md`). It is **not yet on `main`**; the classifier, builder, and viewer below ship with [PR #180](https://github.com/anokye-labs/kbexplorer-template/pull/180), and this section documents the behavior that PR introduces. There, `buildSkillNode()` parses the file's frontmatter, derives the name from the `name` field or the skill's directory, renders the guidance body to safe HTML, and emits an `entityType: 'skill'` node with JSON-LD `@type: 'HowTo'`. Its bespoke `SkillView` (`src/views/viewers/SkillView.tsx`) leads with the skill's most load-bearing field — the **when-to-use trigger** (`description`) that tells an agent when to reach for it — followed by the rendered body. The type and viewer are wired in `registerStructuralTypes()` exactly like `workflow` and `github-action`, with no change to any core union.
 
 ## Bespoke viewers
 
-`registerStructuralTypes()` binds `workflow → WorkflowView`, `github-action → ActionView`, and `skill → SkillView`; every other structural kind uses `GenericStructuredView`, which renders any `data` / `jsonld` payload as a nested table/tree. The viewer-registry resolution rules are shared with the content-model spine — see [node types](node-types) and [UI node types](ui-node-types).
+On `main` today, `registerStructuralTypes()` binds `workflow → WorkflowView` and `github-action → ActionView`; [PR #180](https://github.com/anokye-labs/kbexplorer-template/pull/180) adds the `skill → SkillView` binding. Every other structural kind uses `GenericStructuredView`, which renders any `data` / `jsonld` payload as a nested table/tree. The viewer-registry resolution rules are shared with the content-model spine — see [node types](node-types) and [UI node types](ui-node-types).
 
 ## Untrusted-markup escaping
 

--- a/content/structural-nodes.md
+++ b/content/structural-nodes.md
@@ -41,15 +41,13 @@ Path classifiers in `structural-provider.ts` route each `.github` file to a per-
 |--------------|--------------|-----------------|--------|
 | `.github/workflows/*.yml` | `workflow` | `Workflow` | WorkflowView |
 | `**/action.yml` | `github-action` | `SoftwareApplication` | ActionView |
-| `.github/skills/**/SKILL.md`, `*.skill.md` | `skill` | `HowTo` | SkillView † |
+| `.github/skills/**/SKILL.md`, `*.skill.md` | `skill` | `HowTo` | SkillView |
 | `.github/ISSUE_TEMPLATE/**` | `issue-template` | `CreativeWork` | generic |
 | `PULL_REQUEST_TEMPLATE.md` | `pr-template` | `CreativeWork` | generic |
 | `CODEOWNERS` | `codeowners` | `StructuredConfig` | generic |
 | `.github/dependabot.yml` | `dependabot-config` | `DependabotConfig` | generic |
 | `.github/FUNDING.yml` | `funding-config` | `StructuredConfig` | generic |
 | other `.github` config / docs | `github-config` / `structured-config` | varies | generic |
-
-† The `skill` classifier and its `SkillView` are **not yet on `main`** — they ship with [PR #180](https://github.com/anokye-labs/kbexplorer-template/pull/180). This page documents them so it can land alongside that engine work; everything else in the table is live today.
 
 Anything that doesn't match a dedicated classifier falls through to `buildGenericConfigNode()`, which first tries the declarative [node map](node-mapping) (`node-map.yaml`) plus a heuristic structured mapper, then treats prose markdown (`SECURITY.md`, `SUPPORT.md`, …) as a documentation node.
 
@@ -59,7 +57,7 @@ flowchart TD
   R(("repo-meta")):::repo
   WF["workflow<br/>WorkflowView"] -- structural --> R
   AC["github-action<br/>ActionView"] -- structural --> R
-  SK["skill (PR #180)<br/>SkillView"] -- structural --> R
+  SK["skill<br/>SkillView"] -- structural --> R
   IT["issue-template"] -- structural --> R
   PR["pr-template"] -- structural --> R
   CO["codeowners"] -- structural --> R
@@ -68,13 +66,13 @@ flowchart TD
   classDef repo fill:#5A98A8,stroke:#79c0ff,color:#0d1117;
 ```
 
-## The `skill` node (lands in PR #180)
+## The `skill` node
 
-The next structural type is `skill` — a Copilot / agent `SKILL.md` discovered under `.github/skills/**` (or any `*.skill.md`). It is **not yet on `main`**; the classifier, builder, and viewer below ship with [PR #180](https://github.com/anokye-labs/kbexplorer-template/pull/180), and this section documents the behavior that PR introduces. There, `buildSkillNode()` parses the file's frontmatter, derives the name from the `name` field or the skill's directory, renders the guidance body to safe HTML, and emits an `entityType: 'skill'` node with JSON-LD `@type: 'HowTo'`. Its bespoke `SkillView` (`src/views/viewers/SkillView.tsx`) leads with the skill's most load-bearing field — the **when-to-use trigger** (`description`) that tells an agent when to reach for it — followed by the rendered body. The type and viewer are wired in `registerStructuralTypes()` exactly like `workflow` and `github-action`, with no change to any core union.
+The newest structural type is `skill` — a Copilot / agent `SKILL.md` discovered under `.github/skills/**` (or any `*.skill.md`) by `isSkill()`. `buildSkillNode()` parses the file's frontmatter, derives the name from the `name` field or the skill's directory, renders the guidance body to safe HTML, and emits an `entityType: 'skill'` node with JSON-LD `@type: 'HowTo'` and `source: { type: 'structured', entityType: 'skill', ref: path }`. Its bespoke `SkillView` (`src/views/viewers/SkillView.tsx`) leads with the skill's most load-bearing field — the **when-to-use trigger** (`description`) that tells an agent when to reach for it — followed by the rendered body. The type and viewer are wired in `registerStructuralTypes()` (`registerType({ id: 'skill', … viewer: 'skill' })` + `registerViewer('skill', SkillView)`) exactly like `workflow` and `github-action`, with no change to any core union.
 
 ## Bespoke viewers
 
-On `main` today, `registerStructuralTypes()` binds `workflow → WorkflowView` and `github-action → ActionView`; [PR #180](https://github.com/anokye-labs/kbexplorer-template/pull/180) adds the `skill → SkillView` binding. Every other structural kind uses `GenericStructuredView`, which renders any `data` / `jsonld` payload as a nested table/tree. The viewer-registry resolution rules are shared with the content-model spine — see [node types](node-types) and [UI node types](ui-node-types).
+`registerStructuralTypes()` binds `workflow → WorkflowView`, `github-action → ActionView`, and `skill → SkillView`; every other structural kind uses `GenericStructuredView`, which renders any `data` / `jsonld` payload as a nested table/tree. The viewer-registry resolution rules are shared with the content-model spine — see [node types](node-types) and [UI node types](ui-node-types).
 
 ## Untrusted-markup escaping
 

--- a/content/structural-nodes.md
+++ b/content/structural-nodes.md
@@ -1,0 +1,87 @@
+---
+id: "structural-nodes"
+title: "Repo-Structural Nodes"
+emoji: "Wrench"
+cluster: engine
+derived: true
+connections:
+  - to: node-types
+    type: references
+    description: Registers structural node types
+  - to: content-model-ingestion
+    type: references
+    description: Sibling data-driven provider
+  - to: providers-overview
+    type: references
+    description: Implemented as a GraphProvider
+  - to: node-mapping
+    type: references
+    description: Declarative node-map.yaml + heuristic fallback
+  - to: identity
+    type: references
+    description: urn:structural identity scheme
+  - to: local-loader
+    type: references
+    description: Registered from the manifest
+---
+
+The **StructuralProvider** makes "almost everything in `.github`" a first-class graph citizen. It is the F3 layer (issue [#150](https://github.com/anokye-labs/kbexplorer-template/issues/150)), implemented in `src/engine/providers/structural-provider.ts`, and it turns workflows, actions, templates, ownership and config files into typed nodes on the open [node-type foundation](node-types) — siblings of the [content-model](content-model-ingestion) spine.
+
+Every node it produces carries a `structural`-relation edge back to the repository node (`repo-meta`), so the repo sits at the centre of its own configuration constellation.
+
+## Safe, additive, guarded
+
+Like the content-model pipeline, the provider is a **safe no-op**: with no `.github` files it returns `{ nodes: [], edges: [] }`, so existing graphs are byte-identical. It declares a dependency on the `work` provider so the repository node exists before structural nodes attach to it.
+
+## What gets discovered
+
+Path classifiers in `structural-provider.ts` route each `.github` file to a per-kind builder:
+
+| File pattern | `entityType` | JSON-LD `@type` | Viewer |
+|--------------|--------------|-----------------|--------|
+| `.github/workflows/*.yml` | `workflow` | `Workflow` | WorkflowView |
+| `**/action.yml` | `github-action` | `SoftwareApplication` | ActionView |
+| `.github/skills/**/SKILL.md`, `*.skill.md` | `skill` | `HowTo` | SkillView |
+| `.github/ISSUE_TEMPLATE/**` | `issue-template` | `CreativeWork` | generic |
+| `PULL_REQUEST_TEMPLATE.md` | `pr-template` | `CreativeWork` | generic |
+| `CODEOWNERS` | `codeowners` | `StructuredConfig` | generic |
+| `.github/dependabot.yml` | `dependabot-config` | `DependabotConfig` | generic |
+| `.github/FUNDING.yml` | `funding-config` | `StructuredConfig` | generic |
+| other `.github` config / docs | `github-config` / `structured-config` | varies | generic |
+
+Anything that doesn't match a dedicated classifier falls through to `buildGenericConfigNode()`, which first tries the declarative [node map](node-mapping) (`node-map.yaml`) plus a heuristic structured mapper, then treats prose markdown (`SECURITY.md`, `SUPPORT.md`, …) as a documentation node.
+
+```mermaid
+%%{init: {'theme':'dark', 'themeVariables': {'primaryColor':'#1f2a37','primaryTextColor':'#e6edf3','primaryBorderColor':'#5A98A8','lineColor':'#79c0ff','fontSize':'14px'}}}%%
+flowchart TD
+  R(("repo-meta")):::repo
+  WF["workflow<br/>WorkflowView"] -- structural --> R
+  AC["github-action<br/>ActionView"] -- structural --> R
+  SK["skill<br/>SkillView"] -- structural --> R
+  IT["issue-template"] -- structural --> R
+  PR["pr-template"] -- structural --> R
+  CO["codeowners"] -- structural --> R
+  DB["dependabot-config"] -- structural --> R
+  FU["funding-config"] -- structural --> R
+  classDef repo fill:#5A98A8,stroke:#79c0ff,color:#0d1117;
+```
+
+## The new `skill` node
+
+The newest structural type is `skill` — a Copilot / agent `SKILL.md` discovered under `.github/skills/**` (or any `*.skill.md`). `buildSkillNode()` parses the file's frontmatter, derives the name from the `name` field or the skill's directory, renders the guidance body to safe HTML, and emits an `entityType: 'skill'` node with JSON-LD `@type: 'HowTo'`. Its bespoke `SkillView` (`src/views/viewers/SkillView.tsx`) leads with the skill's most load-bearing field — the **when-to-use trigger** (`description`) that tells an agent when to reach for it — followed by the rendered body. The type and viewer are wired in `registerStructuralTypes()` exactly like `workflow` and `github-action`, with no change to any core union.
+
+## Bespoke viewers
+
+`registerStructuralTypes()` binds `workflow → WorkflowView`, `github-action → ActionView`, and `skill → SkillView`; every other structural kind uses `GenericStructuredView`, which renders any `data` / `jsonld` payload as a nested table/tree. The viewer-registry resolution rules are shared with the content-model spine — see [node types](node-types) and [UI node types](ui-node-types).
+
+## Untrusted-markup escaping
+
+Markup committed under `.github/` (issue/PR templates, `SECURITY.md`) is treated as **untrusted**: the provider uses a dedicated `marked` renderer that escapes raw embedded HTML before it ever reaches `dangerouslySetInnerHTML`, so a template can't inject script when its node renders. This is stricter than the app-wide markdown path used for [authored content](authored-provider).
+
+## Identity and collisions
+
+Each node uses a `urn:structural:<path>` identity (see [identity](identity)) and a deterministic, slugified id (`gh-workflow-…`, `gh-skill-…`). The provider guards against id collisions by suffixing duplicates, so two files that slugify alike never silently drop one another's edges.
+
+## Build wiring
+
+`scripts/generate-manifest.js` collects the `.github` files (and any `node-map.yaml`) into `manifest.structuralFiles`; the [local loader](local-loader) registers `new StructuralProvider(manifest.structuralFiles, manifest.structuredNodeMapRaw ?? null)` whenever structural files are present. Because this template ships a real `.github/` directory, these nodes render today — orbiting the repository node alongside the engine cluster.

--- a/content/ui-node-types.md
+++ b/content/ui-node-types.md
@@ -100,7 +100,7 @@ Most "new" node types never add a bespoke `NodeSource` variant. Instead they reu
 | `org` | `OrgView` | content model |
 | `workflow` | `WorkflowView` | [structural](structural-nodes) |
 | `github-action` | `ActionView` | structural |
-| `skill` | `SkillView` | structural — *lands in [PR #180](https://github.com/anokye-labs/kbexplorer-template/pull/180); not yet registered on `main`* |
+| `skill` | `SkillView` | structural |
 | `dependabot` · `funding` · `codeowners` · `templates` · `docs` | `GenericStructuredView` | structural |
 
-The viewer registry keyed by `@type`, the `structured` source variant, and the `'entity'` display mode are the three open seams that let the [node-type engine](node-types) grow new types as pure data + a renderer. Of the rows above, the `skill` → `SkillView` binding is the one that is **not yet on `main`** — it ships with the engine work in [PR #180](https://github.com/anokye-labs/kbexplorer-template/pull/180), and this page is written to land alongside it.
+The viewer registry keyed by `@type`, the `structured` source variant, and the `'entity'` display mode are the three open seams that let the [node-type engine](node-types) grow new types as pure data + a renderer — no edits to the core unions required.

--- a/content/ui-node-types.md
+++ b/content/ui-node-types.md
@@ -1,8 +1,21 @@
 ---
+id: "ui-node-types"
 title: Node Types & Sources
 emoji: DocumentBulletList
 cluster: ui
 connections:
+  - to: node-types
+    type: references
+    description: The data-driven node-type registry
+  - to: content-model-ingestion
+    type: references
+    description: Where typed (structured) entity nodes come from
+  - to: structural-nodes
+    type: references
+    description: .github structural nodes and the skill type
+  - to: type-system
+    type: references
+    description: Open NodeSource / DisplayMode unions
   - to: github-api
     type: references
     description: GitHub issues and PRs
@@ -17,34 +30,77 @@ connections:
     description: Icon gallery display mode
 ---
 
-Every node in kbexplorer comes from a **provider** — a system of record that feeds data into the knowledge graph. The source badge next to each node's title tells you exactly what kind of thing you're looking at and where it came from.
+Every node in kbexplorer comes from a **provider** — a system of record that feeds data into the knowledge graph. Each node carries a `source` (a [`NodeSource`](type-system) discriminated union) and a `display` mode; together they decide the badge shown beside the title and which view renders the body. Both are **open** unions (`KnownDisplayMode | (string & {})`), so new kinds of nodes slot in without editing the core types in `src/types/index.ts`.
 
-## GitHub Issues
+## Source badges at a glance
+
+The badge next to a node's title is driven by `NodeSource.type`:
+
+| Badge | `NodeSource.type` | Provider |
+| --- | --- | --- |
+| Authored doc | `authored` | [content pipeline](content-pipeline) |
+| GitHub issue | `issue` | [GitHub API](github-api) |
+| Pull request | `pull_request` | [GitHub API](github-api) |
+| Repository file | `file` | files / [structural](structural-nodes) |
+| External article | `external` | Wikipedia & friends |
+| Typed entity | `structured` | [content model](content-model-ingestion) + [structural](structural-nodes) |
+
+The full union also covers `commit`, `readme`, `section`, `derived`, `branch`, `workflow`, and `repository` — see `src/types/index.ts`.
+
+## GitHub issues
 
 Issues show their state (🟢 open / 🟣 closed), labels, assignees, creation date, and a "View on GitHub ↗" link that opens the original issue in a new tab. Cross-references to other issues navigate within the graph.
 
-![GitHub issue node with metadata](screenshots/10-issue-node.png)
-
-## Pull Requests
+## Pull requests
 
 PRs display the same rich metadata — state, labels, dates, and an external link. References to issues in the PR body become graph connections.
 
-![Pull request node](screenshots/11-pr-node.png)
+## Authored content
 
-## Authored Content
+Documentation nodes sourced from markdown files in the `content/` directory. These show the source filename in the badge and typically have the richest inline-linked prose — see the [content pipeline](content-pipeline) and the [authored provider](authored-provider).
 
-Documentation nodes sourced from markdown files in the `content/` directory. These show the source filename in the badge and typically have the richest inline-linked prose.
+## External references
 
-![Authored content node](screenshots/13-content-node.png)
+Wikipedia articles and other external sources show the provider name (`source.type === 'external'`, with `provider` naming the plugin). Each includes an excerpt and a link to the original source.
 
-## External References
+## Icon gallery
 
-Wikipedia articles and other external sources show the provider name. Each includes an excerpt and a link to the original source.
+A special display mode (`display: 'gallery'` / `'icon-detail'`) renders the Fluent icon library as a searchable, tiled grid — thousands of icon families browseable within the graph.
 
-![Wikipedia reference node](screenshots/12-wiki-node.png)
+## Typed (structured) nodes and the viewer registry
 
-## Icon Gallery
+Most "new" node types never add a bespoke `NodeSource` variant. Instead they reuse the open escape hatch:
 
-A special [display mode](icon-gallery) that renders the Fluent icon library as a searchable, tiled grid — 2,647 icon families browseable within the graph.
+```ts
+{ type: 'structured'; entityType: string; ref?: string }
+```
 
-![Icon gallery with search](screenshots/14-icon-gallery.png)
+`entityType` is a key in the [node-type registry](node-types); `ref` optionally records the upstream record id the node was mapped from. On the rendering side, the matching escape hatch is `display: 'entity'` — the open `DisplayMode` value that routes a node to a **viewer resolved at runtime** rather than to a fixed layout.
+
+### How a viewer is resolved
+
+`src/views/ReadingView.tsx` switches on `display`; its `case 'entity'` calls `resolveViewer(node)` from `src/views/viewers/registry.ts`. The registry is a `Map<string, ViewerComponent>` keyed by `entityType` / JSON-LD `@type`, with these rules:
+
+- **Resolution precedence** — `node.entityType` first, then JSON-LD `@type` (when `@type` is an array each entry is tried in order), then the [`GenericStructuredView`](node-renderer) fallback, so coverage is never zero.
+- **Case-insensitive keys** — `registerViewer('Skill', …)` and a `@type` of `skill` resolve to the same entry.
+- **Last registration wins** — re-registering a key replaces the prior viewer, letting downstream packages override built-ins without editing the core.
+
+`registerViewer`, `hasViewer`, `getRegisteredViewers`, and `resetViewerRegistry` make up the rest of the seam. Because resolution falls back to a generic viewer, an unknown `@type` still renders as a structured card.
+
+### Entity types with bespoke viewers
+
+| `entityType` / `@type` | Viewer | Source |
+| --- | --- | --- |
+| `person` | `PersonView` | [content model](content-model-ingestion) |
+| `squad` / `team` | `SquadView` | content model |
+| `workstream` | `WorkstreamView` | content model |
+| `mission` | `MissionView` | content model |
+| `priority` | `PriorityView` | content model |
+| `cycle` | `CycleView` | content model |
+| `org` | `OrgView` | content model |
+| `workflow` | `WorkflowView` | [structural](structural-nodes) |
+| `github-action` | `ActionView` | structural |
+| `skill` | `SkillView` | structural |
+| `dependabot` · `funding` · `codeowners` · `templates` · `docs` | `GenericStructuredView` | structural |
+
+The viewer registry keyed by `@type`, the `structured` source, and the `'entity'` display mode are the three open seams that let the [node-type engine](node-types) grow new types as pure data + a renderer — no edits to the core unions required.

--- a/content/ui-node-types.md
+++ b/content/ui-node-types.md
@@ -30,7 +30,7 @@ connections:
     description: Icon gallery display mode
 ---
 
-Every node in kbexplorer comes from a **provider** — a system of record that feeds data into the knowledge graph. Each node carries a `source` (a [`NodeSource`](type-system) discriminated union) and a `display` mode; together they decide the badge shown beside the title and which view renders the body. Both are **open** unions (`KnownDisplayMode | (string & {})`), so new kinds of nodes slot in without editing the core types in `src/types/index.ts`.
+Every node in kbexplorer comes from a **provider** — a system of record that feeds data into the knowledge graph. Each node carries a `source` (a [`NodeSource`](type-system) value) and a `display` mode; together they decide the badge shown beside the title and which view renders the body. The two types take different approaches to extensibility in `src/types/index.ts`: `DisplayMode` is an **open** union (`KnownDisplayMode | (string & {})`), so a brand-new display mode needs no core edit, while `NodeSource` is a **closed** discriminated union — but it carries a generic `structured` variant that acts as the escape hatch for new typed nodes, so they rarely need a new variant either.
 
 ## Source badges at a glance
 
@@ -65,7 +65,7 @@ Wikipedia articles and other external sources show the provider name (`source.ty
 
 ## Icon gallery
 
-A special display mode (`display: 'gallery'` / `'icon-detail'`) renders the Fluent icon library as a searchable, tiled grid — thousands of icon families browseable within the graph.
+A special display mode (`display: 'gallery'` / `'icon-detail'`) renders the Fluent icon library as a searchable, tiled grid — thousands of icon families browsable within the graph.
 
 ## Typed (structured) nodes and the viewer registry
 
@@ -100,7 +100,7 @@ Most "new" node types never add a bespoke `NodeSource` variant. Instead they reu
 | `org` | `OrgView` | content model |
 | `workflow` | `WorkflowView` | [structural](structural-nodes) |
 | `github-action` | `ActionView` | structural |
-| `skill` | `SkillView` | structural |
+| `skill` | `SkillView` | structural — *lands in [PR #180](https://github.com/anokye-labs/kbexplorer-template/pull/180); not yet registered on `main`* |
 | `dependabot` · `funding` · `codeowners` · `templates` · `docs` | `GenericStructuredView` | structural |
 
-The viewer registry keyed by `@type`, the `structured` source, and the `'entity'` display mode are the three open seams that let the [node-type engine](node-types) grow new types as pure data + a renderer — no edits to the core unions required.
+The viewer registry keyed by `@type`, the `structured` source variant, and the `'entity'` display mode are the three open seams that let the [node-type engine](node-types) grow new types as pure data + a renderer. Of the rows above, the `skill` → `SkillView` binding is the one that is **not yet on `main`** — it ships with the engine work in [PR #180](https://github.com/anokye-labs/kbexplorer-template/pull/180), and this page is written to land alongside it.


### PR DESCRIPTION
Closes #179 (Feature, parent Epic #147).

Refreshes the authored knowledge-base content (`content/*.md`) so the wiki documents the open, data-driven node-type engine and **all** new node types. **Docs + frontmatter only — no engine code changed.** Content is kept illustrative/generic to suit this template repo.

## What changed

**New pages**
- **`content/content-model-ingestion.md`** — the F2 5-pass `ContentModelProvider` (schema reader → discovery/index → JSON-LD node emission → FK edge resolution → derived + deprecated), `@type`-driven `kind` (never the file path), URN/CURIE resolution from the JSON-LD `@context`, the safe no-op via `hasContentModelSource()`, why edges ride on node `connections`, the spine kinds + bespoke viewers, and the full build wiring (`scripts/generate-manifest.js` → `manifest.contentModel` → local/remote loader registration). Includes the `content-model/` starter-directory contract.
- **`content/structural-nodes.md`** — the F3 `StructuralProvider`: workflows / actions / templates / CODEOWNERS / dependabot / funding / docs **plus the new `skill` node**, each linked to the `repo-meta` repository node via `structural` edges. Covers `buildSkillNode` + `SkillView` (JSON-LD `@type: 'HowTo'`, when-to-use trigger), the bespoke viewers, untrusted-markup escaping, identity/collision handling, and build wiring.

**Updated pages**
- **`content/node-types.md`** — populated `connections:` and appended the full registry enumeration (spine + structural tables) with cross-links. Fixes the pre-existing orphan.
- **`content/ui-node-types.md`** — added an explicit `id`, a section on the viewer registry keyed by `@type` / `entityType` (`resolveViewer` precedence + `GenericStructuredView` fallback), and the open `NodeSource` (`structured`) / `DisplayMode` (`'entity'`) unions, with an entity-type → viewer table.
- **`content/content-pipeline.md`** — added inline links so the new pages join the engine cluster (no orphans; every node within 3 hops of the hub).

Every claim is grounded in real code (`src/engine/content-model/{builder,schema-reader,register}.ts`, `src/engine/providers/{content-model-provider,structural-provider}.ts`, `src/views/viewers/{registry,SkillView}.tsx`, `src/types/index.ts`). The `skill` type / `SkillView` referenced here land in #180.

## Evidence
- `npm run validate` → **0 warnings, 0 errors, no orphan authored nodes**
- `tsc -b` → **0**
- `npm run lint` → **0 errors** (1 pre-existing unrelated `HUD.tsx` warning)
- Local build green (`VITE_KB_LOCAL=true; node scripts/generate-manifest.js; vite build`)
- Playwright screenshots of both new pages rendered in the reading view (dark mode, tables, code blocks, RELATED rail confirming cluster connectivity).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>