### PR TITLE
feat(engine): person nodes aggregating active work

### DIFF
--- a/src/api/github.ts
+++ b/src/api/github.ts
@@ -123,6 +123,8 @@ export interface GHIssue {
   state: string;
   labels: Array<{ name: string; color: string }>;
   assignees: Array<{ login: string }>;
+  /** The GitHub user who opened the issue (author). */
+  user?: { login: string };
   html_url: string;
   created_at: string;
   updated_at: string;

--- a/src/engine/__tests__/providers/person-provider.test.ts
+++ b/src/engine/__tests__/providers/person-provider.test.ts
@@ -1,0 +1,330 @@
+/**
+ * Tests for PersonProvider — derivation of person nodes from GitHub work data.
+ *
+ * Covers:
+ * - Person node materialized from an assignee on an open issue
+ * - Person node materialized from an author (user.login) on an open issue
+ * - Person node materialized from open PR assignee / author
+ * - Closed issues / PRs are NOT counted toward threshold
+ * - Threshold: login with < minActiveItems active items produces no node
+ * - No duplicate when a content-model descriptor exists with matching alias
+ *   (descriptor node receives connections to active items instead)
+ * - Zero-people graphs: no active items → no person nodes
+ * - Identity URN is `urn:person:<login>`
+ * - Edges are emitted person → issue/PR with correct `relation` value
+ */
+import { describe, it, expect } from 'vitest';
+import { PersonProvider } from '../../providers/person-provider';
+import type { GHIssue } from '../../../api';
+import type { KBConfig, KBNode } from '../../../types';
+import { DEFAULT_CONFIG } from '../../../types';
+
+const config: KBConfig = DEFAULT_CONFIG;
+
+function makeIssue(overrides: Partial<GHIssue> & { userLogin?: string } = {}): GHIssue {
+  const { userLogin, ...rest } = overrides;
+  return {
+    number: 1,
+    title: 'Test issue',
+    body: null,
+    state: 'open',
+    labels: [{ name: 'feature', color: '4A9CC8' }],
+    assignees: [],
+    user: userLogin ? { login: userLogin } : undefined,
+    html_url: 'https://github.com/test/repo/issues/1',
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-02T00:00:00Z',
+    ...rest,
+  };
+}
+
+function makePR(overrides: { number?: number; state?: string; userLogin?: string; assignees?: Array<{ login: string }> } = {}) {
+  return {
+    number: overrides.number ?? 10,
+    title: `PR #${overrides.number ?? 10}`,
+    state: overrides.state ?? 'open',
+    html_url: `https://github.com/test/repo/pull/${overrides.number ?? 10}`,
+    user: overrides.userLogin ? { login: overrides.userLogin } : undefined,
+    assignees: overrides.assignees ?? [],
+  };
+}
+
+/** Build a minimal descriptor KBNode mimicking a content-model person node. */
+function makeDescriptor(alias: string, id = alias): KBNode {
+  return {
+    id: `urn:people/${id}`,
+    title: alias,
+    cluster: 'person',
+    content: '',
+    rawContent: '',
+    connections: [],
+    source: { type: 'structured', entityType: 'person', ref: id },
+    entityType: 'person',
+    data: { id, alias, name: alias },
+  };
+}
+
+describe('PersonProvider', () => {
+  describe('derivation from open issues', () => {
+    it('creates a person node for an assignee on an open issue', async () => {
+      const issue = makeIssue({ number: 1, assignees: [{ login: 'adaops' }] });
+      const provider = new PersonProvider([issue], []);
+      const { nodes } = await provider.resolve(config, []);
+
+      const personNode = nodes.find(n => n.id === 'person-adaops');
+      expect(personNode).toBeDefined();
+      expect(personNode!.source.type).toBe('person');
+    });
+
+    it('creates a person node for the author (user.login) of an open issue', async () => {
+      const issue = makeIssue({ number: 2, userLogin: 'bendev' });
+      const provider = new PersonProvider([issue], []);
+      const { nodes } = await provider.resolve(config, []);
+
+      expect(nodes.find(n => n.id === 'person-bendev')).toBeDefined();
+    });
+
+    it('ignores closed issues when computing active count', async () => {
+      const openIssue = makeIssue({ number: 1, state: 'open', assignees: [{ login: 'closeduser' }] });
+      const closedIssue = makeIssue({ number: 2, state: 'closed', assignees: [{ login: 'closeduser' }] });
+      // minActiveItems default is 1 — the open issue alone qualifies
+      const provider = new PersonProvider([openIssue, closedIssue], []);
+      const { nodes } = await provider.resolve(config, []);
+
+      expect(nodes.find(n => n.id === 'person-closeduser')).toBeDefined();
+    });
+
+    it('does NOT create a person node when all matching issues are closed', async () => {
+      const closedIssue = makeIssue({ number: 3, state: 'closed', assignees: [{ login: 'driveby' }] });
+      const provider = new PersonProvider([closedIssue], []);
+      const { nodes } = await provider.resolve(config, []);
+
+      expect(nodes.find(n => n.id === 'person-driveby')).toBeUndefined();
+    });
+  });
+
+  describe('derivation from open PRs', () => {
+    it('creates a person node for a PR assignee', async () => {
+      const pr = makePR({ number: 5, assignees: [{ login: 'prassignee' }] });
+      const provider = new PersonProvider([], [pr]);
+      const { nodes } = await provider.resolve(config, []);
+
+      expect(nodes.find(n => n.id === 'person-prassignee')).toBeDefined();
+    });
+
+    it('creates a person node for a PR author (user.login)', async () => {
+      const pr = makePR({ number: 6, userLogin: 'prauthor' });
+      const provider = new PersonProvider([], [pr]);
+      const { nodes } = await provider.resolve(config, []);
+
+      expect(nodes.find(n => n.id === 'person-prauthor')).toBeDefined();
+    });
+
+    it('ignores closed PRs', async () => {
+      const closedPR = makePR({ number: 7, state: 'closed', userLogin: 'closedpr' });
+      const provider = new PersonProvider([], [closedPR]);
+      const { nodes } = await provider.resolve(config, []);
+
+      expect(nodes.find(n => n.id === 'person-closedpr')).toBeUndefined();
+    });
+  });
+
+  describe('threshold (minActiveItems)', () => {
+    it('respects minActiveItems = 1 (default): single active item qualifies', async () => {
+      const issue = makeIssue({ number: 1, assignees: [{ login: 'singleitem' }] });
+      const provider = new PersonProvider([issue], []);
+      const { nodes } = await provider.resolve(config, []);
+
+      expect(nodes.find(n => n.id === 'person-singleitem')).toBeDefined();
+    });
+
+    it('respects minActiveItems = 2: login with only 1 active item is excluded', async () => {
+      const issue = makeIssue({ number: 1, assignees: [{ login: 'driveby' }] });
+      const provider = new PersonProvider([issue], []);
+      const configWith2 = { ...config, people: { minActiveItems: 2 } };
+      const { nodes } = await provider.resolve(configWith2, []);
+
+      expect(nodes.find(n => n.id === 'person-driveby')).toBeUndefined();
+    });
+
+    it('respects minActiveItems = 2: login with 2+ items is included', async () => {
+      const issue1 = makeIssue({ number: 1, assignees: [{ login: 'active' }] });
+      const issue2 = makeIssue({ number: 2, assignees: [{ login: 'active' }] });
+      const provider = new PersonProvider([issue1, issue2], []);
+      const configWith2 = { ...config, people: { minActiveItems: 2 } };
+      const { nodes } = await provider.resolve(configWith2, []);
+
+      expect(nodes.find(n => n.id === 'person-active')).toBeDefined();
+    });
+  });
+
+  describe('descriptor-linking (no duplicate)', () => {
+    it('does NOT emit a new person node when a descriptor with matching alias exists', async () => {
+      const issue = makeIssue({ number: 1, assignees: [{ login: 'aokonkwo' }] });
+      const descriptor = makeDescriptor('aokonkwo', 'ada');
+      const provider = new PersonProvider([issue], []);
+      const { nodes } = await provider.resolve(config, [descriptor]);
+
+      // No new node for login 'aokonkwo'
+      expect(nodes.find(n => n.id === 'person-aokonkwo')).toBeUndefined();
+    });
+
+    it('enriches the descriptor node with connections to active items', async () => {
+      const issue = makeIssue({ number: 5, assignees: [{ login: 'aokonkwo' }] });
+      const descriptor = makeDescriptor('aokonkwo', 'ada');
+      const provider = new PersonProvider([issue], []);
+      await provider.resolve(config, [descriptor]);
+
+      expect(descriptor.connections.some(c => c.to === 'issue-5')).toBe(true);
+    });
+
+    it('emits edges from the descriptor id to its active items', async () => {
+      const issue = makeIssue({ number: 7, assignees: [{ login: 'bcarter' }] });
+      const descriptor = makeDescriptor('bcarter', 'ben');
+      const provider = new PersonProvider([issue], []);
+      const { edges } = await provider.resolve(config, [descriptor]);
+
+      const edge = edges.find(e => e.from === descriptor.id && e.to === 'issue-7');
+      expect(edge).toBeDefined();
+      expect(edge!.relation).toBe('assigned-to');
+    });
+
+    it('does not add duplicate connections to descriptor when resolve is called twice', async () => {
+      const issue = makeIssue({ number: 3, assignees: [{ login: 'aokonkwo' }] });
+      const descriptor = makeDescriptor('aokonkwo', 'ada');
+      const provider = new PersonProvider([issue], []);
+      await provider.resolve(config, [descriptor]);
+      await provider.resolve(config, [descriptor]);
+
+      const conns = descriptor.connections.filter(c => c.to === 'issue-3');
+      // Should appear only once
+      expect(conns).toHaveLength(1);
+    });
+  });
+
+  describe('identity URNs', () => {
+    it('assigns urn:person:<login> as identity URN', async () => {
+      const issue = makeIssue({ number: 1, assignees: [{ login: 'testlogin' }] });
+      const provider = new PersonProvider([issue], []);
+      const { nodes } = await provider.resolve(config, []);
+
+      const node = nodes.find(n => n.id === 'person-testlogin');
+      expect(node!.identity).toBe('urn:person:testlogin');
+    });
+  });
+
+  describe('edges', () => {
+    it('emits a "assigned-to" edge from person to assigned issue', async () => {
+      const issue = makeIssue({ number: 10, assignees: [{ login: 'worker' }] });
+      const provider = new PersonProvider([issue], []);
+      const { edges } = await provider.resolve(config, []);
+
+      const edge = edges.find(e => e.from === 'person-worker' && e.to === 'issue-10');
+      expect(edge).toBeDefined();
+      expect(edge!.relation).toBe('assigned-to');
+    });
+
+    it('emits an "authored" edge from person to authored issue', async () => {
+      const issue = makeIssue({ number: 11, userLogin: 'author' });
+      const provider = new PersonProvider([issue], []);
+      const { edges } = await provider.resolve(config, []);
+
+      const edge = edges.find(e => e.from === 'person-author' && e.to === 'issue-11');
+      expect(edge).toBeDefined();
+      expect(edge!.relation).toBe('authored');
+    });
+
+    it('emits a "assigned-to" edge for assigned open PR', async () => {
+      const pr = makePR({ number: 20, assignees: [{ login: 'prassignee' }] });
+      const provider = new PersonProvider([], [pr]);
+      const { edges } = await provider.resolve(config, []);
+
+      const edge = edges.find(e => e.from === 'person-prassignee' && e.to === 'pr-20');
+      expect(edge).toBeDefined();
+      expect(edge!.relation).toBe('assigned-to');
+    });
+  });
+
+  describe('zero-people graphs', () => {
+    it('returns no nodes or edges when there are no open issues or PRs', async () => {
+      const provider = new PersonProvider([], []);
+      const { nodes, edges } = await provider.resolve(config, []);
+
+      expect(nodes).toHaveLength(0);
+      expect(edges).toHaveLength(0);
+    });
+
+    it('returns no nodes when all issues are closed', async () => {
+      const closedIssue = makeIssue({ state: 'closed' });
+      const provider = new PersonProvider([closedIssue], []);
+      const { nodes } = await provider.resolve(config, []);
+
+      expect(nodes).toHaveLength(0);
+    });
+  });
+
+  describe('data bag', () => {
+    it('populates data.login with the GitHub login', async () => {
+      const issue = makeIssue({ number: 1, assignees: [{ login: 'dataperson' }] });
+      const provider = new PersonProvider([issue], []);
+      const { nodes } = await provider.resolve(config, []);
+
+      const node = nodes.find(n => n.id === 'person-dataperson');
+      expect(node!.data?.login).toBe('dataperson');
+    });
+
+    it('populates data.activeIssues with the active issue list', async () => {
+      const issue = makeIssue({ number: 42, title: 'Big feature', assignees: [{ login: 'researcher' }] });
+      const provider = new PersonProvider([issue], []);
+      const { nodes } = await provider.resolve(config, []);
+
+      const node = nodes.find(n => n.id === 'person-researcher');
+      const issues = node!.data?.activeIssues as Array<{ number: number; title: string }>;
+      expect(issues).toHaveLength(1);
+      expect(issues[0]).toEqual({ number: 42, title: 'Big feature' });
+    });
+
+    it('deduplicates: issue appears only once even if same login is both author and assignee', async () => {
+      const issue = makeIssue({
+        number: 99,
+        userLogin: 'multihat',
+        assignees: [{ login: 'multihat' }],
+      });
+      const provider = new PersonProvider([issue], []);
+      const { nodes } = await provider.resolve(config, []);
+
+      const node = nodes.find(n => n.id === 'person-multihat');
+      const issues = node!.data?.activeIssues as Array<{ number: number }>;
+      expect(issues).toHaveLength(1);
+    });
+  });
+
+  describe('provider metadata', () => {
+    it('tags person nodes with provider: person', async () => {
+      const issue = makeIssue({ number: 1, assignees: [{ login: 'tagged' }] });
+      const provider = new PersonProvider([issue], []);
+      const { nodes } = await provider.resolve(config, []);
+
+      const node = nodes.find(n => n.id === 'person-tagged');
+      expect(node!.provider).toBe('person');
+    });
+
+    it('tags person nodes with entityType: person', async () => {
+      const issue = makeIssue({ number: 1, assignees: [{ login: 'entitytag' }] });
+      const provider = new PersonProvider([issue], []);
+      const { nodes } = await provider.resolve(config, []);
+
+      const node = nodes.find(n => n.id === 'person-entitytag');
+      expect(node!.entityType).toBe('person');
+    });
+
+    it('places person nodes in the "person" cluster', async () => {
+      const issue = makeIssue({ number: 1, assignees: [{ login: 'clustered' }] });
+      const provider = new PersonProvider([issue], []);
+      const { nodes } = await provider.resolve(config, []);
+
+      const node = nodes.find(n => n.id === 'person-clustered');
+      expect(node!.cluster).toBe('person');
+    });
+  });
+});

--- a/src/engine/identity.ts
+++ b/src/engine/identity.ts
@@ -13,6 +13,7 @@ export function assignIdentity(node: KBNode): string | undefined {
     case 'issue':      return `urn:issue:${node.source.number}`;
     case 'pull_request': return `urn:pr:${node.source.number}`;
     case 'commit':     return `urn:commit:${node.source.sha}`;
+    case 'person':     return `urn:person:${node.source.login}`;
     case 'section':    return undefined;
     default:           return undefined;
   }

--- a/src/engine/local-loader.ts
+++ b/src/engine/local-loader.ts
@@ -22,6 +22,7 @@ import { ProviderRegistry } from './providers';
 import { FilesProvider } from './providers/files-provider';
 import { AuthoredProvider } from './providers/authored-provider';
 import { WorkProvider } from './providers/work-provider';
+import { PersonProvider } from './providers/person-provider';
 import { StructuralProvider } from './providers/structural-provider';
 import { ContentModelProvider } from './providers/content-model-provider';
 import { collectProviderNodes } from './orchestrator';
@@ -374,6 +375,11 @@ async function loadLocalKnowledgeBaseV2(): Promise<{
   registry.register(
     new WorkProvider(manifest.issues, manifest.pullRequests, manifest.commits, manifest.branches ?? [], manifest.repoMetadata ?? null),
   );
+
+  // People derived from GitHub activity (#235). Local-manifest PRs do not
+  // carry author/assignees yet (kbexplorer-cli follow-up), so local-mode
+  // person derivation comes from issues; the provider tolerates the gap.
+  registry.register(new PersonProvider(manifest.issues, manifest.pullRequests));
 
   // ── Structural discovery (.github → repository node) ────
   if (manifest.structuralFiles && Object.keys(manifest.structuralFiles).length > 0) {

--- a/src/engine/node-types/__tests__/registry.test.ts
+++ b/src/engine/node-types/__tests__/registry.test.ts
@@ -86,10 +86,18 @@ describe('node-type registry (T1.2/T1.5)', () => {
   });
 
   it('resetNodeTypeRegistry drops custom types but keeps built-ins', () => {
-    registerType({ id: 'person', layer: 'work' });
+    registerType({ id: 'custom-test-kind', layer: 'work' });
+    expect(hasType('custom-test-kind')).toBe(true);
+    resetNodeTypeRegistry();
+    expect(hasType('custom-test-kind')).toBe(false);
+    expect(hasType('file')).toBe(true);
+  });
+
+  it('"person" is a built-in type (registered on import, present after reset)', () => {
+    // person is registered as a built-in since #235 so it survives resetNodeTypeRegistry
     expect(hasType('person')).toBe(true);
     resetNodeTypeRegistry();
-    expect(hasType('person')).toBe(false);
-    expect(hasType('file')).toBe(true);
+    expect(hasType('person')).toBe(true);
+    expect(resolveType('person')?.layer).toBe('work');
   });
 });

--- a/src/engine/node-types/registry.ts
+++ b/src/engine/node-types/registry.ts
@@ -65,6 +65,8 @@ const BUILT_IN_NODE_TYPES: NodeTypeDefinition[] = [
   { id: 'branch', layer: 'work', label: 'Branch' },
   { id: 'workflow', layer: 'work', label: 'Workflow' },
   { id: 'repository', layer: 'work', label: 'Repository' },
+  // Person nodes derived from GitHub activity (#235)
+  { id: 'person', layer: 'work', label: 'Person', cluster: 'person', description: 'A person derived from GitHub activity or a content-model descriptor.' },
   { id: 'file', layer: 'file', label: 'File' },
   { id: 'external', layer: 'file', label: 'External' },
 ];

--- a/src/engine/providers/person-provider.ts
+++ b/src/engine/providers/person-provider.ts
@@ -137,7 +137,13 @@ export class PersonProvider implements GraphProvider {
 
       const addConn = (to: string, relation: 'assigned-to' | 'authored') => {
         if (!seen.has(to)) {
-          connections.push({ to, relation, description: relation === 'assigned-to' ? 'Assigned to' : 'Authored' });
+          connections.push({
+            to,
+            relation,
+            description: relation === 'assigned-to' ? 'Assigned to' : 'Authored',
+            type: 'related',
+            source: 'inferred',
+          });
           seen.add(to);
         }
       };
@@ -148,7 +154,26 @@ export class PersonProvider implements GraphProvider {
       for (const pr of d.authoredPRs) addConn(`pr-${pr.number}`, 'authored');
 
       if (descriptor) {
-        // Descriptor exists: enrich it with connections to active items.
+        // Descriptor exists: enrich it with connections to active items AND
+        // the active-work data bag PersonView renders its "Active work"
+        // section from (data.activeIssues / data.activePRs).
+        const uniqueIssuesD = [
+          ...d.assignedIssues,
+          ...d.authoredIssues.filter(i => !d.assignedIssues.some(a => a.number === i.number)),
+        ];
+        const uniquePRsD = [
+          ...d.assignedPRs,
+          ...d.authoredPRs.filter(pr => !d.assignedPRs.some(a => a.number === pr.number)),
+        ];
+        descriptor.data = {
+          ...(descriptor.data ?? {}),
+          login: d.login,
+          activeIssues: uniqueIssuesD.map(i => ({ number: i.number, title: i.title })),
+          activePRs: uniquePRsD.map(pr => ({ number: pr.number, title: pr.title })),
+          activeIssueCount: uniqueIssuesD.length,
+          activePRCount: uniquePRsD.length,
+        };
+        // Enrich it with connections to active items.
         // We push these connections onto the descriptor node so the graph
         // renders edges from the descriptor person to their active items.
         // (Safe: KBNode.connections is an array we can append to.)

--- a/src/engine/providers/person-provider.ts
+++ b/src/engine/providers/person-provider.ts
@@ -1,0 +1,247 @@
+/**
+ * PersonProvider — derives first-class person nodes from GitHub work data (#235).
+ *
+ * Materialization rules:
+ *  - A GitHub login that appears as author OR assignee on ≥ `minActiveItems`
+ *    OPEN (active) issues or PRs becomes a `person` node.
+ *  - If a content-model person descriptor already exists with a matching
+ *    `alias` field equal to the login, no duplicate is created. Instead the
+ *    work-derived node is suppressed and the descriptor's identity URN is
+ *    reused by emitting connection edges from that login to their active items.
+ *    The descriptor node (from ContentModelProvider) is enriched with
+ *    connections pointing to the active items.
+ *  - Edges emitted:
+ *      person → issue/PR  (relation: 'assigned-to' or 'authored')
+ *      person → team      (when a content-model team descriptor lists the login
+ *                          in its `members` array — future: via existing data)
+ */
+import { marked } from 'marked';
+import type { GraphProvider, ProviderResult } from '../providers';
+import type { KBConfig, KBNode, KBEdge, Connection } from '../../types';
+import { assignIdentity } from '../identity';
+import type { GHIssue } from '../../api';
+
+type WorkPullRequestForPerson = {
+  number: number;
+  title: string;
+  state: string;
+  html_url: string;
+  user?: { login: string };
+  assignees?: Array<{ login: string }>;
+};
+
+export type PersonProviderPR = WorkPullRequestForPerson;
+
+/** Minimum number of active items before a person node materializes. */
+const DEFAULT_MIN_ACTIVE_ITEMS = 1;
+
+interface PersonData {
+  login: string;
+  /** Assigned open issues */
+  assignedIssues: GHIssue[];
+  /** Authored open issues (user.login matches) */
+  authoredIssues: GHIssue[];
+  /** Assigned open PRs */
+  assignedPRs: PersonProviderPR[];
+  /** Authored open PRs */
+  authoredPRs: PersonProviderPR[];
+}
+
+export class PersonProvider implements GraphProvider {
+  id = 'person';
+  name = 'People';
+  /**
+   * Run after work so we can match existing nodes; run after content-model
+   * so we can link to descriptor people.
+   */
+  dependencies: string[] = ['work', 'content-model'];
+
+  private issues: GHIssue[];
+  private pullRequests: PersonProviderPR[];
+
+  constructor(issues: GHIssue[], pullRequests: PersonProviderPR[]) {
+    this.issues = issues;
+    this.pullRequests = pullRequests;
+  }
+
+  async resolve(config: KBConfig, existingNodes: KBNode[]): Promise<ProviderResult> {
+    const minActive = config.people?.minActiveItems ?? DEFAULT_MIN_ACTIVE_ITEMS;
+
+    // ── 1. Collect active (open) items per login ──────────────
+    const byLogin = new Map<string, PersonData>();
+
+    function ensureLogin(login: string): PersonData {
+      let d = byLogin.get(login);
+      if (!d) {
+        d = { login, assignedIssues: [], authoredIssues: [], assignedPRs: [], authoredPRs: [] };
+        byLogin.set(login, d);
+      }
+      return d;
+    }
+
+    for (const issue of this.issues) {
+      if (issue.state !== 'open') continue;
+      for (const a of issue.assignees ?? []) {
+        ensureLogin(a.login).assignedIssues.push(issue);
+      }
+      if (issue.user?.login) {
+        ensureLogin(issue.user.login).authoredIssues.push(issue);
+      }
+    }
+
+    for (const pr of this.pullRequests) {
+      if (pr.state !== 'open') continue;
+      for (const a of pr.assignees ?? []) {
+        ensureLogin(a.login).assignedPRs.push(pr);
+      }
+      if (pr.user?.login) {
+        ensureLogin(pr.user.login).authoredPRs.push(pr);
+      }
+    }
+
+    // ── 2. Apply threshold ────────────────────────────────────
+    const qualifying = [...byLogin.values()].filter(d => {
+      const activeCount =
+        d.assignedIssues.length +
+        d.authoredIssues.length +
+        d.assignedPRs.length +
+        d.authoredPRs.length;
+      return activeCount >= minActive;
+    });
+
+    if (qualifying.length === 0) return { nodes: [], edges: [] };
+
+    // ── 3. Build an index of content-model person descriptors ─
+    //   index: alias (login handle) → existing node
+    const descriptorByAlias = new Map<string, KBNode>();
+    for (const n of existingNodes) {
+      if (n.entityType === 'person' || n.source.type === 'structured' && (n.source as { entityType: string }).entityType === 'person') {
+        const alias = n.data?.alias as string | undefined;
+        if (alias) descriptorByAlias.set(alias.toLowerCase(), n);
+        // Also index by the descriptor's own `id` for completeness
+        const descId = n.data?.id as string | undefined;
+        if (descId) descriptorByAlias.set(descId.toLowerCase(), n);
+      }
+    }
+
+    const nodes: KBNode[] = [];
+    const edges: KBEdge[] = [];
+
+    for (const d of qualifying) {
+      const loginLower = d.login.toLowerCase();
+      const descriptor = descriptorByAlias.get(loginLower);
+
+      // Build connections (edges from person → active items)
+      const connections: Connection[] = [];
+      const seen = new Set<string>();
+
+      const addConn = (to: string, relation: 'assigned-to' | 'authored') => {
+        if (!seen.has(to)) {
+          connections.push({ to, relation, description: relation === 'assigned-to' ? 'Assigned to' : 'Authored' });
+          seen.add(to);
+        }
+      };
+
+      for (const issue of d.assignedIssues) addConn(`issue-${issue.number}`, 'assigned-to');
+      for (const issue of d.authoredIssues) addConn(`issue-${issue.number}`, 'authored');
+      for (const pr of d.assignedPRs) addConn(`pr-${pr.number}`, 'assigned-to');
+      for (const pr of d.authoredPRs) addConn(`pr-${pr.number}`, 'authored');
+
+      if (descriptor) {
+        // Descriptor exists: enrich it with connections to active items.
+        // We push these connections onto the descriptor node so the graph
+        // renders edges from the descriptor person to their active items.
+        // (Safe: KBNode.connections is an array we can append to.)
+        for (const conn of connections) {
+          const alreadyPresent = descriptor.connections.some(c => c.to === conn.to);
+          if (!alreadyPresent) descriptor.connections.push(conn);
+        }
+        // Emit KBEdge entries for the orchestrator's edge set
+        for (const conn of connections) {
+          edges.push({
+            from: descriptor.id,
+            to: conn.to,
+            type: 'related',
+            relation: conn.relation,
+            description: conn.description ?? '',
+            source: 'inferred',
+            weight: 1.5,
+          });
+        }
+        // No new node — descriptor is the canonical representation
+        continue;
+      }
+
+      // ── No descriptor: mint a work-derived person node ────────
+      // Deduplicated issue/PR lists (author OR assignee, deduped by number)
+      const uniqueIssues = [
+        ...d.assignedIssues,
+        ...d.authoredIssues.filter(i => !d.assignedIssues.some(a => a.number === i.number)),
+      ];
+      const uniquePRs = [
+        ...d.assignedPRs,
+        ...d.authoredPRs.filter(p => !d.assignedPRs.some(a => a.number === p.number)),
+      ];
+
+      const issueLines = uniqueIssues.map(i =>
+        `- [#${i.number}: ${i.title}](issue-${i.number}) *(issue)*`
+      );
+      const prLines = uniquePRs.map(p =>
+        `- [#${p.number}: ${p.title}](pr-${p.number}) *(PR)*`
+      );
+
+      const allLines = [...issueLines, ...prLines];
+      const rawContent = [
+        `## @${d.login}`,
+        '',
+        `**GitHub login:** \`${d.login}\``,
+        '',
+        `### Active work (${allLines.length} item${allLines.length !== 1 ? 's' : ''})`,
+        '',
+        ...allLines,
+      ].join('\n');
+      const content = marked.parse(rawContent, { async: false }) as string;
+
+      const nodeId = `person-${d.login}`;
+      const personNode: KBNode = {
+        id: nodeId,
+        title: `@${d.login}`,
+        cluster: 'person',
+        content,
+        rawContent,
+        emoji: 'Person',
+        display: 'entity',
+        connections,
+        source: { type: 'person', login: d.login, linked: false },
+        provider: 'person',
+        entityType: 'person',
+        derived: true,
+        data: {
+          login: d.login,
+          activeIssues: uniqueIssues.map(i => ({ number: i.number, title: i.title })),
+          activePRs: uniquePRs.map(p => ({ number: p.number, title: p.title })),
+          activeIssueCount: uniqueIssues.length,
+          activePRCount: uniquePRs.length,
+        },
+      };
+      personNode.identity = assignIdentity(personNode);
+
+      nodes.push(personNode);
+
+      // Emit KBEdge entries
+      for (const conn of connections) {
+        edges.push({
+          from: nodeId,
+          to: conn.to,
+          type: 'related',
+          relation: conn.relation,
+          description: conn.description ?? '',
+          source: 'inferred',
+          weight: 1.5,
+        });
+      }
+    }
+
+    return { nodes, edges };
+  }
+}

--- a/src/engine/providers/work-provider.ts
+++ b/src/engine/providers/work-provider.ts
@@ -21,6 +21,8 @@ type WorkPullRequest = {
   created_at: string;
   updated_at: string;
   head_branch?: string;
+  /** GitHub user who opened the pull request. */
+  user?: { login: string };
 };
 
 type WorkCommit = {

--- a/src/engine/remote-loader.ts
+++ b/src/engine/remote-loader.ts
@@ -32,6 +32,7 @@ import { ProviderRegistry } from './providers'
 import { FilesProvider } from './providers/files-provider'
 import { AuthoredProvider } from './providers/authored-provider'
 import { WorkProvider } from './providers/work-provider'
+import { PersonProvider } from './providers/person-provider'
 import { StructuralProvider } from './providers/structural-provider'
 import { ContentModelProvider } from './providers/content-model-provider'
 import { collectProviderNodes } from './orchestrator'
@@ -190,6 +191,20 @@ export async function loadRemoteKnowledgeBase(
   }))
 
   registry.register(new WorkProvider(data.issues, shapedPRs, data.commits))
+
+  // People derived from GitHub activity (#235) — author/assignee data comes
+  // straight off the API responses.
+  registry.register(new PersonProvider(
+    data.issues,
+    data.pullRequests.map(pr => ({
+      number: pr.number,
+      title: pr.title,
+      state: pr.state,
+      html_url: pr.html_url,
+      user: pr.user,
+      assignees: pr.assignees,
+    })),
+  ))
 
   // ── Structural discovery (.github → repository node) ────
   if (Object.keys(data.structuralFiles).length > 0) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -230,7 +230,11 @@ export type KnownRelation =
   // Work-graph organizational-layer relations (#233)
   | 'owns'
   | 'has-priority'
-  | 'tracked-in';
+  | 'tracked-in'
+  // Person-node active-work relations (#235)
+  | 'assigned-to'
+  | 'authored'
+  | 'member-of';
 
 /** Default weights per edge type — higher = tighter layout clustering */
 export const EDGE_TYPE_WEIGHTS: Record<KnownEdgeType, number> = {
@@ -279,6 +283,10 @@ export const RELATION_STYLES: Record<KnownRelation, EdgeTypeStyle> = {
   owns:             { color: '#4A9CC8', dashes: false,     width: 2,   label: 'Owns' },
   'has-priority':   { color: '#E8A838', dashes: [4, 3],    width: 1.8, label: 'Has priority' },
   'tracked-in':     { color: '#a371f7', dashes: [6, 3],    width: 1.5, label: 'Tracked in' },
+  // Person-node active-work relations (#235)
+  'assigned-to':    { color: '#56d364', dashes: false,     width: 1.8, label: 'Assigned to' },
+  'authored':       { color: '#79c0ff', dashes: [4, 3],    width: 1.5, label: 'Authored' },
+  'member-of':      { color: '#f0883e', dashes: false,     width: 1.8, label: 'Member of' },
 };
 
 const DEFAULT_RELATION_STYLE: EdgeTypeStyle = { color: '#79c0ff', dashes: [2, 2], width: 1.5, label: 'Related' };
@@ -500,7 +508,7 @@ export const BUILT_IN_VIEWS: GraphView[] = [
     color: '#d29922',
     resolve: (graph) => filterByPredicate(graph, n => {
       const t = n.source.type
-      return t === 'issue' || t === 'pull_request' || t === 'commit' || t === 'branch' || t === 'workflow' || t === 'repository'
+      return t === 'issue' || t === 'pull_request' || t === 'commit' || t === 'branch' || t === 'workflow' || t === 'repository' || t === 'person'
     }),
   },
   {
@@ -841,7 +849,14 @@ export type NodeSource =
    * requiring a bespoke `NodeSource` variant. `ref` optionally records the
    * upstream record id the node was mapped from.
    */
-  | { type: 'structured'; entityType: string; ref?: string };
+  | { type: 'structured'; entityType: string; ref?: string }
+  /**
+   * A person node derived from GitHub activity (author/assignee on active
+   * issues / PRs). When a content-model person descriptor matches (same
+   * alias/login), `linked` is set to true and the identity URN is reused
+   * from the descriptor rather than minted fresh.
+   */
+  | { type: 'person'; login: string; linked: boolean };
 
 /** Optional site branding assets (logo, favicon, etc.). All fields optional/additive. */
 export interface BrandingConfig {
@@ -1015,6 +1030,22 @@ export interface KBConfig {
   };
   branding?: BrandingConfig;
   providers?: ExternalProviderConfig[];
+  /**
+   * Person-node derivation settings (#235).
+   *
+   * Controls whether and how work-derived person nodes are materialized from
+   * GitHub activity. Person nodes appear for every GitHub login that is an
+   * author or assignee on at least `minActiveItems` open issues or PRs.
+   * Set `minActiveItems` to a higher value to exclude drive-by contributors.
+   */
+  people?: {
+    /**
+     * Minimum number of active (open) items a GitHub login must appear on
+     * (as author or assignee) before a person node is materialized.
+     * Default: 1.
+     */
+    minActiveItems?: number;
+  };
   bluf?: {
     audio?: string;
     quote?: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -508,6 +508,7 @@ export const BUILT_IN_VIEWS: GraphView[] = [
     color: '#d29922',
     resolve: (graph) => filterByPredicate(graph, n => {
       const t = n.source.type
+      if (t === 'structured' && n.entityType === 'person') return true
       return t === 'issue' || t === 'pull_request' || t === 'commit' || t === 'branch' || t === 'workflow' || t === 'repository' || t === 'release' || t === 'person'
     }),
   },

--- a/src/views/viewers/PersonView.tsx
+++ b/src/views/viewers/PersonView.tsx
@@ -21,7 +21,7 @@ function NodeLink({ to, label }: { to: string; label: string }) {
   return (
     <a
       className="kb-person-work-link kb-structured-link"
-      href={`#${to}`}
+      href={`#/node/${encodeURIComponent(to)}`}
       data-node-id={to}
     >
       {label}

--- a/src/views/viewers/PersonView.tsx
+++ b/src/views/viewers/PersonView.tsx
@@ -13,11 +13,34 @@ function Row({ label, children }: { label: string; children: React.ReactNode }) 
 }
 
 /**
- * Bespoke viewer for `person` entities (F2 / T2.5 — #164).
+ * A navigable link to a graph node (issue or PR).
+ * Uses an anchor styled like an in-graph reference — clicking opens that
+ * node's reading page without leaving the app.
+ */
+function NodeLink({ to, label }: { to: string; label: string }) {
+  return (
+    <a
+      className="kb-person-work-link kb-structured-link"
+      href={`#${to}`}
+      data-node-id={to}
+    >
+      {label}
+    </a>
+  );
+}
+
+/**
+ * Bespoke viewer for `person` entities (F2 / T2.5 — #164; extended #235).
  *
- * Renders the spine person fields — name, role, alias handle, reporting line and
- * knowledge areas — with the email exposed as a `mailto:` link. className-styled
- * (no pixel sizing, SSR-safe) so it renders identically in tests and the app.
+ * Renders the spine person fields — name, role, alias handle, reporting line
+ * and knowledge areas — with the email exposed as a `mailto:` link.
+ *
+ * When the node carries `data.login` (i.e. it is a work-derived person node
+ * or a descriptor that has been linked to GitHub activity) an "Active work"
+ * section lists all assigned/authored open issues and PRs as navigable links.
+ *
+ * className-styled (no pixel sizing, SSR-safe) so it renders identically in
+ * tests and the app.
  */
 export function PersonView({ node }: ViewerProps) {
   const d = (node.data ?? {}) as Record<string, unknown>;
@@ -30,6 +53,16 @@ export function PersonView({ node }: ViewerProps) {
   const areas = Array.isArray(d.knowledgeAreas) ? (d.knowledgeAreas as unknown[]) : [];
   const native = nativeTypeOf(node);
 
+  // Work-derived active items (present on work-derived person nodes; #235)
+  const activeIssues = Array.isArray(d.activeIssues)
+    ? (d.activeIssues as Array<{ number: number; title: string }>)
+    : [];
+  const activePRs = Array.isArray(d.activePRs)
+    ? (d.activePRs as Array<{ number: number; title: string }>)
+    : [];
+  const login = d.login as string | undefined;
+  const hasActiveWork = activeIssues.length > 0 || activePRs.length > 0;
+
   return (
     <div className="kb-structured-view kb-person-view">
       <EntityHeader label="Person" id={node.jsonld?.['@id'] as string | undefined} native={native} />
@@ -37,7 +70,9 @@ export function PersonView({ node }: ViewerProps) {
       {role && <p className="kb-person-role">{role}</p>}
       <table className="kb-structured-table">
         <tbody>
-          {alias && <Row label="Alias"><code className="kb-structured-code">@{alias}</code></Row>}
+          {(alias ?? login) && (
+            <Row label="GitHub"><code className="kb-structured-code">@{alias ?? login}</code></Row>
+          )}
           {team && <Row label="Team">{team}</Row>}
           {manager && <Row label="Reports to">{manager}</Row>}
           {email && (
@@ -54,6 +89,36 @@ export function PersonView({ node }: ViewerProps) {
           )}
         </tbody>
       </table>
+
+      {hasActiveWork && (
+        <section className="kb-person-active-work">
+          <h3 className="kb-person-active-work-heading">Active work</h3>
+          {activeIssues.length > 0 && (
+            <>
+              <h4 className="kb-person-active-work-subheading">Issues</h4>
+              <ul className="kb-person-work-list">
+                {activeIssues.map(i => (
+                  <li key={i.number}>
+                    <NodeLink to={`issue-${i.number}`} label={`#${i.number}: ${i.title}`} />
+                  </li>
+                ))}
+              </ul>
+            </>
+          )}
+          {activePRs.length > 0 && (
+            <>
+              <h4 className="kb-person-active-work-subheading">Pull Requests</h4>
+              <ul className="kb-person-work-list">
+                {activePRs.map(p => (
+                  <li key={p.number}>
+                    <NodeLink to={`pr-${p.number}`} label={`#${p.number}: ${p.title}`} />
+                  </li>
+                ))}
+              </ul>
+            </>
+          )}
+        </section>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Closes #235

## Summary

- **PersonProvider** derives first-class `person` nodes from GitHub activity: any login appearing as author or assignee on >= `people.minActiveItems` open issues/PRs gets a node (id `person-<login>`, identity `urn:person:<login>`).
- **Descriptor-linking**: when a content-model person descriptor has a matching `alias` (GitHub login), no duplicate is created — the descriptor is enriched with connections to active items instead.
- **Edges**: `person -> issue/PR` with relations `assigned-to` / `authored`. New `KnownRelation` values: `assigned-to`, `authored`, `member-of`.
- **Threshold config**: `config.people.minActiveItems` (default 1) prevents drive-by contributors from exploding the graph.
- **PersonView extended**: renders an "Active work" section with navigable issue/PR links when `data.activeIssues`/`data.activePRs` are populated (works for both work-derived and descriptor nodes).
- `person` registered as a built-in node-type (work layer) — appears in the Work view filter.
- `NodeSource` union extended append-only with `{ type: 'person'; login; linked }`.
- `GHIssue.user` and `WorkPullRequest.user` added to capture authors.

## Test plan

- [x] 26 new unit tests in `src/engine/__tests__/providers/person-provider.test.ts` covering: derivation from issues/PRs, threshold, descriptor-linking (no duplicate), zero-people graphs, identity URNs, relation-typed edges, data bag
- [x] `npx vitest run`: 545 passed (0 failed)
- [x] `npm run build`: clean (pre-existing chunk-size warnings only)
- [x] E2E CI-equivalent (`VITE_KB_LOCAL=true node scripts/generate-manifest.js && npx vite build && npx playwright test --project=chromium`): **55/55 passed**

> Note: unauthenticated GitHub API calls in e2e may occasionally emit 429 console noise in CI; the `smoke.spec.ts` filter already excludes 403/rate-limit errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)