### PR TITLE
T1.2: drive theme.font.* via CSS variables (#189)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { HashRouter, Routes, Route, Navigate, useParams, useLocation } from 'rea
 import { FluentProvider } from '@fluentui/react-components';
 import { useKnowledgeBase } from './hooks/useKnowledgeBase';
 import { useTheme } from './hooks/useTheme';
+import { useThemeFonts } from './hooks/useThemeFonts';
 import { useKeyboardNav } from './hooks/useKeyboardNav';
 import { HUD } from './components/HUD';
 import type { DockPosition } from './components/HUD';
@@ -41,6 +42,8 @@ function Explorer({ themeMode, setThemeMode }: { themeMode: import('./hooks/useT
     state.status === 'ready' ? state.graph : null,
     setThemeMode as (t: import('./types').Theme) => void,
   );
+
+  useThemeFonts(state.status === 'ready' ? state.config.theme.font : undefined);
 
   if (state.status === 'loading') return <LoadingScreen />;
   if (state.status === 'error') return <ErrorScreen message={state.error} />;

--- a/src/hooks/__tests__/useThemeFonts.test.ts
+++ b/src/hooks/__tests__/useThemeFonts.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { applyThemeFonts, type FontStyleTarget } from '../useThemeFonts';
+
+function makeTarget() {
+  const props = new Map<string, string>();
+  const target: FontStyleTarget = {
+    style: {
+      setProperty: (name, value) => { props.set(name, value); },
+      removeProperty: (name) => { props.delete(name); },
+    },
+  };
+  return { target, props };
+}
+
+describe('applyThemeFonts', () => {
+  it('sets the three --kbe-font-* CSS vars from a config font object', () => {
+    const { target, props } = makeTarget();
+
+    applyThemeFonts(
+      {
+        heading: "'Comic Sans MS', cursive",
+        body: "'Georgia', serif",
+        mono: "'Fira Code', monospace",
+      },
+      target,
+    );
+
+    expect(props.get('--kbe-font-heading')).toBe("'Comic Sans MS', cursive");
+    expect(props.get('--kbe-font-body')).toBe("'Georgia', serif");
+    expect(props.get('--kbe-font-mono')).toBe("'Fira Code', monospace");
+  });
+
+  it('removes a var when its font is omitted so the CSS fallback applies', () => {
+    const { target, props } = makeTarget();
+    props.set('--kbe-font-heading', 'stale');
+
+    applyThemeFonts({ body: "'Georgia', serif" }, target);
+
+    expect(props.has('--kbe-font-heading')).toBe(false);
+    expect(props.has('--kbe-font-mono')).toBe(false);
+    expect(props.get('--kbe-font-body')).toBe("'Georgia', serif");
+  });
+
+  it('removes all vars when font config is undefined', () => {
+    const { target, props } = makeTarget();
+    props.set('--kbe-font-heading', 'a');
+    props.set('--kbe-font-body', 'b');
+    props.set('--kbe-font-mono', 'c');
+
+    applyThemeFonts(undefined, target);
+
+    expect(props.size).toBe(0);
+  });
+});

--- a/src/hooks/__tests__/useThemeFonts.test.ts
+++ b/src/hooks/__tests__/useThemeFonts.test.ts
@@ -51,4 +51,18 @@ describe('applyThemeFonts', () => {
 
     expect(props.size).toBe(0);
   });
+
+  it('is a safe no-op without a DOM (no root and no document)', () => {
+    const hadDocument = 'document' in globalThis;
+    const original = (globalThis as { document?: unknown }).document;
+    // Simulate a non-browser environment (Node without jsdom).
+    delete (globalThis as { document?: unknown }).document;
+    try {
+      expect(() => applyThemeFonts({ heading: "'X', serif" })).not.toThrow();
+    } finally {
+      if (hadDocument) {
+        (globalThis as { document?: unknown }).document = original;
+      }
+    }
+  });
 });

--- a/src/hooks/useThemeFonts.ts
+++ b/src/hooks/useThemeFonts.ts
@@ -24,15 +24,17 @@ const FONT_VARS: Record<keyof FontConfig, string> = {
  */
 export function applyThemeFonts(
   font: KBConfig['theme']['font'] | undefined,
-  root: FontStyleTarget = document.documentElement,
+  root?: FontStyleTarget,
 ): void {
+  const target = root ?? (typeof document !== 'undefined' ? document.documentElement : undefined);
+  if (!target) return;
   (Object.keys(FONT_VARS) as (keyof FontConfig)[]).forEach(key => {
     const value = font?.[key];
     const cssVar = FONT_VARS[key];
     if (value) {
-      root.style.setProperty(cssVar, value);
+      target.style.setProperty(cssVar, value);
     } else {
-      root.style.removeProperty(cssVar);
+      target.style.removeProperty(cssVar);
     }
   });
 }

--- a/src/hooks/useThemeFonts.ts
+++ b/src/hooks/useThemeFonts.ts
@@ -1,0 +1,45 @@
+import { useEffect } from 'react';
+import type { KBConfig } from '../types';
+
+/** Minimal target that exposes a CSS-inline-style API (testable without a DOM). */
+export type FontStyleTarget = {
+  style: {
+    setProperty(name: string, value: string): void;
+    removeProperty(name: string): void;
+  };
+};
+
+type FontConfig = NonNullable<KBConfig['theme']['font']>;
+
+const FONT_VARS: Record<keyof FontConfig, string> = {
+  heading: '--kbe-font-heading',
+  body: '--kbe-font-body',
+  mono: '--kbe-font-mono',
+};
+
+/**
+ * Apply `config.theme.font.{heading,body,mono}` to CSS custom properties on the
+ * given root element. When a font is omitted, the corresponding property is
+ * removed so the CSS `var(..., <fallback>)` default takes effect.
+ */
+export function applyThemeFonts(
+  font: KBConfig['theme']['font'] | undefined,
+  root: FontStyleTarget = document.documentElement,
+): void {
+  (Object.keys(FONT_VARS) as (keyof FontConfig)[]).forEach(key => {
+    const value = font?.[key];
+    const cssVar = FONT_VARS[key];
+    if (value) {
+      root.style.setProperty(cssVar, value);
+    } else {
+      root.style.removeProperty(cssVar);
+    }
+  });
+}
+
+/** React hook that applies theme fonts to `document.documentElement` once config is available. */
+export function useThemeFonts(font: KBConfig['theme']['font'] | undefined): void {
+  useEffect(() => {
+    applyThemeFonts(font);
+  }, [font]);
+}

--- a/src/styles/reading.css
+++ b/src/styles/reading.css
@@ -9,7 +9,7 @@
 
 /* Headings — scale proportionally with prose font size */
 .kb-prose h1 {
-  font-family: 'Segoe UI Variable', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  font-family: var(--kbe-font-heading, 'Segoe UI Variable', 'Segoe UI', system-ui, -apple-system, sans-serif);
   font-size: 1.65em;
   font-weight: 600;
   margin: 2.5rem 0 1rem;
@@ -18,7 +18,7 @@
 }
 
 .kb-prose h2 {
-  font-family: 'Segoe UI Variable', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  font-family: var(--kbe-font-heading, 'Segoe UI Variable', 'Segoe UI', system-ui, -apple-system, sans-serif);
   font-size: 1.35em;
   font-weight: 600;
   margin: 2rem 0 0.75rem;
@@ -27,7 +27,7 @@
 }
 
 .kb-prose h3 {
-  font-family: 'Segoe UI Variable', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  font-family: var(--kbe-font-heading, 'Segoe UI Variable', 'Segoe UI', system-ui, -apple-system, sans-serif);
   font-size: 1.12em;
   font-weight: 600;
   margin: 1.5rem 0 0.5rem;
@@ -36,7 +36,7 @@
 }
 
 .kb-prose h4 {
-  font-family: 'Segoe UI Variable', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  font-family: var(--kbe-font-heading, 'Segoe UI Variable', 'Segoe UI', system-ui, -apple-system, sans-serif);
   font-size: 1em;
   font-weight: 600;
   margin: 1.5rem 0 0.5rem;
@@ -80,7 +80,7 @@
 
 /* Code — Fluent neutral background + border radius */
 .kb-prose code {
-  font-family: 'Cascadia Code', 'Cascadia Mono', Consolas, monospace;
+  font-family: var(--kbe-font-mono, 'Cascadia Code', 'Cascadia Mono', Consolas, monospace);
   font-size: 0.88em;
   padding: 0.15em 0.4em;
   background: var(--colorNeutralBackground3);
@@ -166,7 +166,7 @@
 /* ── Display mode styles ─────────────────────────────── */
 
 .kb-code-display {
-  font-family: 'Cascadia Code', 'Cascadia Mono', Consolas, monospace;
+  font-family: var(--kbe-font-mono, 'Cascadia Code', 'Cascadia Mono', Consolas, monospace);
   font-size: var(--prose-font-size, 14px);
   line-height: 1.5;
   padding: 1rem 1.25rem;
@@ -188,7 +188,7 @@
 }
 
 .kb-tree-display {
-  font-family: 'Cascadia Code', 'Cascadia Mono', Consolas, monospace;
+  font-family: var(--kbe-font-mono, 'Cascadia Code', 'Cascadia Mono', Consolas, monospace);
   font-size: var(--prose-font-size, 14px);
   line-height: 1.6;
   padding: 1rem 1.25rem;
@@ -237,7 +237,7 @@
 }
 
 .kb-structured-id {
-  font-family: 'Cascadia Code', 'Cascadia Mono', Consolas, monospace;
+  font-family: var(--kbe-font-mono, 'Cascadia Code', 'Cascadia Mono', Consolas, monospace);
   font-size: 0.82em;
   color: var(--colorNeutralForeground3);
 }
@@ -298,7 +298,7 @@
 }
 
 .kb-structured-code {
-  font-family: 'Cascadia Code', 'Cascadia Mono', Consolas, monospace;
+  font-family: var(--kbe-font-mono, 'Cascadia Code', 'Cascadia Mono', Consolas, monospace);
   font-size: 0.85em;
   padding: 0.1em 0.35em;
   background: var(--colorNeutralBackground3);

--- a/src/styles/visuals.css
+++ b/src/styles/visuals.css
@@ -105,7 +105,7 @@
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-  font-family: 'Segoe UI Variable', 'Segoe UI', system-ui, sans-serif;
+  font-family: var(--kbe-font-body, 'Segoe UI Variable', 'Segoe UI', system-ui, sans-serif);
   font-weight: 600;
   color: var(--colorNeutralForeground2, #d6d6d6);
   background: var(--colorNeutralBackground3, #2e2e2e);


### PR DESCRIPTION
Closes #189

## What
`config.theme.font.{heading,body,mono}` was declared and defaulted but nothing read it. This wires it into CSS custom properties at runtime.

- New `useThemeFonts` hook (`src/hooks/useThemeFonts.ts`) with a pure, testable `applyThemeFonts(font, root?)` helper that sets/removes `--kbe-font-heading`, `--kbe-font-body`, `--kbe-font-mono` on `document.documentElement` (reuses the HUD `setProperty` pattern).
- Hook is invoked in `Explorer` (`src/App.tsx`) once config is available.
- `src/styles/reading.css` (headings → `--kbe-font-heading`, code → `--kbe-font-mono`) and `src/styles/visuals.css` (`.kb-letter` → `--kbe-font-body`) now use `var(--kbe-font-*, <existing stack>)`, preserving the current hardcoded stacks as fallbacks so default behavior is unchanged when config omits fonts.

When config omits a font, the helper removes the var so the CSS fallback applies; a custom `config.theme.font.heading` resolves through `var(--kbe-font-heading, ...)` on all `.kb-prose` headings.

## Out of scope
`CACHE_VERSION` is intentionally **not** bumped (task T1.3). Theme color definitions untouched.

## Validation
- New unit test `src/hooks/__tests__/useThemeFonts.test.ts` (sets the three vars, removes on omit/undefined).
- `npx vitest run`: 308 passed.
- `npm run lint`: 0 errors (only a pre-existing HUD warning).
- `npm run build` (tsc -b + vite): passes.