### PR TITLE
T3.1: add branding.logo and render on HomePage + HUD (#195)

### DIFF
--- a/src/api/github.ts
+++ b/src/api/github.ts
@@ -8,7 +8,7 @@ import type { SourceConfig } from '../types';
 
 const CACHE_PREFIX = 'kbe:';
 const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
-const CACHE_VERSION = 17; // bump to invalidate all cached data (17: F1 config-driven appearance — theme.default initial mode + theme.font.* CSS vars now affect cached render; 16: skill node type — .github/skills/**/SKILL.md → SkillView; 15: F3 structural nodes + node-map JSON-LD merged with content-model spine ingestion; 13: KBNode JSON-LD fields + KBEdge.relation)
+const CACHE_VERSION = 18; // bump to invalidate all cached data (18: F3 branding.logo config field renders on HomePage hero + HUD header — affects cached render; 17: F1 config-driven appearance — theme.default initial mode + theme.font.* CSS vars now affect cached render; 16: skill node type — .github/skills/**/SKILL.md → SkillView; 15: F3 structural nodes + node-map JSON-LD merged with content-model spine ingestion; 13: KBNode JSON-LD fields + KBEdge.relation)
 
 // Clear stale cache from older versions
 try {

--- a/src/components/HUD.tsx
+++ b/src/components/HUD.tsx
@@ -949,16 +949,14 @@ export function HUD({ graph, config, currentNodeId, theme, onThemeChange, onColl
               <>
                 <div className={styles.currentNode} style={{ justifyContent: 'center' }}>
                   {brandLogoUrl && (
-                    <img className={styles.brandLogo} src={brandLogoUrl} alt={config.title} />
+                    <img className={styles.brandLogo} src={brandLogoUrl} alt="" />
                   )}
                   {currentNode?.emoji && isFluentIconName(currentNode.emoji) ? (
                     (() => { const Icon = FLUENT_ICONS[currentNode.emoji]; return <Icon style={{ fontSize: 20 }} />; })()
                   ) : (
                     <span style={{ fontSize: tokens.fontSizeBase500 }}>{currentNode?.emoji ?? ''}</span>
                   )}
-                  {!(brandLogoUrl && !currentNode) && (
-                    <Body1Strong className={styles.currentTitle}>{nodeTitle}</Body1Strong>
-                  )}
+                  <Body1Strong className={styles.currentTitle}>{nodeTitle}</Body1Strong>
                 </div>
                 <div style={{ marginLeft: 'auto', display: 'flex', gap: 4 }}>
                   {themeButtons}

--- a/src/components/HUD.tsx
+++ b/src/components/HUD.tsx
@@ -32,6 +32,7 @@ import type { KBGraph, KBConfig, KBNode, Theme } from '../types';
 import { getEdgeStyle, getEdgeLegendKey, BUILT_IN_VIEWS, filterGraphToView, collapseGraphClusters, trimGraphToLimits } from '../types';
 import type { TrimResult } from '../types';
 import { NodeVisual, FLUENT_ICONS, isFluentIconName } from './NodeVisual';
+import { resolveImageUrl } from '../api';
 import { createGraphNetwork, computeGraphPositions } from '../engine/createGraphNetwork';
 import { ICON_NODE_SHAPE } from '../engine/nodeRenderer';
 
@@ -138,6 +139,13 @@ const useStyles= makeStyles({
     whiteSpace: 'nowrap',
     overflow: 'hidden',
     textOverflow: 'ellipsis',
+  },
+  brandLogo: {
+    display: 'block',
+    width: 'auto',
+    maxHeight: tokens.lineHeightHero700,
+    maxWidth: '40vw',
+    objectFit: 'contain',
   },
   placeholder: {
     color: tokens.colorNeutralForeground3,
@@ -767,6 +775,9 @@ export function HUD({ graph, config, currentNodeId, theme, onThemeChange, onColl
   );
 
   const nodeTitle = currentNode?.title ?? config.title;
+  const brandLogoUrl = config.branding?.logo
+    ? resolveImageUrl(config.source, config.branding.logo)
+    : null;
 
   return (
     <>
@@ -937,12 +948,17 @@ export function HUD({ graph, config, currentNodeId, theme, onThemeChange, onColl
             {!isVertical && (
               <>
                 <div className={styles.currentNode} style={{ justifyContent: 'center' }}>
+                  {brandLogoUrl && (
+                    <img className={styles.brandLogo} src={brandLogoUrl} alt={config.title} />
+                  )}
                   {currentNode?.emoji && isFluentIconName(currentNode.emoji) ? (
                     (() => { const Icon = FLUENT_ICONS[currentNode.emoji]; return <Icon style={{ fontSize: 20 }} />; })()
                   ) : (
                     <span style={{ fontSize: tokens.fontSizeBase500 }}>{currentNode?.emoji ?? ''}</span>
                   )}
-                  <Body1Strong className={styles.currentTitle}>{nodeTitle}</Body1Strong>
+                  {!(brandLogoUrl && !currentNode) && (
+                    <Body1Strong className={styles.currentTitle}>{nodeTitle}</Body1Strong>
+                  )}
                 </div>
                 <div style={{ marginLeft: 'auto', display: 'flex', gap: 4 }}>
                   {themeButtons}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -756,6 +756,12 @@ export type NodeSource =
    */
   | { type: 'structured'; entityType: string; ref?: string };
 
+/** Optional site branding assets (logo, etc.). All fields optional/additive. */
+export interface BrandingConfig {
+  /** Repo-relative path to a logo image, resolved via resolveImageUrl(). */
+  logo?: string;
+}
+
 /** Configuration for an external provider plugin */
 export interface ExternalProviderConfig {
   /** Provider type identifier */
@@ -812,6 +818,7 @@ export interface KBConfig {
     keyboardNav: boolean;
     sparkAnimation: boolean;
   };
+  branding?: BrandingConfig;
   providers?: ExternalProviderConfig[];
   bluf?: {
     audio?: string;
@@ -874,4 +881,7 @@ export const DEFAULT_CONFIG: KBConfig = {
     keyboardNav: true,
     sparkAnimation: false,
   },
+  // branding omitted by default — host repos may set branding.logo (a repo-relative
+  // image path) to render a logo on the HomePage hero and HUD header. Text title is
+  // used as the graceful fallback when no logo is configured.
 };

--- a/src/views/HomePage.tsx
+++ b/src/views/HomePage.tsx
@@ -28,6 +28,7 @@ import {
 } from '@fluentui/react-icons'
 import type { KBGraph, KBConfig, KBNode } from '../types'
 import { NodeVisual } from '../components/NodeVisual'
+import { resolveImageUrl } from '../api'
 import { createGraphNetwork } from '../engine/createGraphNetwork'
 
 const useStyles = makeStyles({
@@ -70,6 +71,14 @@ const useStyles = makeStyles({
     lineHeight: 1.1,
     marginBottom: '0.75rem',
     marginTop: 0,
+  },
+  heroLogo: {
+    display: 'block',
+    maxWidth: '100%',
+    height: 'auto',
+    maxHeight: 'clamp(3rem, 10vh, 7rem)',
+    margin: '0 auto 0.75rem',
+    objectFit: 'contain',
   },
   heroSub: {
     fontSize: 'clamp(0.9rem, 1.5vw, 1.1rem)',
@@ -382,7 +391,15 @@ export function HomePage({ graph, config }: HomePageProps) {
         <div className={styles.heroGlow} style={{ background: '#E8A838', bottom: '-20%', right: '-10%' }} />
         <div ref={heroCanvasRef} className={styles.heroCanvas} />
         <div className={styles.heroContent}>
-          <h1 className={styles.heroTitle}>{config.title}</h1>
+          {config.branding?.logo ? (
+            <img
+              className={styles.heroLogo}
+              src={resolveImageUrl(config.source, config.branding.logo)}
+              alt={config.title}
+            />
+          ) : (
+            <h1 className={styles.heroTitle}>{config.title}</h1>
+          )}
           <p className={styles.heroSub}>
             {config.subtitle ?? 'Turn any repository into a navigable knowledge constellation — explore code, issues, docs, and external references as an interconnected graph.'}
           </p>


### PR DESCRIPTION
## Summary

Adds an optional, additive `branding` config block and renders a configured logo on the HomePage hero and the HUD header. Part of Feature F3 (site branding assets).

Closes #195

## Changes

- **`src/types/index.ts`** — New `BrandingConfig` interface (`{ logo?: string }`) and a new top-level optional `branding?: BrandingConfig` field on `KBConfig`. `DEFAULT_CONFIG` omits it with an explanatory comment. The `theme` section was left untouched (concurrent session owns it).
- **`src/views/HomePage.tsx`** — When `config.branding.logo` is set, the hero renders the logo (resolved via `resolveImageUrl(config.source, …)`) in place of the text title; otherwise the existing `<h1>{config.title}</h1>` is unchanged.
- **`src/components/HUD.tsx`** — The collapsed HUD header renders the logo as a persistent brand mark alongside the node title (resolved via the same helper); falls back to text-only behavior when no logo is configured.
- **`src/api/github.ts`** — Bumped `CACHE_VERSION` 17 → 18 (per AGENTS.md) since `branding.logo` affects cached render.

## Sizing

No fixed-px layout values introduced. Logo height is constrained via `clamp(3rem, 10vh, 7rem)` (hero) and the `lineHeightHero700` Fluent token (HUD), with viewport/`%` max-widths.

## Validation

- `npm run lint` — 0 errors (1 pre-existing HUD `react-hooks/exhaustive-deps` warning).
- `npx vitest run` — 313/313 passing.
- `npm run build` — `tsc -b && vite build` succeeds.
- Playwright (dev server, local mode, logo configured): logo renders in the HomePage hero (`naturalWidth` 240, visible) and the collapsed HUD header alongside the node title. With no logo configured, the hero shows the text title and zero logo `<img>` elements — fallback unchanged.