### PR TITLE
T1.3: bump CACHE_VERSION + cover F1 wiring with tests

### DIFF
--- a/src/api/github.ts
+++ b/src/api/github.ts
@@ -8,7 +8,7 @@ import type { SourceConfig } from '../types';
 
 const CACHE_PREFIX = 'kbe:';
 const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
-const CACHE_VERSION = 16; // bump to invalidate all cached data (16: skill node type — .github/skills/**/SKILL.md → SkillView; 15: F3 structural nodes + node-map JSON-LD merged with content-model spine ingestion; 13: KBNode JSON-LD fields + KBEdge.relation)
+const CACHE_VERSION = 17; // bump to invalidate all cached data (17: F1 config-driven appearance — theme.default initial mode + theme.font.* CSS vars now affect cached render; 16: skill node type — .github/skills/**/SKILL.md → SkillView; 15: F3 structural nodes + node-map JSON-LD merged with content-model spine ingestion; 13: KBNode JSON-LD fields + KBEdge.relation)
 
 // Clear stale cache from older versions
 try {


### PR DESCRIPTION
Closes #190

Final task of Feature F1 (external theme config wiring).

## Changes
- **Bump `CACHE_VERSION` 16 → 17** in `src/api/github.ts` (exactly one increment). F1 introduced config-driven appearance — `config.theme.default` now drives the initial theme mode (T1.1) and `theme.font.*` now sets `--kbe-font-*` CSS vars (T1.2). Per AGENTS.md, any change affecting cached render / `kbe-*` localStorage requires bumping the version so users with stale caches get a clean render. The line keeps an explanatory comment for the new entry.

## F1 test coverage (existing vitest suite)
Confirmed the F1 unit tests are present and green — no new runner/framework added:
- `src/hooks/__tests__/useTheme.test.ts` — default-mode wiring: `resolveInitialMode` (config default applies, stored theme wins, fallback to `dark`, invalid default ignored).
- `src/hooks/__tests__/useThemeFonts.test.ts` — font-var wiring: `applyThemeFonts` sets all three vars, removes omitted/undefined vars (CSS fallback), and the **no-DOM** safe no-op path.

Note: the vitest environment is `node` (no jsdom/testing-library), so the React hook callbacks are validated via their underlying pure functions, which carry the actual wiring logic.

## Validation
- `npm run lint` — 0 errors (1 pre-existing HUD `react-hooks/exhaustive-deps` warning, acceptable)
- `npx vitest run` — 313 passed (29 files)
- `npm run build` — tsc -b + vite succeeded