### PR TITLE
T1.1: wire config.theme.default into initial theme mode (#188)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { HashRouter, Routes, Route, Navigate, useParams, useLocation } from 'react-router-dom';
 import { FluentProvider } from '@fluentui/react-components';
 import { useKnowledgeBase } from './hooks/useKnowledgeBase';
@@ -26,9 +26,15 @@ function useCurrentNodeId(): string | null {
   return match ? decodeURIComponent(match[1]) : null;
 }
 
-function Explorer({ themeMode, setThemeMode }: { themeMode: import('./hooks/useTheme').ThemeMode; setThemeMode: (t: import('./hooks/useTheme').ThemeMode) => void }) {
+function Explorer({ themeMode, setThemeMode, applyConfigDefault }: { themeMode: import('./hooks/useTheme').ThemeMode; setThemeMode: (t: import('./hooks/useTheme').ThemeMode) => void; applyConfigDefault: (configDefault?: import('./types').Theme) => void }) {
   const state = useKnowledgeBase();
   const currentNodeId = useCurrentNodeId();
+
+  useEffect(() => {
+    if (state.status === 'ready') {
+      applyConfigDefault(state.config.theme.default);
+    }
+  }, [state, applyConfigDefault]);
 
   const [hudCollapsed, setHudCollapsed] = useState(() => {
     try { return localStorage.getItem('kbe-hud-collapsed') === 'true'; } catch { return false; }
@@ -79,12 +85,12 @@ function Explorer({ themeMode, setThemeMode }: { themeMode: import('./hooks/useT
 }
 
 function App() {
-  const [themeMode, fluentTheme, setThemeMode] = useTheme();
+  const [themeMode, fluentTheme, setThemeMode, applyConfigDefault] = useTheme();
 
   return (
     <FluentProvider theme={fluentTheme} style={{ minHeight: '100vh' }}>
       <HashRouter>
-        <Explorer themeMode={themeMode} setThemeMode={setThemeMode} />
+        <Explorer themeMode={themeMode} setThemeMode={setThemeMode} applyConfigDefault={applyConfigDefault} />
       </HashRouter>
     </FluentProvider>
   );

--- a/src/hooks/__tests__/useTheme.test.ts
+++ b/src/hooks/__tests__/useTheme.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { resolveInitialMode, readStoredRaw } from '../useTheme';
+
+const STORAGE_KEY = 'kbe-theme';
+
+function installLocalStorage() {
+  const store = new Map<string, string>();
+  const mock = {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => { store.set(k, v); },
+    removeItem: (k: string) => { store.delete(k); },
+    clear: () => { store.clear(); },
+  };
+  (globalThis as { localStorage?: unknown }).localStorage = mock;
+}
+
+describe('useTheme initial mode resolution', () => {
+  beforeEach(() => {
+    installLocalStorage();
+  });
+
+  afterEach(() => {
+    delete (globalThis as { localStorage?: unknown }).localStorage;
+  });
+
+  it('config.default applies when no stored theme', () => {
+    expect(readStoredRaw()).toBeNull();
+    expect(resolveInitialMode('light')).toBe('light');
+  });
+
+  it('stored theme wins over config.default', () => {
+    localStorage.setItem(STORAGE_KEY, 'sepia');
+    expect(resolveInitialMode('light')).toBe('sepia');
+  });
+
+  it('falls back to dark when no stored theme and no config default', () => {
+    expect(resolveInitialMode(undefined)).toBe('dark');
+  });
+
+  it('ignores an invalid config default and falls back to dark', () => {
+    expect(resolveInitialMode('chartreuse' as unknown as 'dark')).toBe('dark');
+  });
+});

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback } from 'react';
+import type { Theme } from '../types';
 import {
   webDarkTheme,
   webLightTheme,
@@ -60,12 +61,28 @@ const sepiaTheme: FluentTheme = {
   colorSubtleBackgroundPressed: '#E5DBC2',
 };
 
-function readStored(): ThemeMode {
+/** Returns the user's explicitly stored theme, or null when none is saved. */
+export function readStoredRaw(): ThemeMode | null {
   try {
     const v = localStorage.getItem(STORAGE_KEY);
     if (v && MODES.includes(v as ThemeMode)) return v as ThemeMode;
   } catch { /* ignore */ }
+  return null;
+}
+
+/**
+ * Resolves the initial theme mode. A theme the user explicitly saved always
+ * wins; otherwise fall back to config.theme.default, then to 'dark'.
+ */
+export function resolveInitialMode(configDefault?: Theme): ThemeMode {
+  const stored = readStoredRaw();
+  if (stored) return stored;
+  if (configDefault && MODES.includes(configDefault)) return configDefault;
   return 'dark';
+}
+
+function readStored(): ThemeMode {
+  return readStoredRaw() ?? 'dark';
 }
 
 const THEME_MAP: Record<ThemeMode, FluentTheme> = {
@@ -74,7 +91,12 @@ const THEME_MAP: Record<ThemeMode, FluentTheme> = {
   sepia: sepiaTheme,
 };
 
-export function useTheme(): [ThemeMode, FluentTheme, (t: ThemeMode) => void] {
+export function useTheme(): [
+  ThemeMode,
+  FluentTheme,
+  (t: ThemeMode) => void,
+  (configDefault?: Theme) => void,
+] {
   const [mode, setModeState] = useState<ThemeMode>(readStored);
 
   const setMode = useCallback((t: ThemeMode) => {
@@ -82,7 +104,17 @@ export function useTheme(): [ThemeMode, FluentTheme, (t: ThemeMode) => void] {
     localStorage.setItem(STORAGE_KEY, t);
   }, []);
 
-  return [mode, THEME_MAP[mode], setMode];
+  // Applies config.theme.default as the initial mode, but never overrides a
+  // theme the user has explicitly saved. Not persisted: a config default is
+  // not a user choice, so a later config change can still take effect.
+  const applyConfigDefault = useCallback((configDefault?: Theme) => {
+    if (readStoredRaw() !== null) return;
+    if (configDefault && MODES.includes(configDefault)) {
+      setModeState(configDefault);
+    }
+  }, []);
+
+  return [mode, THEME_MAP[mode], setMode, applyConfigDefault];
 }
 
 export function nextTheme(current: ThemeMode): ThemeMode {


### PR DESCRIPTION
Closes #188

## Summary
Wires `config.theme.default` into the initial theme mode resolution. Previously `useTheme` ignored `config.theme.default` entirely and always defaulted to `'dark'` when no `kbe-theme` value was stored.

Resolution order is now:
1. User's explicitly saved `kbe-theme` (localStorage) — always wins
2. `config.theme.default` — applied once config resolves
3. `'dark'` — final fallback

A config default is **applied but not persisted** (it isn't a user choice), so a later change to `config.theme.default` can still take effect for users who never picked a theme.

## Changes
- `src/hooks/useTheme.ts`:
  - Added `readStoredRaw()` (returns `null` when nothing valid is stored) and a pure `resolveInitialMode(configDefault?)` helper.
  - `useTheme()` now returns a 4th element, `applyConfigDefault(configDefault?)`, which sets the mode to the config default only when no theme is stored.
- `src/App.tsx`: `Explorer` calls `applyConfigDefault(config.theme.default)` via `useEffect` once `useKnowledgeBase()` reaches `ready` (config is loaded async, after `useTheme` first initializes).

Did **not** touch the dark/light/sepia theme definitions or bump `CACHE_VERSION` (that's T1.3).

## Tests
New `src/hooks/__tests__/useTheme.test.ts`:
- `config.default applies when no stored theme`
- `stored theme wins over config.default`
- `falls back to dark when no stored theme and no config default`
- `ignores an invalid config default and falls back to dark`

## Validation
- `npm run lint` — pass (0 errors; 1 pre-existing unrelated warning in HUD.tsx)
- `npx vitest run` — pass (309/309)
- `npm run build` — pass