### PR TITLE
Add HUD theme palette chooser for all themes

### DIFF
--- a/content/theming-named-themes.md
+++ b/content/theming-named-themes.md
@@ -65,13 +65,20 @@ theme:
         colorNeutralBackground1: "#FFF5F8"
 ```
 
-## Cycling
+## Choosing a theme
 
-Press **`t`** to cycle. The order is the built-ins first (dark → light → sepia),
-then your named themes in declaration order, then wrap. The active choice is
-saved to `localStorage` under `kbe-theme`; if a saved theme is later removed from
-config, the app falls back to `theme.default`. See [keyboard nav](keyboard-nav)
-for all shortcuts and the [theme system](theme-system) for how a resolved Fluent
-`Theme` flows to `<FluentProvider>`.
+There are two ways to switch:
+
+- **Palette menu** — the paint-palette button in the HUD opens a menu listing
+  *every* available theme (built-ins plus your named, external-file, and module
+  themes) with the active one checked. Click one to apply it.
+- **Keyboard** — press **`t`** to cycle. The order is the built-ins first
+  (dark → light → sepia), then your named themes in declaration order, then wrap.
+
+Either way the active choice is saved to `localStorage` under `kbe-theme`; if a
+saved theme is later removed from config, the app falls back to `theme.default`.
+See [keyboard nav](keyboard-nav) for all shortcuts and the
+[theme system](theme-system) for how a resolved Fluent `Theme` flows to
+`<FluentProvider>`.
 
 For per-cluster and per-page accents, see [scoped theming](theming-scoped).

--- a/content/theming-overview.md
+++ b/content/theming-overview.md
@@ -44,7 +44,8 @@ behaves exactly as before (dark / light / sepia only). Add one field at a time:
 
 1. Set `theme.default` and maybe `theme.font.*`.
 2. Add a `theme.brand` seed to recolor the whole app.
-3. Add a couple of `theme.themes` and press `t` to cycle them.
+3. Add a couple of `theme.themes`, then switch between them from the HUD's
+   paint-palette menu (or press `t` to cycle).
 4. Reach for an [escape hatch](theming-escape-hatches) only when the structured
    options can't express what you need.
 

--- a/e2e/visual-validation.spec.ts
+++ b/e2e/visual-validation.spec.ts
@@ -46,9 +46,8 @@ test.describe('Visual Validation', () => {
     await expect(page.getByRole('button', { name: 'Dock right' })).toBeVisible()
     await expect(page.getByRole('button', { name: 'Dock top' })).toBeVisible()
 
-    // Theme buttons
-    await expect(page.getByRole('button', { name: /Dark/ })).toBeVisible()
-    await expect(page.getByRole('button', { name: /Light/ })).toBeVisible()
+    // Theme chooser (palette menu)
+    await expect(page.getByRole('button', { name: 'Choose theme' })).toBeVisible()
 
     // Sliders (at least detail + zoom or font + width)
     const sliders = page.locator('input[type="range"]')
@@ -310,16 +309,18 @@ test.describe('Visual Validation', () => {
     await page.goto('/#/node/readme', { timeout: 60000 })
     await page.waitForTimeout(3000)
 
-    // Switch to light
-    await page.getByRole('button', { name: /Light/ }).click()
+    // Open the palette menu and switch to light
+    await page.getByRole('button', { name: 'Choose theme' }).click()
+    await page.getByRole('menuitemradio', { name: 'Light' }).click()
     await page.waitForTimeout(1000)
     const lightBg = await page.evaluate(() => {
       const el = document.querySelector('[class*=fui-FluentProvider]') || document.documentElement
       return getComputedStyle(el).backgroundColor
     })
 
-    // Switch to dark
-    await page.getByRole('button', { name: /Dark/ }).click()
+    // Open the palette menu and switch to dark
+    await page.getByRole('button', { name: 'Choose theme' }).click()
+    await page.getByRole('menuitemradio', { name: 'Dark' }).click()
     await page.waitForTimeout(1000)
     const darkBg = await page.evaluate(() => {
       const el = document.querySelector('[class*=fui-FluentProvider]') || document.documentElement

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -112,7 +112,7 @@ function Explorer({ themeMode, fluentTheme, isDark, setThemeMode, applyConfig, c
           theme={themeMode}
           isDark={isDark}
           availableThemes={availableThemes}
-          onThemeChange={setThemeMode as (t: import('./hooks/useTheme').ThemeMode) => void}
+          onThemeChange={setThemeMode}
           onCollapsedChange={setHudCollapsed}
           onDockChange={setHudDock}
         />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,7 +31,7 @@ function useCurrentNodeId(): string | null {
   return match ? decodeURIComponent(match[1]) : null;
 }
 
-function Explorer({ themeMode, fluentTheme, isDark, setThemeMode, applyConfig, cycleTheme }: { themeMode: import('./hooks/useTheme').ThemeMode; fluentTheme: FluentTheme; isDark: boolean; setThemeMode: (t: import('./hooks/useTheme').ThemeMode) => void; applyConfig: (theme?: import('./types').KBConfig['theme'], moduleThemes?: Record<string, FluentTheme>) => void; cycleTheme: () => void }) {
+function Explorer({ themeMode, fluentTheme, isDark, setThemeMode, applyConfig, cycleTheme, availableThemes }: { themeMode: import('./hooks/useTheme').ThemeMode; fluentTheme: FluentTheme; isDark: boolean; setThemeMode: (t: import('./hooks/useTheme').ThemeMode) => void; applyConfig: (theme?: import('./types').KBConfig['theme'], moduleThemes?: Record<string, FluentTheme>) => void; cycleTheme: () => void; availableThemes: import('./hooks/useTheme').ThemeMode[] }) {
   const state = useKnowledgeBase();
   const currentNodeId = useCurrentNodeId();
 
@@ -111,7 +111,8 @@ function Explorer({ themeMode, fluentTheme, isDark, setThemeMode, applyConfig, c
           currentNodeId={currentNodeId}
           theme={themeMode}
           isDark={isDark}
-          onThemeChange={setThemeMode as (t: import('./types').Theme) => void}
+          availableThemes={availableThemes}
+          onThemeChange={setThemeMode as (t: import('./hooks/useTheme').ThemeMode) => void}
           onCollapsedChange={setHudCollapsed}
           onDockChange={setHudDock}
         />
@@ -120,13 +121,13 @@ function Explorer({ themeMode, fluentTheme, isDark, setThemeMode, applyConfig, c
 }
 
 function App() {
-  const [themeMode, fluentTheme, setThemeMode, applyConfig, cycleTheme] = useTheme();
+  const [themeMode, fluentTheme, setThemeMode, applyConfig, cycleTheme, availableThemes] = useTheme();
   const isDark = isDarkTheme(fluentTheme);
 
   return (
     <FluentProvider theme={fluentTheme} style={{ minHeight: '100vh' }}>
       <HashRouter>
-        <Explorer themeMode={themeMode} fluentTheme={fluentTheme} isDark={isDark} setThemeMode={setThemeMode} applyConfig={applyConfig} cycleTheme={cycleTheme} />
+        <Explorer themeMode={themeMode} fluentTheme={fluentTheme} isDark={isDark} setThemeMode={setThemeMode} applyConfig={applyConfig} cycleTheme={cycleTheme} availableThemes={availableThemes} />
       </HashRouter>
     </FluentProvider>
   );

--- a/src/components/HUD.tsx
+++ b/src/components/HUD.tsx
@@ -9,6 +9,11 @@ import {
   Body1Strong,
   Caption1,
   Caption2,
+  Menu,
+  MenuTrigger,
+  MenuPopover,
+  MenuList,
+  MenuItemRadio,
 } from '@fluentui/react-components';
 import {
   ChevronLeftRegular,
@@ -22,13 +27,14 @@ import {
   WeatherMoonRegular,
   WeatherSunnyRegular,
   BookRegular,
+  ColorRegular,
   GridRegular,
   PanelBottomRegular,
   PanelLeftRegular,
   PanelRightRegular,
   PanelTopExpandRegular,
 } from '@fluentui/react-icons';
-import type { KBGraph, KBConfig, KBNode, Theme } from '../types';
+import type { KBGraph, KBConfig, KBNode } from '../types';
 import { getEdgeStyle, getEdgeLegendKey, BUILT_IN_VIEWS, filterGraphToView, collapseGraphClusters, trimGraphToLimits } from '../types';
 import type { TrimResult } from '../types';
 import type { ThemeMode } from '../hooks/useTheme';
@@ -50,7 +56,9 @@ interface HUDProps {
    * carry any key — drive minimap edge/highlight contrast correctly.
    */
   isDark: boolean;
-  onThemeChange: (theme: Theme) => void;
+  /** Full selectable theme set (built-ins + config/external/module themes). */
+  availableThemes: ThemeMode[];
+  onThemeChange: (theme: ThemeMode) => void;
   onCollapsedChange?: (collapsed: boolean) => void;
   onDockChange?: (dock: DockPosition) => void;
 }
@@ -278,7 +286,22 @@ const useStyles= makeStyles({
   },
 });
 
-export function HUD({ graph, config, currentNodeId, theme, isDark, onThemeChange, onCollapsedChange, onDockChange }: HUDProps) {
+const THEME_LABELS: Record<string, string> = { dark: 'Dark', light: 'Light', sepia: 'Sepia' };
+
+/** Human label for a theme key — known built-ins, else title-cased key. */
+function themeLabel(mode: string): string {
+  return THEME_LABELS[mode] ?? mode.replace(/[-_]+/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+/** Icon for a theme key — built-ins keep their glyph, config themes get a swatch. */
+function themeIcon(mode: string): React.ReactElement {
+  if (mode === 'dark') return <WeatherMoonRegular />;
+  if (mode === 'light') return <WeatherSunnyRegular />;
+  if (mode === 'sepia') return <BookRegular />;
+  return <ColorRegular />;
+}
+
+export function HUD({ graph, config, currentNodeId, theme, isDark, availableThemes, onThemeChange, onCollapsedChange, onDockChange }: HUDProps) {
   const styles = useStyles();
   const canvasElRef = useRef<HTMLCanvasElement | null>(null);
   const [canvasMountKey, setCanvasMountKey] = useState(0);
@@ -756,29 +779,32 @@ export function HUD({ graph, config, currentNodeId, theme, isDark, onThemeChange
   const expandIcon = dock === 'top' ? <ChevronDownRegular /> : dock === 'left' ? <ChevronRightRegular /> : dock === 'right' ? <ChevronLeftRegular /> : <ChevronUpRegular />;
 
   const themeButtons = (
-    <>
-      <Button
-        appearance={theme === 'dark' ? 'primary' : 'subtle'}
-        size="small"
-        icon={<WeatherMoonRegular />}
-        onClick={() => onThemeChange('dark')}
-        title="Dark"
-      />
-      <Button
-        appearance={theme === 'light' ? 'primary' : 'subtle'}
-        size="small"
-        icon={<WeatherSunnyRegular />}
-        onClick={() => onThemeChange('light')}
-        title="Light"
-      />
-      <Button
-        appearance={theme === 'sepia' ? 'primary' : 'subtle'}
-        size="small"
-        icon={<BookRegular />}
-        onClick={() => onThemeChange('sepia')}
-        title="Sepia"
-      />
-    </>
+    <Menu
+      checkedValues={{ theme: [theme] }}
+      onCheckedValueChange={(_e, data) => {
+        const next = data.checkedItems[0];
+        if (next) onThemeChange(next as ThemeMode);
+      }}
+    >
+      <MenuTrigger disableButtonEnhancement>
+        <Button
+          appearance="subtle"
+          size="small"
+          icon={themeIcon(theme)}
+          title={`Theme: ${themeLabel(theme)}`}
+          aria-label="Choose theme"
+        />
+      </MenuTrigger>
+      <MenuPopover>
+        <MenuList>
+          {availableThemes.map((m) => (
+            <MenuItemRadio key={m} name="theme" value={m} icon={themeIcon(m)}>
+              {themeLabel(m)}
+            </MenuItemRadio>
+          ))}
+        </MenuList>
+      </MenuPopover>
+    </Menu>
   );
 
   const nodeTitle = currentNode?.title ?? config.title;

--- a/src/components/HUD.tsx
+++ b/src/components/HUD.tsx
@@ -790,7 +790,7 @@ export function HUD({ graph, config, currentNodeId, theme, isDark, availableThem
         <Button
           appearance="subtle"
           size="small"
-          icon={themeIcon(theme)}
+          icon={<ColorRegular />}
           title={`Theme: ${themeLabel(theme)}`}
           aria-label="Choose theme"
         />

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -239,6 +239,7 @@ export function useTheme(): [
   (t: ThemeMode) => void,
   (theme?: KBConfig['theme'], moduleThemes?: Record<string, FluentTheme>) => void,
   () => void,
+  ThemeMode[],
 ] {
   const [mode, setModeState] = useState<ThemeMode>(() => readStored());
   const [themeMap, setThemeMap] = useState<Record<string, FluentTheme>>(BUILTIN_THEME_MAP);
@@ -290,7 +291,11 @@ export function useTheme(): [
   const fluentTheme =
     themeMap[mode] ?? (BUILTIN_THEME_MAP as Record<string, FluentTheme>)[mode] ?? webDarkTheme;
 
-  return [mode, fluentTheme, setMode, applyConfig, cycleTheme];
+  // The full selectable set (built-ins first, then config/external/module
+  // themes) so the UI can render a theme chooser, not just the `t` cycle.
+  const availableModes = modesForMap(themeMap);
+
+  return [mode, fluentTheme, setMode, applyConfig, cycleTheme, availableModes];
 }
 
 /**


### PR DESCRIPTION
## What

The HUD previously exposed only three hardcoded **dark / light / sepia** buttons, so any config-defined, external-file, or JS-module theme was reachable **only** via the `t` keyboard cycle — with no visible affordance. This adds a clickable **paint-palette menu** in the HUD that lists *every* available theme.

## Changes

- **`useTheme.ts`** — now returns the live selectable mode list (`modesForMap(themeMap)`) as a 6th tuple element, so the UI knows the full dynamic set (built-ins + config + external-file + module themes).
- **`HUD.tsx`** — replaces the three fixed buttons with a Fluent `Menu` of `MenuItemRadio` items (one per theme), triggered by a `Color` palette-icon button. The active theme is checked; selection routes through `onThemeChange` (persisted to `kbe-theme`). Built-ins keep their moon/sun/book glyphs; named themes get a swatch icon and a title-cased label. `onThemeChange` widened from `Theme` to `ThemeMode`.
- **`App.tsx`** — threads `availableThemes` through to the HUD.
- **Docs** — `theming-named-themes.md` and `theming-overview.md` now describe the palette chooser alongside the `t` shortcut.

No cache/config-shape change, so `CACHE_VERSION` is unchanged (`kbe-theme` already existed).

## Validation

- `npx tsc -b` ✓, `npm run lint` 0 errors (only the pre-existing HUD `exhaustive-deps` warning), `npx vitest run` 443 passed, `npm run build` ✓, `npm run validate` 0/0.
- **Playwright (local mode):** palette menu lists all 8 themes `["Dark","Light","Sepia","Ocean","Rose","Midnight","Forest","Sandstone"]`; picking *Ocean* persists `kbe-theme=ocean`, picking *Light* persists `light`; zero console errors.

Closes #221