### PR TITLE
T2.1: extend KBConfig.theme schema (brand, tokens, themes)

### DIFF
--- a/src/types/__tests__/theme-config-schema.test.ts
+++ b/src/types/__tests__/theme-config-schema.test.ts
@@ -4,13 +4,15 @@ import { DEFAULT_CONFIG } from '../index';
 import type { KBConfig } from '../index';
 
 // Mirrors the parse + shallow-merge that loadConfig() performs in
-// src/engine/parser.ts, without the network fetch. Validates that the
-// additive theme.brand / theme.tokens / theme.themes fields round-trip
-// from config.yaml into a typed KBConfig with the expected shapes.
+// src/engine/parser.ts (including the final `source` injection), without the
+// network fetch. Validates that the additive theme.brand / theme.tokens /
+// theme.themes fields round-trip from config.yaml into a typed KBConfig with
+// the expected shapes.
 
 function parseConfigYaml(raw: string): KBConfig {
+  const source = DEFAULT_CONFIG.source;
   const parsed = yaml.parse(raw) as Partial<KBConfig>;
-  return { ...DEFAULT_CONFIG, ...parsed };
+  return { ...DEFAULT_CONFIG, ...parsed, source };
 }
 
 describe('KBConfig.theme schema (brand, tokens, themes)', () => {
@@ -90,7 +92,9 @@ theme:
         "160": "#FBF3E2"
 `);
     const themes = config.theme.themes!;
-    expect(Object.keys(themes)).toEqual(['ocean', 'parchment']);
+    expect(Object.keys(themes)).toHaveLength(2);
+    expect(themes).toHaveProperty('ocean');
+    expect(themes).toHaveProperty('parchment');
 
     expect(themes.ocean.base).toBe('dark');
     expect(themes.ocean.brand).toBe('#1B6CA8');

--- a/src/types/__tests__/theme-config-schema.test.ts
+++ b/src/types/__tests__/theme-config-schema.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import yaml from 'yaml';
+import { DEFAULT_CONFIG } from '../index';
+import type { KBConfig } from '../index';
+
+// Mirrors the parse + shallow-merge that loadConfig() performs in
+// src/engine/parser.ts, without the network fetch. Validates that the
+// additive theme.brand / theme.tokens / theme.themes fields round-trip
+// from config.yaml into a typed KBConfig with the expected shapes.
+
+function parseConfigYaml(raw: string): KBConfig {
+  const parsed = yaml.parse(raw) as Partial<KBConfig>;
+  return { ...DEFAULT_CONFIG, ...parsed };
+}
+
+describe('KBConfig.theme schema (brand, tokens, themes)', () => {
+  it('round-trips theme.brand as a single seed hex string', () => {
+    const config = parseConfigYaml(`
+title: Test KB
+theme:
+  default: dark
+  brand: "#4A9CC8"
+`);
+    expect(typeof config.theme.brand).toBe('string');
+    expect(config.theme.brand).toBe('#4A9CC8');
+  });
+
+  it('round-trips theme.brand as a 16-key Fluent ramp object', () => {
+    const config = parseConfigYaml(`
+title: Test KB
+theme:
+  default: dark
+  brand:
+    "10": "#020305"
+    "20": "#111A1F"
+    "30": "#16242C"
+    "40": "#1B2F39"
+    "50": "#1F3B47"
+    "60": "#244655"
+    "70": "#295264"
+    "80": "#2E5E73"
+    "90": "#336A82"
+    "100": "#387691"
+    "110": "#4A9CC8"
+    "120": "#5BA8D0"
+    "130": "#6CB4D8"
+    "140": "#90C8E2"
+    "150": "#B5DCEC"
+    "160": "#EAF3F8"
+`);
+    const brand = config.theme.brand as Record<string, string>;
+    expect(typeof brand).toBe('object');
+    expect(Object.keys(brand)).toHaveLength(16);
+    expect(brand['10']).toBe('#020305');
+    expect(brand['110']).toBe('#4A9CC8');
+    expect(brand['160']).toBe('#EAF3F8');
+  });
+
+  it('round-trips theme.tokens as arbitrary token overrides', () => {
+    const config = parseConfigYaml(`
+title: Test KB
+theme:
+  default: light
+  tokens:
+    colorNeutralBackground1: "#101418"
+    borderRadiusMedium: "8px"
+`);
+    expect(config.theme.tokens).toEqual({
+      colorNeutralBackground1: '#101418',
+      borderRadiusMedium: '8px',
+    });
+  });
+
+  it('round-trips theme.themes named variants with brand/tokens/base', () => {
+    const config = parseConfigYaml(`
+title: Test KB
+theme:
+  default: dark
+  themes:
+    ocean:
+      base: dark
+      brand: "#1B6CA8"
+      tokens:
+        colorNeutralBackground1: "#0A1A24"
+    parchment:
+      base: light
+      brand:
+        "10": "#1A1206"
+        "110": "#B5832E"
+        "160": "#FBF3E2"
+`);
+    const themes = config.theme.themes!;
+    expect(Object.keys(themes)).toEqual(['ocean', 'parchment']);
+
+    expect(themes.ocean.base).toBe('dark');
+    expect(themes.ocean.brand).toBe('#1B6CA8');
+    expect(themes.ocean.tokens).toEqual({ colorNeutralBackground1: '#0A1A24' });
+
+    expect(themes.parchment.base).toBe('light');
+    const parchmentBrand = themes.parchment.brand as Record<string, string>;
+    expect(parchmentBrand['110']).toBe('#B5832E');
+  });
+
+  it('keeps the new fields optional — a minimal theme still type-checks', () => {
+    const config = parseConfigYaml(`
+title: Test KB
+theme:
+  default: sepia
+`);
+    expect(config.theme.default).toBe('sepia');
+    expect(config.theme.brand).toBeUndefined();
+    expect(config.theme.tokens).toBeUndefined();
+    expect(config.theme.themes).toBeUndefined();
+  });
+
+  it('DEFAULT_CONFIG leaves brand/tokens/themes unset (no behavior change)', () => {
+    expect(DEFAULT_CONFIG.theme.brand).toBeUndefined();
+    expect(DEFAULT_CONFIG.theme.tokens).toBeUndefined();
+    expect(DEFAULT_CONFIG.theme.themes).toBeUndefined();
+  });
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -725,6 +725,18 @@ export type VisualMode = 'sprites' | 'heroes' | 'emoji' | 'none';
 /** Theme preference. */
 export type Theme = 'dark' | 'light' | 'sepia';
 
+/** The 16 stop keys of a Fluent brand color ramp ("10".."160"). */
+export type FluentBrandRampKey =
+  | '10' | '20' | '30' | '40' | '50' | '60' | '70' | '80'
+  | '90' | '100' | '110' | '120' | '130' | '140' | '150' | '160';
+
+/**
+ * A Fluent brand color ramp keyed by stop ("10".."160"). Typed as `Partial`
+ * so configs may omit stops, but keys are constrained to the 16 valid slots
+ * (arbitrary keys won't type-check). A complete ramp supplies all 16.
+ */
+export type FluentBrandRamp = Partial<Record<FluentBrandRampKey, string>>;
+
 /** Content source configuration. */
 export interface SourceConfig {
   owner: string;
@@ -804,11 +816,12 @@ export interface KBConfig {
      * Global brand color override. Two accepted forms:
      *   1. A single seed hex string (e.g. "#4A9CC8") — used to generate a full
      *      Fluent brand ramp via `createDarkTheme`/`createLightTheme`.
-     *   2. A full 16-key Fluent ramp object with keys "10".."160"
-     *      (e.g. { "10": "#020305", ..., "160": "#EAF3F8" }), used verbatim.
+     *   2. A Fluent ramp object keyed by stop ("10".."160"); a complete ramp
+     *      supplies all 16 stops (e.g. { "10": "#020305", ..., "160": "#EAF3F8" })
+     *      and is used verbatim.
      * Schema only for now; wiring happens in T2.2.
      */
-    brand?: string | Partial<Record<string, string>>;
+    brand?: string | FluentBrandRamp;
     /**
      * Arbitrary Fluent design-token overrides (token name → CSS value),
      * applied on top of the active base theme. Example:
@@ -824,7 +837,7 @@ export interface KBConfig {
     themes?: Record<
       string,
       {
-        brand?: string | Partial<Record<string, string>>;
+        brand?: string | FluentBrandRamp;
         tokens?: Partial<Record<string, string>>;
         base?: 'dark' | 'light';
       }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -800,6 +800,35 @@ export interface KBConfig {
       body?: string;
       mono?: string;
     };
+    /**
+     * Global brand color override. Two accepted forms:
+     *   1. A single seed hex string (e.g. "#4A9CC8") — used to generate a full
+     *      Fluent brand ramp via `createDarkTheme`/`createLightTheme`.
+     *   2. A full 16-key Fluent ramp object with keys "10".."160"
+     *      (e.g. { "10": "#020305", ..., "160": "#EAF3F8" }), used verbatim.
+     * Schema only for now; wiring happens in T2.2.
+     */
+    brand?: string | Partial<Record<string, string>>;
+    /**
+     * Arbitrary Fluent design-token overrides (token name → CSS value),
+     * applied on top of the active base theme. Example:
+     *   { colorNeutralBackground1: "#101418", borderRadiusMedium: "8px" }
+     * Schema only for now; wiring happens in T2.2.
+     */
+    tokens?: Partial<Record<string, string>>;
+    /**
+     * Named custom theme variants. Each variant may specify its own brand
+     * (seed hex or ramp), token overrides, and the base theme it derives from
+     * ('dark' or 'light'). Schema only for now; wiring happens in T2.2.
+     */
+    themes?: Record<
+      string,
+      {
+        brand?: string | Partial<Record<string, string>>;
+        tokens?: Partial<Record<string, string>>;
+        base?: 'dark' | 'light';
+      }
+    >;
   };
   graph: {
     physics: boolean;
@@ -862,6 +891,9 @@ export const DEFAULT_CONFIG: KBConfig = {
       body: "'Segoe UI Variable', 'Segoe UI', system-ui, sans-serif",
       mono: "'Cascadia Code', 'Cascadia Mono', Consolas, monospace",
     },
+    // brand / tokens / themes are optional, additive overrides (see KBConfig.theme).
+    // Left unset by default so the built-in dark/light/sepia themes are unchanged.
+    // Wiring into useTheme/THEME_MAP happens in T2.2.
   },
   graph: {
     physics: true,


### PR DESCRIPTION
## Summary

First task of Feature F2 (config-driven global brand + token overrides). **Schema only — no behavior change.**

Extends the `theme` section of the `KBConfig` interface in `src/types/index.ts` with three new optional, additive fields:

- **`brand?: string | Partial<Record<string, string>>`** — either a single seed hex (e.g. `"#4A9CC8"`) or a full 16-key Fluent ramp object (keys `"10".."160"`).
- **`tokens?: Partial<Record<string, string>>`** — arbitrary Fluent design-token overrides (token name → CSS value), applied on top of the active base theme.
- **`themes?: Record<string, { brand?; tokens?; base?: 'dark' | 'light' }>`** — named custom theme variants.

`DEFAULT_CONFIG` gains explanatory comments only; runtime defaults are unchanged (`brand`/`tokens`/`themes` left unset). These are **not** wired into `useTheme`/`THEME_MAP` yet — that's T2.2.

All fields are optional and additive, so existing configs still type-check.

## Tests

Adds `src/types/__tests__/theme-config-schema.test.ts` mirroring `loadConfig`'s parse + shallow-merge (via `yaml.parse` + `DEFAULT_CONFIG`), asserting that a sample `config.yaml` with `theme.brand` (both hex-string and ramp-object forms), `theme.tokens`, and `theme.themes` round-trips into the expected shapes. Uses the existing vitest setup (node env); no new test deps.

## Validation

- `npm run lint` → 0 errors (only the pre-existing HUD exhaustive-deps warning)
- `npx vitest run` → 319 passed
- `npm run build` → tsc -b + vite succeed

Closes #191

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>