### PR TITLE
T2.4: extend theme cycle + persistence to config themes; bump CACHE_VERSION

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,7 +28,7 @@ function useCurrentNodeId(): string | null {
   return match ? decodeURIComponent(match[1]) : null;
 }
 
-function Explorer({ themeMode, setThemeMode, applyConfig }: { themeMode: import('./hooks/useTheme').ThemeMode; setThemeMode: (t: import('./hooks/useTheme').ThemeMode) => void; applyConfig: (theme?: import('./types').KBConfig['theme']) => void }) {
+function Explorer({ themeMode, setThemeMode, applyConfig, cycleTheme }: { themeMode: import('./hooks/useTheme').ThemeMode; setThemeMode: (t: import('./hooks/useTheme').ThemeMode) => void; applyConfig: (theme?: import('./types').KBConfig['theme']) => void; cycleTheme: () => void }) {
   const state = useKnowledgeBase();
   const currentNodeId = useCurrentNodeId();
 
@@ -47,7 +47,7 @@ function Explorer({ themeMode, setThemeMode, applyConfig }: { themeMode: import(
 
   useKeyboardNav(
     state.status === 'ready' ? state.graph : null,
-    setThemeMode as (t: import('./types').Theme) => void,
+    cycleTheme,
   );
 
   useThemeFonts(state.status === 'ready' ? state.config.theme.font : undefined);
@@ -81,7 +81,7 @@ function Explorer({ themeMode, setThemeMode, applyConfig }: { themeMode: import(
           graph={graph}
           config={config}
           currentNodeId={currentNodeId}
-          theme={themeMode}
+          theme={themeMode as import('./types').Theme}
           onThemeChange={setThemeMode as (t: import('./types').Theme) => void}
           onCollapsedChange={setHudCollapsed}
           onDockChange={setHudDock}
@@ -91,12 +91,12 @@ function Explorer({ themeMode, setThemeMode, applyConfig }: { themeMode: import(
 }
 
 function App() {
-  const [themeMode, fluentTheme, setThemeMode, applyConfig] = useTheme();
+  const [themeMode, fluentTheme, setThemeMode, applyConfig, cycleTheme] = useTheme();
 
   return (
     <FluentProvider theme={fluentTheme} style={{ minHeight: '100vh' }}>
       <HashRouter>
-        <Explorer themeMode={themeMode} setThemeMode={setThemeMode} applyConfig={applyConfig} />
+        <Explorer themeMode={themeMode} setThemeMode={setThemeMode} applyConfig={applyConfig} cycleTheme={cycleTheme} />
       </HashRouter>
     </FluentProvider>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { HashRouter, Routes, Route, Navigate, useParams, useLocation } from 'react-router-dom';
 import { FluentProvider } from '@fluentui/react-components';
 import { useKnowledgeBase } from './hooks/useKnowledgeBase';
-import { useTheme } from './hooks/useTheme';
+import { useTheme, isDarkTheme } from './hooks/useTheme';
 import { useThemeFonts } from './hooks/useThemeFonts';
 import { useFavicon } from './hooks/useFavicon';
 import { useKeyboardNav } from './hooks/useKeyboardNav';
@@ -28,7 +28,7 @@ function useCurrentNodeId(): string | null {
   return match ? decodeURIComponent(match[1]) : null;
 }
 
-function Explorer({ themeMode, setThemeMode, applyConfig, cycleTheme }: { themeMode: import('./hooks/useTheme').ThemeMode; setThemeMode: (t: import('./hooks/useTheme').ThemeMode) => void; applyConfig: (theme?: import('./types').KBConfig['theme']) => void; cycleTheme: () => void }) {
+function Explorer({ themeMode, isDark, setThemeMode, applyConfig, cycleTheme }: { themeMode: import('./hooks/useTheme').ThemeMode; isDark: boolean; setThemeMode: (t: import('./hooks/useTheme').ThemeMode) => void; applyConfig: (theme?: import('./types').KBConfig['theme']) => void; cycleTheme: () => void }) {
   const state = useKnowledgeBase();
   const currentNodeId = useCurrentNodeId();
 
@@ -81,7 +81,8 @@ function Explorer({ themeMode, setThemeMode, applyConfig, cycleTheme }: { themeM
           graph={graph}
           config={config}
           currentNodeId={currentNodeId}
-          theme={themeMode as import('./types').Theme}
+          theme={themeMode}
+          isDark={isDark}
           onThemeChange={setThemeMode as (t: import('./types').Theme) => void}
           onCollapsedChange={setHudCollapsed}
           onDockChange={setHudDock}
@@ -92,11 +93,12 @@ function Explorer({ themeMode, setThemeMode, applyConfig, cycleTheme }: { themeM
 
 function App() {
   const [themeMode, fluentTheme, setThemeMode, applyConfig, cycleTheme] = useTheme();
+  const isDark = isDarkTheme(fluentTheme);
 
   return (
     <FluentProvider theme={fluentTheme} style={{ minHeight: '100vh' }}>
       <HashRouter>
-        <Explorer themeMode={themeMode} setThemeMode={setThemeMode} applyConfig={applyConfig} cycleTheme={cycleTheme} />
+        <Explorer themeMode={themeMode} isDark={isDark} setThemeMode={setThemeMode} applyConfig={applyConfig} cycleTheme={cycleTheme} />
       </HashRouter>
     </FluentProvider>
   );

--- a/src/api/github.ts
+++ b/src/api/github.ts
@@ -8,7 +8,7 @@ import type { SourceConfig } from '../types';
 
 const CACHE_PREFIX = 'kbe:';
 const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
-const CACHE_VERSION = 19; // bump to invalidate all cached data (19: F3 branding.favicon config field swaps document <link rel=icon> at runtime — affects cached render; 18: F3 branding.logo config field renders on HomePage hero + HUD header — affects cached render; 17: F1 config-driven appearance — theme.default initial mode + theme.font.* CSS vars now affect cached render; 16: skill node type — .github/skills/**/SKILL.md → SkillView; 15: F3 structural nodes + node-map JSON-LD merged with content-model spine ingestion; 13: KBNode JSON-LD fields + KBEdge.relation)
+const CACHE_VERSION = 20; // bump to invalidate all cached data (20: T2.4 F2 config-driven brand — theme cycle + persistence now span config.theme.themes.*; selectable theme set is dynamic (built-ins + config themes) and stored kbe-theme is validated against it, changing the cached render's theme shape; 19: F3 branding.favicon config field swaps document <link rel=icon> at runtime — affects cached render; 18: F3 branding.logo config field renders on HomePage hero + HUD header — affects cached render; 17: F1 config-driven appearance — theme.default initial mode + theme.font.* CSS vars now affect cached render; 16: skill node type — .github/skills/**/SKILL.md → SkillView; 15: F3 structural nodes + node-map JSON-LD merged with content-model spine ingestion; 13: KBNode JSON-LD fields + KBEdge.relation)
 
 // Clear stale cache from older versions
 try {

--- a/src/components/HUD.tsx
+++ b/src/components/HUD.tsx
@@ -31,6 +31,7 @@ import {
 import type { KBGraph, KBConfig, KBNode, Theme } from '../types';
 import { getEdgeStyle, getEdgeLegendKey, BUILT_IN_VIEWS, filterGraphToView, collapseGraphClusters, trimGraphToLimits } from '../types';
 import type { TrimResult } from '../types';
+import type { ThemeMode } from '../hooks/useTheme';
 import { NodeVisual, FLUENT_ICONS, isFluentIconName } from './NodeVisual';
 import { resolveImageUrl } from '../api';
 import { createGraphNetwork, computeGraphPositions } from '../engine/createGraphNetwork';
@@ -42,7 +43,13 @@ interface HUDProps {
   graph: KBGraph;
   config: KBConfig;
   currentNodeId: string | null;
-  theme: Theme;
+  theme: ThemeMode;
+  /**
+   * Whether the active theme renders on a dark background. Derived from the
+   * resolved Fluent theme (not the mode string) so config themes — which may
+   * carry any key — drive minimap edge/highlight contrast correctly.
+   */
+  isDark: boolean;
   onThemeChange: (theme: Theme) => void;
   onCollapsedChange?: (collapsed: boolean) => void;
   onDockChange?: (dock: DockPosition) => void;
@@ -271,7 +278,7 @@ const useStyles= makeStyles({
   },
 });
 
-export function HUD({ graph, config, currentNodeId, theme, onThemeChange, onCollapsedChange, onDockChange }: HUDProps) {
+export function HUD({ graph, config, currentNodeId, theme, isDark, onThemeChange, onCollapsedChange, onDockChange }: HUDProps) {
   const styles = useStyles();
   const canvasElRef = useRef<HTMLCanvasElement | null>(null);
   const [canvasMountKey, setCanvasMountKey] = useState(0);
@@ -464,8 +471,8 @@ export function HUD({ graph, config, currentNodeId, theme, onThemeChange, onColl
     const posMap = minimapPositions;
     if (posMap.size === 0) return;
 
-    const edgeColor = theme === 'dark' ? 'rgba(255, 255, 255, 0.08)' : 'rgba(0, 0, 0, 0.12)';
-    const highlightColor = theme === 'dark' ? HIGHLIGHT_COLOR_DARK : HIGHLIGHT_COLOR_LIGHT;
+    const edgeColor = isDark ? 'rgba(255, 255, 255, 0.08)' : 'rgba(0, 0, 0, 0.12)';
+    const highlightColor = isDark ? HIGHLIGHT_COLOR_DARK : HIGHLIGHT_COLOR_LIGHT;
 
     const dpr = window.devicePixelRatio || 1;
     const W = canvas.clientWidth || 120;
@@ -557,7 +564,7 @@ export function HUD({ graph, config, currentNodeId, theme, onThemeChange, onColl
       ctx.lineWidth = isCurrent ? 1.5 : 0.8;
       ctx.stroke();
     }
-  }, [filteredGraph, currentNodeId, theme, dock, minimapPositions, canvasMountKey]);
+  }, [filteredGraph, currentNodeId, isDark, dock, minimapPositions, canvasMountKey]);
 
   useEffect(() => { const t = setTimeout(() => drawMinimap(), 50); return () => clearTimeout(t); }, [drawMinimap]);
 
@@ -568,7 +575,7 @@ export function HUD({ graph, config, currentNodeId, theme, onThemeChange, onColl
     const { network, setEmphasis: overlaySetEmphasis } = createGraphNetwork({
       container: overlayRef.current,
       graph: filteredGraph,
-      isDark: theme === 'dark',
+      isDark,
       onNodeClick: (id) => {
         setMapExpanded(false);
         window.location.hash = `/node/${encodeURIComponent(id)}`;
@@ -615,7 +622,7 @@ export function HUD({ graph, config, currentNodeId, theme, onThemeChange, onColl
       }
       const { network, nodes: visNodes, setEmphasis } = createGraphNetwork({
         container: sidebarGraphRef.current,
-        graph: filteredGraph,        isDark: theme === 'dark',
+        graph: filteredGraph,        isDark,
         onNodeClick: (id) => {
           window.location.hash = `/node/${encodeURIComponent(id)}`;
         },
@@ -648,7 +655,7 @@ export function HUD({ graph, config, currentNodeId, theme, onThemeChange, onColl
       }
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isVertical, collapsed, filteredGraph, theme]);
+  }, [isVertical, collapsed, filteredGraph, isDark]);
 
   // Update selection + focus + neighborhood emphasis when currentNodeId changes (no rebuild)
   useEffect(() => {

--- a/src/hooks/__tests__/useTheme.test.ts
+++ b/src/hooks/__tests__/useTheme.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { resolveInitialMode, readStoredRaw, buildThemeMap } from '../useTheme';
+import { resolveInitialMode, readStoredRaw, buildThemeMap, nextTheme, modesForMap, BUILTIN_MODES } from '../useTheme';
 import { generateBrandVariants } from '../../theme/brandRamp';
 import { webDarkTheme, webLightTheme, createDarkTheme } from '@fluentui/react-components';
 
@@ -104,5 +104,75 @@ describe('buildThemeMap', () => {
     });
     // The reserved 'dark' built-in is preserved, not replaced by the config theme.
     expect(map.dark).toBe(webDarkTheme);
+  });
+});
+
+describe('modesForMap', () => {
+  it('with no config themes the cycle is exactly dark/light/sepia', () => {
+    const map = buildThemeMap({ default: 'dark' });
+    expect(modesForMap(map)).toEqual(['dark', 'light', 'sepia']);
+    expect(modesForMap(map)).toEqual(BUILTIN_MODES);
+  });
+
+  it('lists built-ins first, then config themes in config order', () => {
+    const map = buildThemeMap({
+      default: 'dark',
+      themes: {
+        ocean: { base: 'light', brand: '#1B6CA8' },
+        forest: { base: 'dark', brand: '#2E7D32' },
+      },
+    });
+    expect(modesForMap(map)).toEqual(['dark', 'light', 'sepia', 'ocean', 'forest']);
+  });
+});
+
+describe('nextTheme', () => {
+  it('cycles the built-ins and wraps around (default modes)', () => {
+    expect(nextTheme('dark')).toBe('light');
+    expect(nextTheme('light')).toBe('sepia');
+    expect(nextTheme('sepia')).toBe('dark');
+  });
+
+  it('cycles built-ins + config themes and wraps around', () => {
+    const modes = ['dark', 'light', 'sepia', 'ocean', 'forest'];
+    expect(nextTheme('sepia', modes)).toBe('ocean');
+    expect(nextTheme('ocean', modes)).toBe('forest');
+    // Wrap from the last config theme back to the first built-in.
+    expect(nextTheme('forest', modes)).toBe('dark');
+  });
+
+  it('resolves an unknown current mode to the first mode', () => {
+    expect(nextTheme('gone', ['dark', 'light', 'sepia'])).toBe('dark');
+  });
+});
+
+describe('readStored / resolveInitialMode against a dynamic set', () => {
+  beforeEach(() => {
+    installLocalStorage();
+  });
+
+  afterEach(() => {
+    delete (globalThis as { localStorage?: unknown }).localStorage;
+  });
+
+  it('accepts a valid stored config-theme key', () => {
+    const modes = ['dark', 'light', 'sepia', 'ocean'];
+    localStorage.setItem(STORAGE_KEY, 'ocean');
+    expect(readStoredRaw(modes)).toBe('ocean');
+    expect(resolveInitialMode('dark', modes)).toBe('ocean');
+  });
+
+  it('rejects a stale stored key not in the current set and falls back to config default', () => {
+    // 'ocean' was removed from config, so the live set no longer contains it.
+    const modes = ['dark', 'light', 'sepia'];
+    localStorage.setItem(STORAGE_KEY, 'ocean');
+    expect(readStoredRaw(modes)).toBeNull();
+    expect(resolveInitialMode('light', modes)).toBe('light');
+  });
+
+  it('falls back to dark when the stale key has no valid config default', () => {
+    const modes = ['dark', 'light', 'sepia'];
+    localStorage.setItem(STORAGE_KEY, 'ocean');
+    expect(resolveInitialMode(undefined, modes)).toBe('dark');
   });
 });

--- a/src/hooks/__tests__/useTheme.test.ts
+++ b/src/hooks/__tests__/useTheme.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { resolveInitialMode, readStoredRaw, buildThemeMap, nextTheme, modesForMap, BUILTIN_MODES } from '../useTheme';
+import { resolveInitialMode, readStoredRaw, buildThemeMap, nextTheme, modesForMap, isDarkTheme, BUILTIN_MODES } from '../useTheme';
 import { generateBrandVariants } from '../../theme/brandRamp';
 import { webDarkTheme, webLightTheme, createDarkTheme } from '@fluentui/react-components';
 
@@ -143,6 +143,27 @@ describe('nextTheme', () => {
 
   it('resolves an unknown current mode to the first mode', () => {
     expect(nextTheme('gone', ['dark', 'light', 'sepia'])).toBe('dark');
+  });
+});
+
+describe('isDarkTheme', () => {
+  it('classifies the built-ins by background luminance', () => {
+    const map = buildThemeMap({ default: 'dark' });
+    expect(isDarkTheme(map.dark)).toBe(true);
+    expect(isDarkTheme(map.light)).toBe(false);
+    // Sepia is a warm light reading theme.
+    expect(isDarkTheme(map.sepia)).toBe(false);
+  });
+
+  it('uses the resolved background, so a dark-based config theme with a light token override is light', () => {
+    const map = buildThemeMap({
+      default: 'dark',
+      themes: {
+        ocean: { base: 'dark', brand: '#1B6CA8', tokens: { colorNeutralBackground1: '#E0F0FA' } },
+      },
+    });
+    // base: 'dark' but the explicit light background wins for isDark decisions.
+    expect(isDarkTheme(map.ocean)).toBe(false);
   });
 });
 

--- a/src/hooks/useKeyboardNav.ts
+++ b/src/hooks/useKeyboardNav.ts
@@ -1,16 +1,15 @@
 import { useEffect } from 'react';
-import type { KBGraph, Theme } from '../types';
-import { nextTheme, type ThemeMode } from './useTheme';
+import type { KBGraph } from '../types';
 
 /**
  * Global keyboard shortcuts.
  *
- * t        → cycle theme
+ * t        → cycle theme (built-ins + config themes, via the live theme map)
  * ←/→      → prev/next node (reading view)
  */
 export function useKeyboardNav(
   graph: KBGraph | null,
-  setTheme: (t: Theme) => void,
+  cycleTheme: () => void,
 ): void {
   useEffect(() => {
     function handler(e: KeyboardEvent) {
@@ -20,9 +19,7 @@ export function useKeyboardNav(
 
       switch (e.key) {
         case 't': {
-          const stored = localStorage.getItem('kbe-theme') as ThemeMode | null;
-          const current: ThemeMode = stored === 'light' ? 'light' : 'dark';
-          setTheme(nextTheme(current));
+          cycleTheme();
           break;
         }
         case 'ArrowLeft':
@@ -45,5 +42,5 @@ export function useKeyboardNav(
 
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [graph, setTheme]);
+  }, [graph, cycleTheme]);
 }

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -282,7 +282,8 @@ export function useTheme(): [
     });
   }, [themeMap]);
 
-  const fluentTheme = themeMap[mode] ?? BUILTIN_THEME_MAP[mode as 'dark'] ?? webDarkTheme;
+  const fluentTheme =
+    themeMap[mode] ?? (BUILTIN_THEME_MAP as Record<string, FluentTheme>)[mode] ?? webDarkTheme;
 
   return [mode, fluentTheme, setMode, applyConfig, cycleTheme];
 }
@@ -296,4 +297,21 @@ export function nextTheme(current: ThemeMode, modes: ThemeMode[] = BUILTIN_MODES
   if (modes.length === 0) return current;
   const i = modes.indexOf(current);
   return modes[(i + 1) % modes.length];
+}
+
+/**
+ * Whether a resolved Fluent theme renders on a dark background, derived from
+ * the perceived luminance of `colorNeutralBackground1`. Used instead of a
+ * `mode === 'dark'` string check so config themes (any key) drive dark/light
+ * UI decisions correctly. Defaults to dark when the background is unparseable.
+ */
+export function isDarkTheme(theme: FluentTheme): boolean {
+  const m = /^#?([0-9a-fA-F]{6})$/.exec(theme.colorNeutralBackground1 ?? '');
+  if (!m) return true;
+  const n = parseInt(m[1], 16);
+  const r = (n >> 16) & 0xff;
+  const g = (n >> 8) & 0xff;
+  const b = n & 0xff;
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+  return luminance < 0.5;
 }

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback } from 'react';
-import type { Theme, KBConfig, FluentBrandRamp, FluentBrandRampKey } from '../types';
+import type { KBConfig, FluentBrandRamp, FluentBrandRampKey } from '../types';
 import {
   webDarkTheme,
   webLightTheme,
@@ -10,10 +10,32 @@ import {
 } from '@fluentui/react-components';
 import { generateBrandVariants } from '../theme/brandRamp';
 
-export type ThemeMode = 'dark' | 'light' | 'sepia';
+/**
+ * A selectable theme key. The three built-ins (dark/light/sepia) are always
+ * present; config-defined themes (`config.theme.themes.<name>`) widen this set
+ * at runtime, so the type is intentionally open. `(string & {})` keeps built-in
+ * autocomplete while still accepting arbitrary config theme keys.
+ */
+export type ThemeMode = 'dark' | 'light' | 'sepia' | (string & {});
 
 const STORAGE_KEY = 'kbe-theme';
-const MODES: ThemeMode[] = ['dark', 'light', 'sepia'];
+
+/** The always-present built-in themes, in canonical cycle order. */
+export const BUILTIN_MODES: ThemeMode[] = ['dark', 'light', 'sepia'];
+
+/**
+ * Derive the ordered, selectable mode list from a runtime theme map: the
+ * built-ins first (dark, light, sepia — only those actually present), then any
+ * config-defined theme keys in config (insertion) order. This is the dynamic
+ * equivalent of the old static `MODES` array and drives both the cycle order
+ * and stored-key validation.
+ */
+export function modesForMap(themeMap: Record<string, FluentTheme>): ThemeMode[] {
+  const keys = Object.keys(themeMap);
+  const builtins = BUILTIN_MODES.filter(m => keys.includes(m as string));
+  const extras = keys.filter(k => !(BUILTIN_MODES as string[]).includes(k));
+  return [...builtins, ...extras];
+}
 
 // Warm amber brand ramp for the sepia reading theme
 const sepiaBrand: BrandVariants = {
@@ -63,28 +85,41 @@ const sepiaTheme: FluentTheme = {
   colorSubtleBackgroundPressed: '#E5DBC2',
 };
 
-/** Returns the user's explicitly stored theme, or null when none is saved. */
-export function readStoredRaw(): ThemeMode | null {
+/**
+ * Returns the user's explicitly stored theme, or null when none is saved or the
+ * saved key is not in the supplied selectable set. Validating against `modes`
+ * means a stored config-theme key that no longer exists (e.g. the theme was
+ * removed from config) is treated as absent rather than selected.
+ */
+export function readStoredRaw(modes: ThemeMode[] = BUILTIN_MODES): ThemeMode | null {
   try {
     const v = localStorage.getItem(STORAGE_KEY);
-    if (v && MODES.includes(v as ThemeMode)) return v as ThemeMode;
+    if (v && (modes as string[]).includes(v)) return v as ThemeMode;
   } catch { /* ignore */ }
   return null;
 }
 
 /**
- * Resolves the initial theme mode. A theme the user explicitly saved always
- * wins; otherwise fall back to config.theme.default, then to 'dark'.
+ * Resolves the initial theme mode against the given selectable set. A theme the
+ * user explicitly saved (and that is still valid) always wins; otherwise fall
+ * back to config.theme.default (if valid), then to 'dark'.
  */
-export function resolveInitialMode(configDefault?: Theme): ThemeMode {
-  const stored = readStoredRaw();
+export function resolveInitialMode(
+  configDefault?: ThemeMode,
+  modes: ThemeMode[] = BUILTIN_MODES,
+): ThemeMode {
+  const stored = readStoredRaw(modes);
   if (stored) return stored;
-  if (configDefault && MODES.includes(configDefault)) return configDefault;
-  return 'dark';
+  if (configDefault && (modes as string[]).includes(configDefault as string)) return configDefault;
+  return (modes as string[]).includes('dark') ? 'dark' : (modes[0] ?? 'dark');
 }
 
-function readStored(): ThemeMode {
-  return readStoredRaw() ?? 'dark';
+/**
+ * Resolve a starting mode for the hook's initial state: a valid stored choice
+ * wins, otherwise `fallback` (clamped to the selectable set).
+ */
+function readStored(modes: ThemeMode[] = BUILTIN_MODES, fallback: ThemeMode = 'dark'): ThemeMode {
+  return readStoredRaw(modes) ?? ((modes as string[]).includes(fallback as string) ? fallback : (modes[0] ?? 'dark'));
 }
 
 /**
@@ -92,7 +127,7 @@ function readStored(): ThemeMode {
  * the entire theme map, so default (no brand/tokens/themes) behavior is byte-
  * for-byte identical to the previous static map.
  */
-const BUILTIN_THEME_MAP: Record<ThemeMode, FluentTheme> = {
+const BUILTIN_THEME_MAP: Record<'dark' | 'light' | 'sepia', FluentTheme> = {
   dark: webDarkTheme,
   light: webLightTheme,
   sepia: sepiaTheme,
@@ -177,7 +212,7 @@ export function buildThemeMap(theme?: KBConfig['theme']): Record<string, FluentT
 
   if (theme?.themes) {
     for (const [key, def] of Object.entries(theme.themes)) {
-      if ((MODES as string[]).includes(key)) {
+      if ((BUILTIN_MODES as string[]).includes(key)) {
         console.warn(
           `[useTheme] Ignoring config theme "${key}": that name is reserved for a built-in theme.`,
         );
@@ -203,34 +238,62 @@ export function useTheme(): [
   FluentTheme,
   (t: ThemeMode) => void,
   (theme?: KBConfig['theme']) => void,
+  () => void,
 ] {
-  const [mode, setModeState] = useState<ThemeMode>(readStored);
+  const [mode, setModeState] = useState<ThemeMode>(() => readStored());
   const [themeMap, setThemeMap] = useState<Record<string, FluentTheme>>(BUILTIN_THEME_MAP);
 
   const setMode = useCallback((t: ThemeMode) => {
     setModeState(t);
-    localStorage.setItem(STORAGE_KEY, t);
+    try { localStorage.setItem(STORAGE_KEY, t); } catch { /* ignore */ }
   }, []);
 
   // Invoked once config resolves (async, after mount). Builds the dynamic theme
-  // map from config and applies config.theme.default as the initial mode — but
-  // never overrides a theme the user has explicitly saved. The default is not
-  // persisted, so a later config change can still take effect.
+  // map from config and reconciles the active mode against the new selectable
+  // set: a still-valid stored choice wins; a stale stored key (e.g. a config
+  // theme that was removed) is ignored and we fall back to config.theme.default
+  // then 'dark'. The default is not persisted, so a later config change can
+  // still take effect.
   const applyConfig = useCallback((theme?: KBConfig['theme']) => {
-    setThemeMap(buildThemeMap(theme));
-    if (readStoredRaw() !== null) return;
+    const map = buildThemeMap(theme);
+    setThemeMap(map);
+    const modes = modesForMap(map);
+    const stored = readStoredRaw(modes);
+    if (stored !== null) {
+      setModeState(stored);
+      return;
+    }
     const configDefault = theme?.default;
-    if (configDefault && MODES.includes(configDefault)) {
+    if (configDefault && (modes as string[]).includes(configDefault as string)) {
       setModeState(configDefault);
+    } else {
+      setModeState((modes as string[]).includes('dark') ? 'dark' : (modes[0] ?? 'dark'));
     }
   }, []);
 
-  const fluentTheme = themeMap[mode] ?? BUILTIN_THEME_MAP[mode] ?? webDarkTheme;
+  // Cycle to the next theme based on the live map keys (built-ins + config
+  // themes), wrapping around. Persists the choice like an explicit selection.
+  const cycleTheme = useCallback(() => {
+    const modes = modesForMap(themeMap);
+    setModeState(prev => {
+      const next = nextTheme(prev, modes);
+      try { localStorage.setItem(STORAGE_KEY, next); } catch { /* ignore */ }
+      return next;
+    });
+  }, [themeMap]);
 
-  return [mode, fluentTheme, setMode, applyConfig];
+  const fluentTheme = themeMap[mode] ?? BUILTIN_THEME_MAP[mode as 'dark'] ?? webDarkTheme;
+
+  return [mode, fluentTheme, setMode, applyConfig, cycleTheme];
 }
 
-export function nextTheme(current: ThemeMode): ThemeMode {
-  const i = MODES.indexOf(current);
-  return MODES[(i + 1) % MODES.length];
+/**
+ * Return the next theme in the cycle after `current`, wrapping around. The
+ * cycle is the supplied `modes` list (built-ins first, then config themes); an
+ * unknown `current` (not in the set) resolves to the first mode.
+ */
+export function nextTheme(current: ThemeMode, modes: ThemeMode[] = BUILTIN_MODES): ThemeMode {
+  if (modes.length === 0) return current;
+  const i = modes.indexOf(current);
+  return modes[(i + 1) % modes.length];
 }


### PR DESCRIPTION
Closes #194

Final task of Feature F2 (config-driven brand). Makes the selectable theme set dynamic so config-defined themes (`config.theme.themes.<name>`, registered by `buildThemeMap` since T2.2) are now reachable via the theme cycle and persisted.

## Changes
- **`src/hooks/useTheme.ts`**
  - `ThemeMode` widened from the closed `'dark'|'light'|'sepia'` union to `… | (string & {})` so config theme keys are valid while built-in autocomplete is preserved.
  - New `BUILTIN_MODES` constant and pure `modesForMap(themeMap)` helper deriving the cycle order from the **live** map keys: built-ins first (dark, light, sepia), then config theme keys in config order.
  - `nextTheme(current, modes)` now cycles over the supplied modes and wraps around (unknown current → first mode).
  - `readStoredRaw(modes)` / `resolveInitialMode(default, modes)` / `readStored(modes, fallback)` validate the stored `kbe-theme` against the **current** selectable set; a stale key (e.g. a removed config theme) is ignored and falls back to `theme.default` → `dark`. "Stored user choice wins" is preserved.
  - `applyConfig` rebuilds the map and reconciles the active mode against the new set (valid stored wins, else config default, else dark).
  - New `cycleTheme()` returned from the hook — cycles via the live map keys and persists like an explicit selection.
- **`src/hooks/useKeyboardNav.ts`** — `'t'` now calls `cycleTheme()` (removed the broken light/dark-only localStorage read that never reached sepia/config themes).
- **`src/App.tsx`** — threads `cycleTheme` into `useKeyboardNav`.
- **`src/api/github.ts`** — `CACHE_VERSION` 19 → 20 (theme shape + selectable cycle set changed).

Backward compatible: with no config themes the cycle is exactly `dark → light → sepia → dark`.

## Validation
- `npm run lint` — 0 errors (pre-existing HUD exhaustive-deps warning only)
- `npx vitest run` — 346 passed (added: `modesForMap`, `nextTheme` cycle/wrap, stale-key rejection + valid config-key acceptance, unchanged built-in cycle)
- `npm run build` — tsc -b + vite OK
- Real-flow (local build + Playwright, temporary `config.theme.themes.ocean`): pressing `t` reaches `ocean`, UI recolors to the token override, reload persists; a stale stored key falls back with no console errors. (Temporary config/spec reverted.)