### PR TITLE
T2.3: seed-color → BrandVariants (16-stop) generator (#192)

### DIFF
--- a/src/theme/__tests__/brandRamp.test.ts
+++ b/src/theme/__tests__/brandRamp.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { generateBrandVariants } from '../brandRamp';
+
+const STOP_KEYS = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160] as const;
+
+function hexLightness(hex: string): number {
+  const value = hex.replace(/^#/, '');
+  const r = parseInt(value.slice(0, 2), 16) / 255;
+  const g = parseInt(value.slice(2, 4), 16) / 255;
+  const b = parseInt(value.slice(4, 6), 16) / 255;
+  return (Math.max(r, g, b) + Math.min(r, g, b)) / 2;
+}
+
+describe('generateBrandVariants', () => {
+  it('returns exactly the 16 stop keys "10".."160"', () => {
+    const ramp = generateBrandVariants('#4A9CC8');
+    expect(Object.keys(ramp).map(Number).sort((a, b) => a - b)).toEqual([...STOP_KEYS]);
+    expect(Object.keys(ramp)).toHaveLength(16);
+  });
+
+  it('produces valid 6-digit hex values for every stop', () => {
+    const ramp = generateBrandVariants('#4A9CC8');
+    for (const key of STOP_KEYS) {
+      expect(ramp[key]).toMatch(/^#[0-9A-F]{6}$/);
+    }
+  });
+
+  it('is monotonically ascending in lightness from "10" to "160"', () => {
+    const ramp = generateBrandVariants('#4A9CC8');
+    const lightnesses = STOP_KEYS.map((key) => hexLightness(ramp[key]));
+    for (let i = 1; i < lightnesses.length; i += 1) {
+      expect(lightnesses[i]).toBeGreaterThan(lightnesses[i - 1]);
+    }
+  });
+
+  it('clamps endpoints toward near-black and near-white', () => {
+    const ramp = generateBrandVariants('#4A9CC8');
+    expect(hexLightness(ramp[10])).toBeLessThan(0.08);
+    expect(hexLightness(ramp[160])).toBeGreaterThan(0.92);
+  });
+
+  it('maps the seed near the middle of the ramp', () => {
+    const seedL = hexLightness('#4A9CC8');
+    const ramp = generateBrandVariants('#4A9CC8');
+    const middleL = hexLightness(ramp[80]);
+    expect(Math.abs(middleL - seedL)).toBeLessThan(0.06);
+  });
+
+  it('is deterministic: same seed → same ramp', () => {
+    expect(generateBrandVariants('#4A9CC8')).toEqual(generateBrandVariants('#4A9CC8'));
+  });
+
+  it('normalizes 3-digit, unprefixed, and mixed-case hex equivalently', () => {
+    const canonical = generateBrandVariants('#4488CC');
+    expect(generateBrandVariants('4488cc')).toEqual(canonical);
+    expect(generateBrandVariants('#48c')).toEqual(canonical);
+    expect(generateBrandVariants('48C')).toEqual(canonical);
+  });
+
+  it('throws on invalid hex input', () => {
+    expect(() => generateBrandVariants('not-a-color')).toThrow();
+    expect(() => generateBrandVariants('#12')).toThrow();
+    expect(() => generateBrandVariants('#12345')).toThrow();
+  });
+
+  it('matches the committed snapshot for seed "#4A9CC8"', () => {
+    expect(generateBrandVariants('#4A9CC8')).toMatchInlineSnapshot(`
+      {
+        "10": "#04090C",
+        "100": "#74B3D5",
+        "110": "#89BFDB",
+        "120": "#9FCAE2",
+        "130": "#B4D6E8",
+        "140": "#C9E1EF",
+        "150": "#DEEDF5",
+        "160": "#F3F9FB",
+        "20": "#0C1E28",
+        "30": "#153444",
+        "40": "#1D4961",
+        "50": "#265F7D",
+        "60": "#2F7499",
+        "70": "#378AB6",
+        "80": "#4A9CC8",
+        "90": "#5FA8CE",
+      }
+    `);
+  });
+});

--- a/src/theme/brandRamp.ts
+++ b/src/theme/brandRamp.ts
@@ -1,0 +1,163 @@
+import type { BrandVariants } from '@fluentui/react-components';
+
+/**
+ * The 16 Fluent brand ramp stop keys, in order ("10" → "160").
+ * Lower stops are darker (near-black); higher stops are lighter (near-white).
+ */
+const STOPS = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160] as const;
+
+// Lightness (in %) for the clamped ramp endpoints.
+const NEAR_BLACK_L = 3;
+const NEAR_WHITE_L = 97;
+
+// The seed's lightness is anchored near the middle of the ramp. Clamping it
+// into this range guarantees both halves of the ramp stay strictly monotonic.
+const ANCHOR_INDEX = 7; // stop "80"
+const ANCHOR_MIN_L = 12;
+const ANCHOR_MAX_L = 88;
+
+interface Rgb {
+  r: number;
+  g: number;
+  b: number;
+}
+
+interface Hsl {
+  h: number;
+  s: number;
+  l: number;
+}
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.min(max, Math.max(min, value));
+
+/**
+ * Normalize a seed hex string into a 6-digit, lowercase, '#'-prefixed value.
+ * Accepts 3- or 6-digit hex with or without a leading '#'. Throws on anything
+ * that is not a valid hex color.
+ */
+function normalizeHex(input: string): string {
+  if (typeof input !== 'string') {
+    throw new TypeError(`Invalid seed color: expected a string, received ${typeof input}`);
+  }
+  const raw = input.trim().replace(/^#/, '').toLowerCase();
+  if (!/^[0-9a-f]+$/.test(raw)) {
+    throw new Error(`Invalid seed color: "${input}" is not a valid hex color`);
+  }
+  if (raw.length === 3) {
+    const [r, g, b] = raw.split('');
+    return `#${r}${r}${g}${g}${b}${b}`;
+  }
+  if (raw.length === 6) {
+    return `#${raw}`;
+  }
+  throw new Error(`Invalid seed color: "${input}" must be a 3- or 6-digit hex color`);
+}
+
+function hexToRgb(hex: string): Rgb {
+  const value = hex.replace(/^#/, '');
+  return {
+    r: parseInt(value.slice(0, 2), 16),
+    g: parseInt(value.slice(2, 4), 16),
+    b: parseInt(value.slice(4, 6), 16),
+  };
+}
+
+function rgbToHex({ r, g, b }: Rgb): string {
+  const toHex = (channel: number): string =>
+    clamp(Math.round(channel), 0, 255).toString(16).padStart(2, '0');
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`.toUpperCase();
+}
+
+function rgbToHsl({ r, g, b }: Rgb): Hsl {
+  const rn = r / 255;
+  const gn = g / 255;
+  const bn = b / 255;
+  const max = Math.max(rn, gn, bn);
+  const min = Math.min(rn, gn, bn);
+  const delta = max - min;
+  const l = (max + min) / 2;
+
+  let h = 0;
+  let s = 0;
+  if (delta !== 0) {
+    s = delta / (1 - Math.abs(2 * l - 1));
+    switch (max) {
+      case rn:
+        h = ((gn - bn) / delta) % 6;
+        break;
+      case gn:
+        h = (bn - rn) / delta + 2;
+        break;
+      default:
+        h = (rn - gn) / delta + 4;
+        break;
+    }
+    h *= 60;
+    if (h < 0) h += 360;
+  }
+
+  return { h, s: s * 100, l: l * 100 };
+}
+
+function hslToRgb({ h, s, l }: Hsl): Rgb {
+  const sn = s / 100;
+  const ln = l / 100;
+  const c = (1 - Math.abs(2 * ln - 1)) * sn;
+  const hp = h / 60;
+  const x = c * (1 - Math.abs((hp % 2) - 1));
+  let r: number;
+  let g: number;
+  let b: number;
+  if (hp >= 0 && hp < 1) {
+    [r, g, b] = [c, x, 0];
+  } else if (hp < 2) {
+    [r, g, b] = [x, c, 0];
+  } else if (hp < 3) {
+    [r, g, b] = [0, c, x];
+  } else if (hp < 4) {
+    [r, g, b] = [0, x, c];
+  } else if (hp < 5) {
+    [r, g, b] = [x, 0, c];
+  } else {
+    [r, g, b] = [c, 0, x];
+  }
+  const m = ln - c / 2;
+  return {
+    r: (r + m) * 255,
+    g: (g + m) * 255,
+    b: (b + m) * 255,
+  };
+}
+
+/**
+ * Convert a single seed hex color into a deterministic 16-stop Fluent
+ * `BrandVariants` ramp (keys "10".."160"), suitable for `createLightTheme` /
+ * `createDarkTheme`.
+ *
+ * The ramp preserves the seed's hue and saturation while varying lightness
+ * monotonically: stop "10" clamps toward near-black and stop "160" toward
+ * near-white, with the seed mapped near the middle (stop "80"). The same seed
+ * always produces the same ramp.
+ */
+export function generateBrandVariants(seedHex: string): BrandVariants {
+  const hex = normalizeHex(seedHex);
+  const { h, s, l } = rgbToHsl(hexToRgb(hex));
+
+  const anchorL = clamp(l, ANCHOR_MIN_L, ANCHOR_MAX_L);
+
+  const ramp = {} as Record<(typeof STOPS)[number], string>;
+  STOPS.forEach((stop, index) => {
+    let lightness: number;
+    if (index <= ANCHOR_INDEX) {
+      const t = index / ANCHOR_INDEX;
+      lightness = NEAR_BLACK_L + (anchorL - NEAR_BLACK_L) * t;
+    } else {
+      const t = (index - ANCHOR_INDEX) / (STOPS.length - 1 - ANCHOR_INDEX);
+      lightness = anchorL + (NEAR_WHITE_L - anchorL) * t;
+    }
+    ramp[stop] = rgbToHex(hslToRgb({ h, s, l: lightness }));
+  });
+
+  return ramp as BrandVariants;
+}

--- a/src/theme/brandRamp.ts
+++ b/src/theme/brandRamp.ts
@@ -1,7 +1,7 @@
 import type { BrandVariants } from '@fluentui/react-components';
 
 /**
- * The 16 Fluent brand ramp stop keys, in order ("10" → "160").
+ * The 16 Fluent brand ramp stop keys, in order (10 → 160).
  * Lower stops are darker (near-black); higher stops are lighter (near-white).
  */
 const STOPS = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160] as const;
@@ -132,12 +132,12 @@ function hslToRgb({ h, s, l }: Hsl): Rgb {
 
 /**
  * Convert a single seed hex color into a deterministic 16-stop Fluent
- * `BrandVariants` ramp (keys "10".."160"), suitable for `createLightTheme` /
- * `createDarkTheme`.
+ * `BrandVariants` ramp (numeric keys 10..160), suitable for `createLightTheme`
+ * / `createDarkTheme`.
  *
  * The ramp preserves the seed's hue and saturation while varying lightness
- * monotonically: stop "10" clamps toward near-black and stop "160" toward
- * near-white, with the seed mapped near the middle (stop "80"). The same seed
+ * monotonically: stop 10 clamps toward near-black and stop 160 toward
+ * near-white, with the seed mapped near the middle (stop 80). The same seed
  * always produces the same ramp.
  */
 export function generateBrandVariants(seedHex: string): BrandVariants {


### PR DESCRIPTION
## Summary

Adds a pure, deterministic helper that converts one seed hex color into a 16-stop Fluent `BrandVariants` ramp (keys `"10"`..`"160"`), suitable for `@fluentui/react-components` `createLightTheme` / `createDarkTheme`.

- New file `src/theme/brandRamp.ts` exporting `generateBrandVariants(seedHex: string): BrandVariants`.
- Type-only import of `BrandVariants` from `@fluentui/react-components`; no new runtime deps, no new npm packages.
- Self-contained hex→RGB→HSL→hex conversion.
- Deterministic: same seed → same ramp. Lightness is strictly monotonic ascending across the 16 stops; stop `"10"` clamps toward near-black and `"160"` toward near-white; the seed maps near the middle (stop `"80"`).
- Normalizes 3- and 6-digit hex, with or without leading `#`, mixed case; throws on invalid input.
- Does **not** touch `useTheme` or `src/types/index.ts`.

## Tests

New `src/theme/__tests__/brandRamp.test.ts` (vitest, `node` env — no new frameworks):
- Returns exactly the 16 keys `"10"`..`"160"`.
- Lightness is monotonically ascending (ordering asserted).
- Endpoints clamp to near-black / near-white.
- Seed maps near the middle of the ramp.
- Determinism + hex normalization equivalence + invalid-input throws.
- Committed inline snapshot for seed `#4A9CC8` (stop `"80"` == `#4A9CC8`).

## Validation

- `npm run lint` → 0 errors (pre-existing HUD `useCallback` warning only)
- `npx vitest run` → 322 passed (30 files)
- `npm run build` → tsc -b + vite build succeed

Closes #192