### PR TITLE
T3.2: dynamic favicon swap from branding.favicon (#196)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { FluentProvider } from '@fluentui/react-components';
 import { useKnowledgeBase } from './hooks/useKnowledgeBase';
 import { useTheme } from './hooks/useTheme';
 import { useThemeFonts } from './hooks/useThemeFonts';
+import { useFavicon } from './hooks/useFavicon';
 import { useKeyboardNav } from './hooks/useKeyboardNav';
 import { HUD } from './components/HUD';
 import type { DockPosition } from './components/HUD';
@@ -50,6 +51,8 @@ function Explorer({ themeMode, setThemeMode, applyConfigDefault }: { themeMode: 
   );
 
   useThemeFonts(state.status === 'ready' ? state.config.theme.font : undefined);
+
+  useFavicon(state.status === 'ready' ? state.config : undefined);
 
   if (state.status === 'loading') return <LoadingScreen />;
   if (state.status === 'error') return <ErrorScreen message={state.error} />;

--- a/src/api/github.ts
+++ b/src/api/github.ts
@@ -8,7 +8,7 @@ import type { SourceConfig } from '../types';
 
 const CACHE_PREFIX = 'kbe:';
 const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
-const CACHE_VERSION = 18; // bump to invalidate all cached data (18: F3 branding.logo config field renders on HomePage hero + HUD header — affects cached render; 17: F1 config-driven appearance — theme.default initial mode + theme.font.* CSS vars now affect cached render; 16: skill node type — .github/skills/**/SKILL.md → SkillView; 15: F3 structural nodes + node-map JSON-LD merged with content-model spine ingestion; 13: KBNode JSON-LD fields + KBEdge.relation)
+const CACHE_VERSION = 19; // bump to invalidate all cached data (19: F3 branding.favicon config field swaps document <link rel=icon> at runtime — affects cached render; 18: F3 branding.logo config field renders on HomePage hero + HUD header — affects cached render; 17: F1 config-driven appearance — theme.default initial mode + theme.font.* CSS vars now affect cached render; 16: skill node type — .github/skills/**/SKILL.md → SkillView; 15: F3 structural nodes + node-map JSON-LD merged with content-model spine ingestion; 13: KBNode JSON-LD fields + KBEdge.relation)
 
 // Clear stale cache from older versions
 try {

--- a/src/hooks/__tests__/useFavicon.test.ts
+++ b/src/hooks/__tests__/useFavicon.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { applyFavicon, type FaviconDocTarget, type IconLinkTarget } from '../useFavicon';
+
+function makeDoc(existing = false) {
+  const attrs = new Map<string, string>();
+  const link: IconLinkTarget = {
+    setAttribute: (name, value) => { attrs.set(name, value); },
+  };
+  if (existing) attrs.set('rel', 'icon');
+  const appended: IconLinkTarget[] = [];
+  let created = 0;
+  const doc: FaviconDocTarget = {
+    querySelector: (selector) =>
+      existing && selector === 'link[rel="icon"]' ? link : null,
+    createElement: () => { created += 1; return link; },
+    head: { appendChild: (el) => { appended.push(el); } },
+  };
+  return { doc, attrs, appended, getCreated: () => created };
+}
+
+describe('applyFavicon', () => {
+  it('sets href on an existing <link rel="icon">', () => {
+    const { doc, attrs, appended } = makeDoc(true);
+
+    applyFavicon('https://example.com/icon.png', doc);
+
+    expect(attrs.get('href')).toBe('https://example.com/icon.png');
+    expect(appended.length).toBe(0);
+  });
+
+  it('creates and appends a <link rel="icon"> when none exists', () => {
+    const { doc, attrs, appended, getCreated } = makeDoc(false);
+
+    applyFavicon('https://example.com/icon.png', doc);
+
+    expect(getCreated()).toBe(1);
+    expect(appended.length).toBe(1);
+    expect(attrs.get('rel')).toBe('icon');
+    expect(attrs.get('href')).toBe('https://example.com/icon.png');
+  });
+
+  it('is a no-op when href is empty/null so the default favicon is untouched', () => {
+    const { doc, attrs, appended } = makeDoc(true);
+
+    applyFavicon(null, doc);
+    applyFavicon('', doc);
+    applyFavicon(undefined, doc);
+
+    expect(attrs.has('href')).toBe(false);
+    expect(appended.length).toBe(0);
+  });
+
+  it('is a safe no-op without a DOM (no doc and no document)', () => {
+    const hadDocument = 'document' in globalThis;
+    const original = (globalThis as { document?: unknown }).document;
+    delete (globalThis as { document?: unknown }).document;
+    try {
+      expect(() => applyFavicon('https://example.com/icon.png')).not.toThrow();
+    } finally {
+      if (hadDocument) {
+        (globalThis as { document?: unknown }).document = original;
+      }
+    }
+  });
+});

--- a/src/hooks/useFavicon.ts
+++ b/src/hooks/useFavicon.ts
@@ -1,0 +1,49 @@
+import { useEffect } from 'react';
+import type { KBConfig } from '../types';
+import { resolveImageUrl } from '../api';
+
+/** Minimal element target that exposes the attribute API we need (testable without a DOM). */
+export type IconLinkTarget = {
+  setAttribute(name: string, value: string): void;
+};
+
+/** Minimal document target so this is testable without jsdom. */
+export type FaviconDocTarget = {
+  querySelector(selector: string): IconLinkTarget | null;
+  createElement(tag: string): IconLinkTarget;
+  head: { appendChild(el: IconLinkTarget): void };
+};
+
+/**
+ * Swap the document's `<link rel="icon">` href to the resolved favicon URL.
+ *
+ * When `href` is null/empty the function is a no-op so the static default in
+ * index.html (`/favicon.svg`) is left untouched. When the link element is
+ * missing it is created and appended to <head>.
+ */
+export function applyFavicon(href: string | null | undefined, doc?: FaviconDocTarget): void {
+  if (!href) return;
+  const target = doc ?? (typeof document !== 'undefined' ? (document as unknown as FaviconDocTarget) : undefined);
+  if (!target) return;
+
+  let link = target.querySelector('link[rel="icon"]');
+  if (!link) {
+    link = target.createElement('link');
+    link.setAttribute('rel', 'icon');
+    target.head.appendChild(link);
+  }
+  link.setAttribute('href', href);
+}
+
+/**
+ * React hook that swaps the document favicon from `config.branding.favicon`
+ * (resolved via resolveImageUrl, same host-repo asset path the logo uses) once
+ * config is available. Unset favicon leaves the default /favicon.svg in place.
+ */
+export function useFavicon(config: KBConfig | undefined): void {
+  const favicon = config?.branding?.favicon;
+  const href = favicon && config ? resolveImageUrl(config.source, favicon) : null;
+  useEffect(() => {
+    applyFavicon(href);
+  }, [href]);
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -756,10 +756,16 @@ export type NodeSource =
    */
   | { type: 'structured'; entityType: string; ref?: string };
 
-/** Optional site branding assets (logo, etc.). All fields optional/additive. */
+/** Optional site branding assets (logo, favicon, etc.). All fields optional/additive. */
 export interface BrandingConfig {
   /** Repo-relative path to a logo image, resolved via resolveImageUrl(). */
   logo?: string;
+  /**
+   * Repo-relative path to a favicon image, resolved via resolveImageUrl() and
+   * swapped into the document's <link rel="icon"> at runtime. When unset, the
+   * static /favicon.svg from index.html is left untouched.
+   */
+  favicon?: string;
 }
 
 /** Configuration for an external provider plugin */
@@ -882,6 +888,8 @@ export const DEFAULT_CONFIG: KBConfig = {
     sparkAnimation: false,
   },
   // branding omitted by default — host repos may set branding.logo (a repo-relative
-  // image path) to render a logo on the HomePage hero and HUD header. Text title is
-  // used as the graceful fallback when no logo is configured.
+  // image path) to render a logo on the HomePage hero and HUD header, and
+  // branding.favicon (a repo-relative image path) to swap the document favicon at
+  // runtime. Text title and the static /favicon.svg are used as graceful fallbacks
+  // when no logo / favicon is configured.
 };


### PR DESCRIPTION
## Summary

Implements Task T3.2 (Feature F3, site branding assets): the document favicon is now swapped at runtime from the optional `branding.favicon` config field, mirroring how T3.1 wired `branding.logo` into the HomePage hero and HUD.

Closes #196

## Changes

- **`src/types/index.ts`** — extended the existing `BrandingConfig` block with an optional `favicon?: string` (now `{ logo?, favicon? }`). Additive/optional; updated the `DEFAULT_CONFIG` comment.
- **`src/hooks/useFavicon.ts`** (new) — `applyFavicon(href, doc?)` sets the `<link rel="icon">` href (creating + appending the element if missing) and is a no-op when the resolved href is empty so the static `/favicon.svg` is left untouched. `useFavicon(config)` resolves the path via the existing `resolveImageUrl(config.source, …)` helper (same host-repo asset path the logo uses) and applies it in an effect once config is ready.
- **`src/App.tsx`** — calls `useFavicon` in `Explorer` once config resolves, alongside the existing `useThemeFonts` effect.
- **`src/api/github.ts`** — bumped `CACHE_VERSION` 18 → 19 (per AGENTS.md, a config field affecting cached render).
- **Tests** — added `src/hooks/__tests__/useFavicon.test.ts` (4 cases: existing link, missing link creation, no-op on empty, no-DOM safety).

## Validation

- `npm run lint` — 0 errors (pre-existing HUD exhaustive-deps warning only)
- `npx vitest run` — 326 passed (incl. 4 new)
- `npm run build` — tsc -b + vite build clean
- Real-flow readback (Playwright, local mode):
  - With `branding.favicon` set → `document.querySelector('link[rel=icon]').href` = resolved `…/screenshots/11-pr-node.png`, no console errors
  - With it unset → href stays the default `/favicon.svg`, no console errors

Note: the per-node favicon override was skipped as a low-risk decision per the task's optional note.