### PR TITLE
T2.2: build THEME_MAP dynamically from config brand/tokens/themes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,15 +27,15 @@ function useCurrentNodeId(): string | null {
   return match ? decodeURIComponent(match[1]) : null;
 }
 
-function Explorer({ themeMode, setThemeMode, applyConfigDefault }: { themeMode: import('./hooks/useTheme').ThemeMode; setThemeMode: (t: import('./hooks/useTheme').ThemeMode) => void; applyConfigDefault: (configDefault?: import('./types').Theme) => void }) {
+function Explorer({ themeMode, setThemeMode, applyConfig }: { themeMode: import('./hooks/useTheme').ThemeMode; setThemeMode: (t: import('./hooks/useTheme').ThemeMode) => void; applyConfig: (theme?: import('./types').KBConfig['theme']) => void }) {
   const state = useKnowledgeBase();
   const currentNodeId = useCurrentNodeId();
 
   useEffect(() => {
     if (state.status === 'ready') {
-      applyConfigDefault(state.config.theme.default);
+      applyConfig(state.config.theme);
     }
-  }, [state, applyConfigDefault]);
+  }, [state, applyConfig]);
 
   const [hudCollapsed, setHudCollapsed] = useState(() => {
     try { return localStorage.getItem('kbe-hud-collapsed') === 'true'; } catch { return false; }
@@ -88,12 +88,12 @@ function Explorer({ themeMode, setThemeMode, applyConfigDefault }: { themeMode: 
 }
 
 function App() {
-  const [themeMode, fluentTheme, setThemeMode, applyConfigDefault] = useTheme();
+  const [themeMode, fluentTheme, setThemeMode, applyConfig] = useTheme();
 
   return (
     <FluentProvider theme={fluentTheme} style={{ minHeight: '100vh' }}>
       <HashRouter>
-        <Explorer themeMode={themeMode} setThemeMode={setThemeMode} applyConfigDefault={applyConfigDefault} />
+        <Explorer themeMode={themeMode} setThemeMode={setThemeMode} applyConfig={applyConfig} />
       </HashRouter>
     </FluentProvider>
   );

--- a/src/hooks/__tests__/useTheme.test.ts
+++ b/src/hooks/__tests__/useTheme.test.ts
@@ -85,4 +85,24 @@ describe('buildThemeMap', () => {
     // Sepia is the curated reading theme with its warm paper background.
     expect(map.sepia.colorNeutralBackground1).toBe('#F5ECD7');
   });
+
+  it('ignores an invalid brand seed instead of crashing', () => {
+    const map = buildThemeMap({ default: 'dark', brand: 'not-a-color' });
+    expect(map.dark).toBe(webDarkTheme);
+    expect(map.light).toBe(webLightTheme);
+  });
+
+  it('ignores an empty brand ramp object', () => {
+    const map = buildThemeMap({ default: 'dark', brand: {} });
+    expect(map.dark).toBe(webDarkTheme);
+  });
+
+  it('does not let a custom theme overwrite a reserved built-in key', () => {
+    const map = buildThemeMap({
+      default: 'dark',
+      themes: { dark: { brand: '#FF0000' } },
+    });
+    // The reserved 'dark' built-in is preserved, not replaced by the config theme.
+    expect(map.dark).toBe(webDarkTheme);
+  });
 });

--- a/src/hooks/__tests__/useTheme.test.ts
+++ b/src/hooks/__tests__/useTheme.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { resolveInitialMode, readStoredRaw } from '../useTheme';
+import { resolveInitialMode, readStoredRaw, buildThemeMap } from '../useTheme';
+import { generateBrandVariants } from '../../theme/brandRamp';
+import { webDarkTheme, webLightTheme, createDarkTheme } from '@fluentui/react-components';
 
 const STORAGE_KEY = 'kbe-theme';
 
@@ -39,5 +41,48 @@ describe('useTheme initial mode resolution', () => {
 
   it('ignores an invalid config default and falls back to dark', () => {
     expect(resolveInitialMode('chartreuse' as unknown as 'dark')).toBe('dark');
+  });
+});
+
+describe('buildThemeMap', () => {
+  it('applies a global brand (hex) and token overrides to the base themes', () => {
+    const seed = '#4A9CC8';
+    const map = buildThemeMap({
+      default: 'dark',
+      brand: seed,
+      tokens: { colorNeutralBackground1: '#101418' },
+    });
+
+    // Explicit token override wins over the generated theme.
+    expect(map.dark.colorNeutralBackground1).toBe('#101418');
+
+    // The brand ramp is generated from the seed via generateBrandVariants and
+    // fed through createDarkTheme, so a brand-derived token matches.
+    const expected = createDarkTheme(generateBrandVariants(seed));
+    expect(map.dark.colorBrandBackground).toBe(expected.colorBrandBackground);
+  });
+
+  it('registers each named theme.themes entry as a selectable theme', () => {
+    const map = buildThemeMap({
+      default: 'dark',
+      themes: {
+        ocean: {
+          base: 'light',
+          brand: '#1B6CA8',
+          tokens: { colorNeutralBackground1: '#E0F0FA' },
+        },
+      },
+    });
+
+    expect(map.ocean).toBeDefined();
+    expect(map.ocean.colorNeutralBackground1).toBe('#E0F0FA');
+  });
+
+  it('leaves the built-ins unchanged when no overrides are configured', () => {
+    const map = buildThemeMap({ default: 'dark' });
+    expect(map.dark).toBe(webDarkTheme);
+    expect(map.light).toBe(webLightTheme);
+    // Sepia is the curated reading theme with its warm paper background.
+    expect(map.sepia.colorNeutralBackground1).toBe('#F5ECD7');
   });
 });

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,12 +1,14 @@
 import { useState, useCallback } from 'react';
-import type { Theme } from '../types';
+import type { Theme, KBConfig, FluentBrandRamp, FluentBrandRampKey } from '../types';
 import {
   webDarkTheme,
   webLightTheme,
   createLightTheme,
+  createDarkTheme,
   type Theme as FluentTheme,
   type BrandVariants,
 } from '@fluentui/react-components';
+import { generateBrandVariants } from '../theme/brandRamp';
 
 export type ThemeMode = 'dark' | 'light' | 'sepia';
 
@@ -85,36 +87,126 @@ function readStored(): ThemeMode {
   return readStoredRaw() ?? 'dark';
 }
 
-const THEME_MAP: Record<ThemeMode, FluentTheme> = {
+/**
+ * The three always-present built-in themes. With no config overrides this is
+ * the entire theme map, so default (no brand/tokens/themes) behavior is byte-
+ * for-byte identical to the previous static map.
+ */
+const BUILTIN_THEME_MAP: Record<ThemeMode, FluentTheme> = {
   dark: webDarkTheme,
   light: webLightTheme,
   sepia: sepiaTheme,
 };
 
+// Brand ramp stops in ascending order, used to fill a partial ramp object.
+const RAMP_STOPS = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160] as const;
+
+/**
+ * Convert a config brand ramp object (string keys "10".."160", possibly
+ * partial) into a complete Fluent `BrandVariants`. A complete ramp is used
+ * verbatim; a partial ramp has its gaps filled by carrying the nearest
+ * provided neighbor (forward, then backward) so every stop is defined.
+ */
+function rampToBrandVariants(ramp: FluentBrandRamp): BrandVariants {
+  const out: Record<number, string> = {};
+  for (const stop of RAMP_STOPS) {
+    const value = ramp[String(stop) as FluentBrandRampKey];
+    if (value) out[stop] = value;
+  }
+  let last: string | undefined;
+  for (const stop of RAMP_STOPS) {
+    if (out[stop]) last = out[stop];
+    else if (last) out[stop] = last;
+  }
+  let next: string | undefined;
+  for (let i = RAMP_STOPS.length - 1; i >= 0; i--) {
+    const stop = RAMP_STOPS[i];
+    if (out[stop]) next = out[stop];
+    else if (next) out[stop] = next;
+  }
+  return out as BrandVariants;
+}
+
+/** Resolve a config brand value (seed hex or ramp object) to BrandVariants. */
+function resolveBrandVariants(brand: string | FluentBrandRamp): BrandVariants {
+  return typeof brand === 'string' ? generateBrandVariants(brand) : rampToBrandVariants(brand);
+}
+
+/** Spread arbitrary token overrides over a Theme so explicit values win. */
+function applyTokens(base: FluentTheme, tokens?: Partial<Record<string, string>>): FluentTheme {
+  if (!tokens) return base;
+  return { ...base, ...tokens } as FluentTheme;
+}
+
+/**
+ * Build the runtime theme map from config. Pure and side-effect free.
+ *
+ * - Starts from the three built-ins (dark/light/sepia).
+ * - A global `theme.brand` regenerates the dark/light base themes via
+ *   `createDarkTheme`/`createLightTheme`; `theme.tokens` are then spread on top.
+ * - Each `theme.themes.<name>` entry becomes a selectable theme keyed by name,
+ *   derived from its `base` ('dark'→createDarkTheme, 'light'→createLightTheme,
+ *   default 'dark'), its `brand`, and its `tokens`.
+ *
+ * With no brand/tokens/themes configured the result equals BUILTIN_THEME_MAP
+ * (same object references), so behavior is unchanged.
+ */
+export function buildThemeMap(theme?: KBConfig['theme']): Record<string, FluentTheme> {
+  const globalVariants = theme?.brand ? resolveBrandVariants(theme.brand) : undefined;
+  const globalTokens = theme?.tokens;
+
+  const dark = applyTokens(globalVariants ? createDarkTheme(globalVariants) : webDarkTheme, globalTokens);
+  const light = applyTokens(globalVariants ? createLightTheme(globalVariants) : webLightTheme, globalTokens);
+
+  const map: Record<string, FluentTheme> = { dark, light, sepia: sepiaTheme };
+
+  if (theme?.themes) {
+    for (const [key, def] of Object.entries(theme.themes)) {
+      const base = def.base ?? 'dark';
+      const variants = def.brand ? resolveBrandVariants(def.brand) : undefined;
+      let baseTheme: FluentTheme;
+      if (variants) {
+        baseTheme = base === 'light' ? createLightTheme(variants) : createDarkTheme(variants);
+      } else {
+        baseTheme = base === 'light' ? webLightTheme : webDarkTheme;
+      }
+      map[key] = applyTokens(baseTheme, def.tokens);
+    }
+  }
+
+  return map;
+}
+
 export function useTheme(): [
   ThemeMode,
   FluentTheme,
   (t: ThemeMode) => void,
-  (configDefault?: Theme) => void,
+  (theme?: KBConfig['theme']) => void,
 ] {
   const [mode, setModeState] = useState<ThemeMode>(readStored);
+  const [themeMap, setThemeMap] = useState<Record<string, FluentTheme>>(BUILTIN_THEME_MAP);
 
   const setMode = useCallback((t: ThemeMode) => {
     setModeState(t);
     localStorage.setItem(STORAGE_KEY, t);
   }, []);
 
-  // Applies config.theme.default as the initial mode, but never overrides a
-  // theme the user has explicitly saved. Not persisted: a config default is
-  // not a user choice, so a later config change can still take effect.
-  const applyConfigDefault = useCallback((configDefault?: Theme) => {
+  // Invoked once config resolves (async, after mount). Builds the dynamic theme
+  // map from config and applies config.theme.default as the initial mode — but
+  // never overrides a theme the user has explicitly saved. The default is not
+  // persisted, so a later config change can still take effect.
+  const applyConfig = useCallback((theme?: KBConfig['theme']) => {
+    setThemeMap(buildThemeMap(theme));
     if (readStoredRaw() !== null) return;
+    const configDefault = theme?.default;
     if (configDefault && MODES.includes(configDefault)) {
       setModeState(configDefault);
     }
   }, []);
 
-  return [mode, THEME_MAP[mode], setMode, applyConfigDefault];
+  const fluentTheme = themeMap[mode] ?? BUILTIN_THEME_MAP[mode] ?? webDarkTheme;
+
+  return [mode, fluentTheme, setMode, applyConfig];
 }
 
 export function nextTheme(current: ThemeMode): ThemeMode {

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -106,13 +106,17 @@ const RAMP_STOPS = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140,
  * partial) into a complete Fluent `BrandVariants`. A complete ramp is used
  * verbatim; a partial ramp has its gaps filled by carrying the nearest
  * provided neighbor (forward, then backward) so every stop is defined.
+ * Returns `undefined` for an empty ramp (no stops provided) so callers can
+ * ignore an invalid brand rather than feed an incomplete ramp into
+ * `createDarkTheme`/`createLightTheme`.
  */
-function rampToBrandVariants(ramp: FluentBrandRamp): BrandVariants {
+function rampToBrandVariants(ramp: FluentBrandRamp): BrandVariants | undefined {
   const out: Record<number, string> = {};
   for (const stop of RAMP_STOPS) {
     const value = ramp[String(stop) as FluentBrandRampKey];
     if (value) out[stop] = value;
   }
+  if (Object.keys(out).length === 0) return undefined;
   let last: string | undefined;
   for (const stop of RAMP_STOPS) {
     if (out[stop]) last = out[stop];
@@ -127,9 +131,18 @@ function rampToBrandVariants(ramp: FluentBrandRamp): BrandVariants {
   return out as BrandVariants;
 }
 
-/** Resolve a config brand value (seed hex or ramp object) to BrandVariants. */
-function resolveBrandVariants(brand: string | FluentBrandRamp): BrandVariants {
-  return typeof brand === 'string' ? generateBrandVariants(brand) : rampToBrandVariants(brand);
+/**
+ * Resolve a config brand value (seed hex or ramp object) to BrandVariants.
+ * Returns `undefined` for an invalid hex seed or an empty ramp so a bad
+ * `config.theme.brand` is ignored (config.yaml is merged without validation)
+ * instead of crashing the app.
+ */
+function resolveBrandVariants(brand: string | FluentBrandRamp): BrandVariants | undefined {
+  try {
+    return typeof brand === 'string' ? generateBrandVariants(brand) : rampToBrandVariants(brand);
+  } catch {
+    return undefined;
+  }
 }
 
 /** Spread arbitrary token overrides over a Theme so explicit values win. */
@@ -144,12 +157,14 @@ function applyTokens(base: FluentTheme, tokens?: Partial<Record<string, string>>
  * - Starts from the three built-ins (dark/light/sepia).
  * - A global `theme.brand` regenerates the dark/light base themes via
  *   `createDarkTheme`/`createLightTheme`; `theme.tokens` are then spread on top.
- * - Each `theme.themes.<name>` entry becomes a selectable theme keyed by name,
- *   derived from its `base` ('dark'→createDarkTheme, 'light'→createLightTheme,
- *   default 'dark'), its `brand`, and its `tokens`.
+ * - Each `theme.themes.<name>` entry is registered under its name (built-in
+ *   names dark/light/sepia are reserved and skipped with a warning), derived
+ *   from its `base` ('dark'→createDarkTheme, 'light'→createLightTheme, default
+ *   'dark'), its `brand`, and its `tokens`.
  *
- * With no brand/tokens/themes configured the result equals BUILTIN_THEME_MAP
- * (same object references), so behavior is unchanged.
+ * With no brand/tokens/themes configured the dark/light/sepia entries reuse the
+ * built-in theme object references, so behavior is unchanged. (The returned map
+ * is always a fresh object literal — only its theme *values* are shared.)
  */
 export function buildThemeMap(theme?: KBConfig['theme']): Record<string, FluentTheme> {
   const globalVariants = theme?.brand ? resolveBrandVariants(theme.brand) : undefined;
@@ -162,6 +177,12 @@ export function buildThemeMap(theme?: KBConfig['theme']): Record<string, FluentT
 
   if (theme?.themes) {
     for (const [key, def] of Object.entries(theme.themes)) {
+      if ((MODES as string[]).includes(key)) {
+        console.warn(
+          `[useTheme] Ignoring config theme "${key}": that name is reserved for a built-in theme.`,
+        );
+        continue;
+      }
       const base = def.base ?? 'dark';
       const variants = def.brand ? resolveBrandVariants(def.brand) : undefined;
       let baseTheme: FluentTheme;


### PR DESCRIPTION
## Summary

Makes the theme map dynamic — built at runtime from `config.theme` — while preserving the three built-ins (dark/light/sepia) and existing switching behavior. This is the integration task of Feature F2, wiring the previously-dead `theme.brand` / `theme.tokens` / `theme.themes` schema (T2.1) into the live FluentProvider via the `generateBrandVariants` helper (T2.3).

Closes #193

## What changed

- **`src/hooks/useTheme.ts`**
  - New pure `buildThemeMap(config?: KBConfig['theme'])`:
    - Starts from the three built-ins (now `BUILTIN_THEME_MAP`).
    - **Global override:** if `theme.brand` is set, regenerates the dark/light base themes via `createDarkTheme`/`createLightTheme` (hex → `generateBrandVariants`; ramp object → filled to a complete `BrandVariants`), then spreads `theme.tokens` on top so explicit token overrides win.
    - **Named themes:** each `theme.themes.<name>` entry becomes a selectable theme keyed by its name, derived from its `base` (`dark`→`createDarkTheme`, `light`→`createLightTheme`, default `dark`), its `brand`, and its `tokens`.
  - The hook now holds the built map in state and exposes `applyConfig(theme?)` (replacing `applyConfigDefault`), invoked once config resolves — it builds the dynamic map **and** applies `theme.default` without clobbering a user's saved `localStorage` mode.
  - With no brand/tokens/themes configured, the map equals `BUILTIN_THEME_MAP` (same object references) — behavior is byte-for-byte identical to before.
- **`src/App.tsx`** — passes the full `config.theme` to `applyConfig`.
- **`src/hooks/__tests__/useTheme.test.ts`** — adds pure-builder tests (no React rendering).

`CACHE_VERSION` is intentionally **not** bumped (deferred to T2.4 to avoid a conflict), and cycle/persistence semantics are unchanged beyond registering config themes.

## Validation

- `npm run lint` — 0 errors (pre-existing HUD `exhaustive-deps` warning only)
- `npx vitest run` — 331 passed (incl. 7 in `useTheme`)
- `npm run build` — `tsc -b` + vite both succeed
- **Brand recolor (real flow, Playwright):** with `content/config.yaml` set to `theme.brand: "#E81CA9"` in local mode, the FluentProvider's `--colorBrandBackground` resolved to `#CC1594` (magenta, derived from the seed) vs the default `#115ea3`, and the "Explore the Graph" primary button + HUD active indicators visibly recolored magenta. Confirmed unbranded config leaves them Fluent blue.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>