### PR TITLE
docs: mention HUD theme palette chooser alongside the t shortcut

### DIFF
--- a/content/wiki-getting-started.md
+++ b/content/wiki-getting-started.md
@@ -45,7 +45,7 @@ Vite starts on `http://localhost:5173`. The [Vite configuration](vite-config) au
 
 - Open the browser — land on the [overview grid](overview-view)
 - Click a card to enter the [reading view](reading-view)
-- Press `t` to try different [themes](theme-system)
+- Pick a theme from the paint-palette menu in the [HUD](hud) — or press `t` to cycle [themes](theme-system)
 - Open the [HUD](hud) minimap to see the full constellation
 
 ## Troubleshooting

--- a/content/wiki-hud-system.md
+++ b/content/wiki-hud-system.md
@@ -29,6 +29,9 @@ Click cluster label to collapse all nodes into one summary node. The [node rende
 
 Drag to any screen edge. The [style system](style-system) adapts layout. Persists in localStorage. Added in PR #28 alongside depth controls.
 
+The HUD also has a paint-palette menu that lists every available theme (built-ins
+plus any host-repo themes) for direct selection.
+
 ## Keyboard
 
 Press `t` to cycle [themes](theme-system), arrows to navigate nodes — handled by [keyboard navigation](keyboard-nav).

--- a/content/wiki-theming.md
+++ b/content/wiki-theming.md
@@ -11,14 +11,16 @@ Three built-in visual themes ship with the app, and your host repo can add more.
 
 ## Available Themes
 
-| Theme | Shortcut | Best For |
-|-------|----------|----------|
-| **Dark** | `t` to cycle | Code reading, low light |
-| **Light** | `t` to cycle | Bright environments, presentations |
-| **Sepia** | `t` to cycle | Extended reading, reduced eye strain |
+| Theme | How to switch | Best For |
+|-------|---------------|----------|
+| **Dark** | palette menu or `t` | Code reading, low light |
+| **Light** | palette menu or `t` | Bright environments, presentations |
+| **Sepia** | palette menu or `t` | Extended reading, reduced eye strain |
 
 Named themes defined in `config.yaml` (see [External Theming](theming-overview))
-join the same `t` cycle after the built-ins.
+join the same list. Switch between any of them from the **paint-palette menu**
+in the HUD (it lists every available theme with the active one checked), or press
+**`t`** to cycle through them.
 
 ## How Themes Propagate
 
@@ -40,7 +42,8 @@ colorNeutralForeground1: '#2A2520'  // warm dark text
 You no longer need to edit the `.kbexplorer` submodule to restyle the site.
 Everything is driven from your host repo's `config.yaml` (plus optional companion
 files). The fastest path: add a `theme.brand` seed to recolor the whole app, or
-add entries under `theme.themes` to grow the `t` cycle with your own variants.
+add entries under `theme.themes` to grow the palette menu (and the `t` cycle)
+with your own variants.
 
 See **[External Theming](theming-overview)** for the full picture:
 [brand, tokens & named themes](theming-named-themes),

--- a/content/wiki-theming.md
+++ b/content/wiki-theming.md
@@ -13,9 +13,9 @@ Three built-in visual themes ship with the app, and your host repo can add more.
 
 | Theme | How to switch | Best For |
 |-------|---------------|----------|
-| **Dark** | palette menu or `t` | Code reading, low light |
-| **Light** | palette menu or `t` | Bright environments, presentations |
-| **Sepia** | palette menu or `t` | Extended reading, reduced eye strain |
+| **Dark** | paint-palette menu or `t` | Code reading, low light |
+| **Light** | paint-palette menu or `t` | Bright environments, presentations |
+| **Sepia** | paint-palette menu or `t` | Extended reading, reduced eye strain |
 
 Named themes defined in `config.yaml` (see [External Theming](theming-overview))
 join the same list. Switch between any of them from the **paint-palette menu**
@@ -42,7 +42,7 @@ colorNeutralForeground1: '#2A2520'  // warm dark text
 You no longer need to edit the `.kbexplorer` submodule to restyle the site.
 Everything is driven from your host repo's `config.yaml` (plus optional companion
 files). The fastest path: add a `theme.brand` seed to recolor the whole app, or
-add entries under `theme.themes` to grow the palette menu (and the `t` cycle)
+add entries under `theme.themes` to grow the paint-palette menu (and the `t` cycle)
 with your own variants.
 
 See **[External Theming](theming-overview)** for the full picture:


### PR DESCRIPTION
Follow-up to PR #222 (the HUD theme palette chooser). Several content docs still described theme switching as `t`-cycle only; this updates them to mention the new clickable paint-palette menu so users discover it.

- wiki-theming.md, wiki-getting-started.md, wiki-hud-system.md now reference the palette menu.

Docs-only. npm run validate -> 0 warnings, 0 errors.

Closes #230