### PR TITLE
feat(landing): reading-first landing mode with collapsed graph

### DIFF
--- a/.github/skills/kbexplorer/references/configuration.md
+++ b/.github/skills/kbexplorer/references/configuration.md
@@ -82,6 +82,21 @@ features:
                                    #   HUD search buttons. Unset = enabled;
                                    #   set false to opt out entirely.
 
+# Landing mode — controls the initial view when arriving at / with no deep link
+# Optional and additive. Deep links (#/node/x, #/overview) are always honored
+# unchanged. localStorage user preferences (set after first interaction) win.
+landing:
+  view: reading                    # Optional. reading | overview | graph (default).
+                                   #   reading → a reading-view node (lead with content).
+                                   #   overview → the card-grid overview (/overview).
+                                   #   graph → constellation graph (current default).
+  node: home                       # Optional. Node ID to land on for reading/graph.
+                                   #   Defaults to 'home'. Ignored for overview.
+  graph: collapsed                 # Optional. HUD initial state: collapsed | expanded.
+                                   #   collapsed → HUD starts as a rail (one click
+                                   #     expands). Only applies when the user has no
+                                   #     stored kbe-hud-collapsed preference.
+
 # BLUF (Bottom Line Up Front) — optional intro screen
 bluf:
   quote: "Knowledge is the path."  # Quote shown on intro screen.

--- a/.github/skills/kbexplorer/references/configuration.md
+++ b/.github/skills/kbexplorer/references/configuration.md
@@ -87,11 +87,12 @@ features:
 # unchanged. localStorage user preferences (set after first interaction) win.
 landing:
   view: reading                    # Optional. reading | overview | graph (default).
-                                   #   reading → a reading-view node (lead with content).
+                                   #   reading → a content node in ReadingView.
                                    #   overview → the card-grid overview (/overview).
-                                   #   graph → constellation graph (current default).
-  node: home                       # Optional. Node ID to land on for reading/graph.
-                                   #   Defaults to 'home'. Ignored for overview.
+                                   #   graph → graph-first HomePage (current default).
+  node: readme                     # Optional. Node ID for reading/graph; ignored
+                                   #   for overview. Default differs by view:
+                                   #   reading → 'readme' (content), graph → 'home'.
   graph: collapsed                 # Optional. HUD initial state: collapsed | expanded.
                                    #   collapsed → HUD starts as a rail (one click
                                    #     expands). Only applies when the user has no

--- a/e2e/landing-mode.spec.ts
+++ b/e2e/landing-mode.spec.ts
@@ -1,0 +1,171 @@
+/**
+ * E2E spec for landing-mode config (#238).
+ *
+ * Covers:
+ *   - landing.view=reading + landing.graph=collapsed → reading view, collapsed HUD.
+ *   - landing.view=overview → overview route.
+ *   - deep links are always honored (hash routes override landing config).
+ *   - localStorage user preference wins over config-driven HUD state.
+ *
+ * Config fixturing follows the same pattern as search.spec.ts: intercept the
+ * local-mode manifest asset and the remote-mode GitHub contents API response,
+ * patching configRaw with the desired landing block.
+ */
+
+import { test, expect } from '@playwright/test';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import YAML from 'yaml';
+
+const manifestPath = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../src/generated/repo-manifest.json',
+);
+
+type LandingConfig = {
+  view?: 'reading' | 'overview' | 'graph';
+  node?: string;
+  graph?: 'collapsed' | 'expanded';
+};
+
+function patchedManifest(landing: LandingConfig): { manifest: Record<string, unknown>; configRaw: string } {
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8')) as Record<string, unknown>;
+  const config = (manifest.configRaw ? YAML.parse(manifest.configRaw as string) : null) ?? {};
+  config.landing = landing;
+  const configRaw = YAML.stringify(config);
+  manifest.configRaw = configRaw;
+  return { manifest, configRaw };
+}
+
+async function routeWithLanding(
+  page: import('@playwright/test').Page,
+  landing: LandingConfig,
+): Promise<void> {
+  const { manifest, configRaw } = patchedManifest(landing);
+
+  // Local-mode: intercept the lazy manifest chunk.
+  await page.route('**/assets/repo-manifest-*.js', route => {
+    void route.fulfill({
+      status: 200,
+      contentType: 'application/javascript',
+      body: `export default ${JSON.stringify(manifest)};`,
+    });
+  });
+
+  // Remote-mode: intercept the GitHub contents API for config.yaml.
+  await page.route('**/contents/**config.yaml*', route => {
+    void route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        content: Buffer.from(configRaw).toString('base64'),
+        sha: 'e2e-landing-mode',
+        encoding: 'base64',
+      }),
+    });
+  });
+}
+
+/** Wait for the app to be ready: HUD visible (expanded or collapsed). */
+async function waitForApp(page: import('@playwright/test').Page): Promise<void> {
+  // When the HUD is expanded the "Cards" button is visible; when collapsed the
+  // "Expand" button is visible. Waiting for either covers both states.
+  // We use the kb-prose or the HUD's lowest-common-denominator element.
+  // Actually the safest signal is the reading view prose appearing (which
+  // always loads for /node/* routes regardless of HUD state) OR the overview
+  // grid (for /overview). We accept either.
+  await page.waitForFunction(() => {
+    const prose = document.querySelector('.kb-prose');
+    const cards = Array.from(document.querySelectorAll('button')).find(b => b.textContent?.trim() === 'Cards');
+    const expand = Array.from(document.querySelectorAll('button')).find(b => b.getAttribute('title') === 'Expand');
+    return !!(prose || cards || expand);
+  }, { timeout: 45000 });
+}
+
+test.describe('Landing mode: reading-first with collapsed graph', () => {
+  test('landing.view=reading + landing.graph=collapsed → reading view with collapsed HUD', async ({ page }) => {
+    // Clear any stored HUD preference so the config wins.
+    await page.addInitScript(() => {
+      localStorage.removeItem('kbe-hud-collapsed');
+    });
+
+    await routeWithLanding(page, { view: 'reading', graph: 'collapsed' });
+
+    // Navigate to `/` — the landing config should redirect to a reading node.
+    await page.goto('/', { timeout: 60000 });
+    await waitForApp(page);
+
+    // The URL should be a /node/ path (reading view), not /overview.
+    await expect(page).toHaveURL(/\/#\/node\//, { timeout: 10000 });
+
+    // Reading view prose should be visible.
+    await expect(page.locator('.kb-prose')).toBeVisible({ timeout: 10000 });
+
+    // HUD should be collapsed: the expand button should be present and the
+    // HUD should be in its collapsed (rail) state.
+    // The collapsed HUD has an expand button (ChevronUpRegular for bottom dock).
+    // We detect the collapsed state by the absence of the Cards button that lives
+    // only in the expanded HUD content.
+    const expandButton = page.locator('[title="Expand"]');
+    await expect(expandButton).toBeVisible({ timeout: 5000 });
+  });
+
+  test('landing.view=reading + custom node → navigates to that node', async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.removeItem('kbe-hud-collapsed');
+    });
+
+    await routeWithLanding(page, { view: 'reading', node: 'readme' });
+    await page.goto('/', { timeout: 60000 });
+    await waitForApp(page);
+
+    // Should land on the readme node.
+    await expect(page).toHaveURL(/\/#\/node\/readme/, { timeout: 10000 });
+    await expect(page.locator('.kb-prose')).toBeVisible({ timeout: 10000 });
+  });
+
+  test('landing.view=overview → card-grid overview', async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.removeItem('kbe-hud-collapsed');
+    });
+
+    await routeWithLanding(page, { view: 'overview' });
+    await page.goto('/', { timeout: 60000 });
+    await waitForApp(page);
+
+    await expect(page).toHaveURL(/\/#\/overview/, { timeout: 10000 });
+  });
+
+  test('deep links bypass landing config', async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.removeItem('kbe-hud-collapsed');
+    });
+
+    // Config says land on overview, but we navigate directly to a node.
+    await routeWithLanding(page, { view: 'overview' });
+    await page.goto('/#/node/readme', { timeout: 60000 });
+    await waitForApp(page);
+
+    // Deep link wins — should still be on /node/readme.
+    await expect(page).toHaveURL(/\/#\/node\/readme/, { timeout: 10000 });
+    await expect(page.locator('.kb-prose')).toBeVisible({ timeout: 10000 });
+  });
+
+  test('localStorage HUD preference wins over config.landing.graph=collapsed', async ({ page }) => {
+    // Pre-seed the stored preference to "false" (user previously expanded).
+    await page.addInitScript(() => {
+      localStorage.setItem('kbe-hud-collapsed', 'false');
+    });
+
+    await routeWithLanding(page, { view: 'reading', graph: 'collapsed' });
+    await page.goto('/', { timeout: 60000 });
+    await waitForApp(page);
+
+    // HUD should be expanded (Cards button visible in HUD).
+    await expect(page.getByRole('button', { name: 'Cards' })).toBeVisible({ timeout: 10000 });
+
+    // The Expand button should NOT be visible (HUD is not collapsed).
+    await expect(page.locator('[title="Expand"]')).not.toBeVisible({ timeout: 3000 });
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { HashRouter, Routes, Route, Navigate, useParams, useLocation, useNavigate } from 'react-router-dom';
 import { FluentProvider, type Theme as FluentTheme } from '@fluentui/react-components';
 import { useKnowledgeBase } from './hooks/useKnowledgeBase';
@@ -9,6 +9,7 @@ import { useCssOverride, isAbsoluteUrl } from './hooks/useCssOverride';
 import { loadThemeModule, applyThemeModuleInOrder } from './theme/themeModule';
 import { resolveImageUrl } from './api';
 import { useKeyboardNav } from './hooks/useKeyboardNav';
+import { resolveLandingPath, resolveLandingHudCollapsed } from './landing/resolveLanding';
 import { HUD } from './components/HUD';
 import type { DockPosition } from './components/HUD';
 import { SearchPalette } from './components/SearchPalette';
@@ -67,12 +68,37 @@ function Explorer({ themeMode, fluentTheme, isDark, setThemeMode, applyConfig, c
     return () => { cancelled = true; };
   }, [state, applyConfig]);
 
+  // HUD collapsed state for content padding. Synced via onCollapsedChange
+  // whenever the user or the landing-mode logic changes it.
   const [hudCollapsed, setHudCollapsed] = useState(() => {
     try { return localStorage.getItem('kbe-hud-collapsed') === 'true'; } catch { return false; }
   });
+
   const [hudDock, setHudDock] = useState<DockPosition>(() => {
     try { return (localStorage.getItem('kbe-hud-dock') ?? 'bottom') as DockPosition; } catch { return 'bottom'; }
   });
+
+  // Landing-mode initial HUD collapsed state (#238).
+  // Computed once on the first 'ready' render (the render that mounts HUD
+  // for the first time) and passed as `initialCollapsed` to HUD so it starts
+  // in the right state without a flash. A ref prevents re-computation on
+  // subsequent renders.
+  const hudInitialCollapsedRef = useRef<boolean | undefined>(undefined);
+  if (state.status === 'ready' && hudInitialCollapsedRef.current === undefined) {
+    let storedPref: string | null = null;
+    try { storedPref = localStorage.getItem('kbe-hud-collapsed'); } catch { /* ignore */ }
+    hudInitialCollapsedRef.current = resolveLandingHudCollapsed(state.config, storedPref);
+  }
+
+  // Sync the App-level hudCollapsed (used for content padding) with the
+  // landing-mode resolved value. This runs once after the first 'ready'
+  // render to ensure the padding reflects the HUD's actual initial state.
+  useEffect(() => {
+    if (hudInitialCollapsedRef.current !== undefined) {
+      setHudCollapsed(hudInitialCollapsedRef.current);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.status]);
 
   // ── Search palette ─────────────────────────────────────────
   // Host repos can opt out via `features.search: false` in config.yaml.
@@ -117,15 +143,17 @@ function Explorer({ themeMode, fluentTheme, isDark, setThemeMode, applyConfig, c
     : hudDock === 'right' ? { paddingRight: hudCollapsed ? 40 : `var(--kbe-sidebar-width, ${sidebarVw}vw)` }
     : { paddingBottom: paddingSize };
 
+  const landingPath = resolveLandingPath(config);
+
   return (
     <>
       <div style={paddingStyle}>
         <Routes>
-          <Route path="/" element={<Navigate to="/node/home" replace />} />
+          <Route path="/" element={<Navigate to={landingPath} replace />} />
           <Route path="/node/home" element={<HomePage graph={graph} config={config} />} />
           <Route path="/overview" element={<OverviewView graph={graph} config={config} />} />
           <Route path="/node/:id" element={<ReadingRoute graph={graph} config={config} theme={fluentTheme} />} />
-          <Route path="*" element={<Navigate to="/node/home" replace />} />
+          <Route path="*" element={<Navigate to={landingPath} replace />} />
         </Routes>
       </div>
       <HUD
@@ -139,6 +167,7 @@ function Explorer({ themeMode, fluentTheme, isDark, setThemeMode, applyConfig, c
           onCollapsedChange={setHudCollapsed}
           onDockChange={setHudDock}
           onOpenSearch={searchEnabled ? openSearch : undefined}
+          initialCollapsed={hudInitialCollapsedRef.current}
         />
       {searchEnabled && searchOpen && (
         <SearchPalette

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -78,16 +78,30 @@ function Explorer({ themeMode, fluentTheme, isDark, setThemeMode, applyConfig, c
     try { return (localStorage.getItem('kbe-hud-dock') ?? 'bottom') as DockPosition; } catch { return 'bottom'; }
   });
 
+  // Whether this load is a true landing (root URL, no deep-link hash) vs a
+  // deep link (#/node/x, #/overview). Captured once from the initial hash so
+  // deep links bypass landing config — including the HUD-collapse default.
+  const isRootLandingRef = useRef<boolean | null>(null);
+  if (isRootLandingRef.current === null) {
+    let h = '';
+    try { h = window.location.hash; } catch { /* ignore */ }
+    isRootLandingRef.current = h === '' || h === '#' || h === '#/';
+  }
+
   // Landing-mode initial HUD collapsed state (#238).
   // Computed once on the first 'ready' render (the render that mounts HUD
   // for the first time) and passed as `initialCollapsed` to HUD so it starts
   // in the right state without a flash. A ref prevents re-computation on
-  // subsequent renders.
+  // subsequent renders. On a deep link, landing config is bypassed: only the
+  // user's stored preference applies (config.landing.graph must not force a
+  // deep-linked visitor's HUD closed).
   const hudInitialCollapsedRef = useRef<boolean | undefined>(undefined);
   if (state.status === 'ready' && hudInitialCollapsedRef.current === undefined) {
     let storedPref: string | null = null;
     try { storedPref = localStorage.getItem('kbe-hud-collapsed'); } catch { /* ignore */ }
-    hudInitialCollapsedRef.current = resolveLandingHudCollapsed(state.config, storedPref);
+    hudInitialCollapsedRef.current = isRootLandingRef.current
+      ? resolveLandingHudCollapsed(state.config, storedPref)
+      : storedPref === 'true';
   }
 
   // Sync the App-level hudCollapsed (used for content padding) with the

--- a/src/components/HUD.tsx
+++ b/src/components/HUD.tsx
@@ -64,6 +64,18 @@ interface HUDProps {
   onDockChange?: (dock: DockPosition) => void;
   /** Called when the user activates the search button (Ctrl-K palette). */
   onOpenSearch?: () => void;
+  /**
+   * Override the HUD's initial collapsed state.
+   *
+   * Used by the landing-mode feature (#238): when `config.landing.graph` is
+   * `'collapsed'` AND the user has no stored `kbe-hud-collapsed` preference,
+   * the parent passes `true` here so the HUD starts collapsed on first visit.
+   * The HUD's own localStorage read (which happens inside the `useState`
+   * initializer) is bypassed in favour of this prop when provided.
+   *
+   * Optional — when absent the HUD falls back to its normal localStorage read.
+   */
+  initialCollapsed?: boolean;
 }
 
 const FONT_SIZES = [0.92, 1.0, 1.1, 1.2, 1.35, 1.5, 1.6];
@@ -304,7 +316,7 @@ function themeIcon(mode: string): React.ReactElement {
   return <ColorRegular />;
 }
 
-export function HUD({ graph, config, currentNodeId, theme, isDark, availableThemes, onThemeChange, onCollapsedChange, onDockChange, onOpenSearch }: HUDProps) {
+export function HUD({ graph, config, currentNodeId, theme, isDark, availableThemes, onThemeChange, onCollapsedChange, onDockChange, onOpenSearch, initialCollapsed }: HUDProps) {
   const styles = useStyles();
   const canvasElRef = useRef<HTMLCanvasElement | null>(null);
   const [canvasMountKey, setCanvasMountKey] = useState(0);
@@ -351,6 +363,10 @@ export function HUD({ graph, config, currentNodeId, theme, isDark, availableThem
   const splitResizeRef = useRef<{ startY: number; startPct: number } | null>(null);
 
   const [collapsed, setCollapsed] = useState(() => {
+    // Landing-mode override (#238): when the parent has already resolved the
+    // initial state (honoring config vs localStorage precedence), use it
+    // directly — no second localStorage read needed.
+    if (initialCollapsed !== undefined) return initialCollapsed;
     try { return localStorage.getItem('kbe-hud-collapsed') === 'true'; } catch { return false; }
   });
   const [dock, setDock] = useState<DockPosition>(() =>

--- a/src/landing/__tests__/resolveLanding.test.ts
+++ b/src/landing/__tests__/resolveLanding.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Unit tests for landing-mode resolution logic (#238).
+ *
+ * Covers:
+ *   - resolveLandingPath: all view modes, custom node, defaults.
+ *   - resolveLandingHudCollapsed: config vs localStorage precedence.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { resolveLandingPath, resolveLandingHudCollapsed } from '../resolveLanding';
+import { DEFAULT_CONFIG } from '../../types';
+import type { KBConfig } from '../../types';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function withLanding(overrides: KBConfig['landing']): KBConfig {
+  return { ...DEFAULT_CONFIG, landing: overrides };
+}
+
+// ── resolveLandingPath ─────────────────────────────────────────────────────
+
+describe('resolveLandingPath', () => {
+  it('defaults to /node/home when no landing config is present', () => {
+    expect(resolveLandingPath(DEFAULT_CONFIG)).toBe('/node/home');
+  });
+
+  it('defaults to /node/home when landing block is empty', () => {
+    expect(resolveLandingPath(withLanding({}))).toBe('/node/home');
+  });
+
+  it('view: reading → /node/home when no node is specified', () => {
+    expect(resolveLandingPath(withLanding({ view: 'reading' }))).toBe('/node/home');
+  });
+
+  it('view: reading + node → /node/<id>', () => {
+    expect(resolveLandingPath(withLanding({ view: 'reading', node: 'team-charter' })))
+      .toBe('/node/team-charter');
+  });
+
+  it('view: overview → /overview', () => {
+    expect(resolveLandingPath(withLanding({ view: 'overview' }))).toBe('/overview');
+  });
+
+  it('view: overview ignores node field', () => {
+    expect(resolveLandingPath(withLanding({ view: 'overview', node: 'some-node' })))
+      .toBe('/overview');
+  });
+
+  it('view: graph → /node/home (same as no-config default)', () => {
+    expect(resolveLandingPath(withLanding({ view: 'graph' }))).toBe('/node/home');
+  });
+
+  it('view: graph + node → /node/<id>', () => {
+    expect(resolveLandingPath(withLanding({ view: 'graph', node: 'overview' })))
+      .toBe('/node/overview');
+  });
+
+  it('URI-encodes node IDs that contain special characters', () => {
+    expect(resolveLandingPath(withLanding({ view: 'reading', node: 'team/charter' })))
+      .toBe('/node/team%2Fcharter');
+  });
+});
+
+// ── resolveLandingHudCollapsed ─────────────────────────────────────────────
+
+describe('resolveLandingHudCollapsed', () => {
+  // Scenario A: no stored preference, no config → default (expanded = false)
+  it('returns false (expanded) by default with no config and no stored pref', () => {
+    expect(resolveLandingHudCollapsed(DEFAULT_CONFIG, null)).toBe(false);
+  });
+
+  // Scenario B: no stored preference, config says collapsed
+  it('returns true when config.landing.graph=collapsed and no stored pref', () => {
+    expect(resolveLandingHudCollapsed(withLanding({ graph: 'collapsed' }), null))
+      .toBe(true);
+  });
+
+  // Scenario C: no stored preference, config says expanded explicitly
+  it('returns false when config.landing.graph=expanded and no stored pref', () => {
+    expect(resolveLandingHudCollapsed(withLanding({ graph: 'expanded' }), null))
+      .toBe(false);
+  });
+
+  // Scenario D: localStorage wins — user expanded (stored='false')
+  it('returns false when stored pref is "false" even if config says collapsed', () => {
+    expect(resolveLandingHudCollapsed(withLanding({ graph: 'collapsed' }), 'false'))
+      .toBe(false);
+  });
+
+  // Scenario E: localStorage wins — user collapsed (stored='true')
+  it('returns true when stored pref is "true" even if config says expanded', () => {
+    expect(resolveLandingHudCollapsed(withLanding({ graph: 'expanded' }), 'true'))
+      .toBe(true);
+  });
+
+  // Scenario F: stored pref is "true", no landing config
+  it('returns true when stored pref is "true" and no landing config', () => {
+    expect(resolveLandingHudCollapsed(DEFAULT_CONFIG, 'true')).toBe(true);
+  });
+
+  // Scenario G: stored pref is "false", no landing config
+  it('returns false when stored pref is "false" and no landing config', () => {
+    expect(resolveLandingHudCollapsed(DEFAULT_CONFIG, 'false')).toBe(false);
+  });
+
+  // Scenario H: empty landing block, no stored pref → default expanded
+  it('returns false when landing block is empty and no stored pref', () => {
+    expect(resolveLandingHudCollapsed(withLanding({}), null)).toBe(false);
+  });
+});

--- a/src/landing/__tests__/resolveLanding.test.ts
+++ b/src/landing/__tests__/resolveLanding.test.ts
@@ -28,8 +28,8 @@ describe('resolveLandingPath', () => {
     expect(resolveLandingPath(withLanding({}))).toBe('/node/home');
   });
 
-  it('view: reading → /node/home when no node is specified', () => {
-    expect(resolveLandingPath(withLanding({ view: 'reading' }))).toBe('/node/home');
+  it('view: reading → /node/readme when no node is specified (content node, not the graph HomePage)', () => {
+    expect(resolveLandingPath(withLanding({ view: 'reading' }))).toBe('/node/readme');
   });
 
   it('view: reading + node → /node/<id>', () => {

--- a/src/landing/resolveLanding.ts
+++ b/src/landing/resolveLanding.ts
@@ -1,0 +1,73 @@
+/**
+ * Landing-mode resolution (#238).
+ *
+ * Pure functions: no React, no side effects, no localStorage reads — all
+ * inputs are explicit so the logic is unit-testable in isolation.
+ */
+
+import type { KBConfig } from '../types';
+
+/**
+ * The resolved initial destination for the app when the user lands at `/`
+ * with no deep-link hash.
+ */
+export interface LandingDestination {
+  /** Hash-router path, e.g. `/node/home` or `/overview`. */
+  path: string;
+}
+
+/**
+ * Resolve the initial route path from the landing config.
+ *
+ * Called only when the user arrives at `/` (no deep-link hash).
+ * Deep links (`#/node/x`, `#/overview`) bypass this entirely.
+ *
+ * @param config - The loaded KB config.
+ * @returns The hash-router path to navigate to.
+ */
+export function resolveLandingPath(config: KBConfig): string {
+  const landing = config.landing;
+  if (!landing) return '/node/home';
+
+  switch (landing.view) {
+    case 'overview':
+      return '/overview';
+    case 'reading':
+    case 'graph':
+    default: {
+      // Both 'reading' and 'graph' land on a node; 'graph' just leaves the
+      // HUD expanded (handled separately in resolveLandingHudCollapsed).
+      const nodeId = landing.node ?? 'home';
+      return `/node/${encodeURIComponent(nodeId)}`;
+    }
+  }
+}
+
+/**
+ * Resolve the initial HUD collapsed state, honoring the config ONLY when
+ * the user has no stored preference.
+ *
+ * Precedence (highest first):
+ *   1. localStorage `kbe-hud-collapsed` (user's explicit choice after first
+ *      interaction) — wins always.
+ *   2. `config.landing.graph === 'collapsed'` — config-driven initial state.
+ *   3. Default: `false` (HUD expanded).
+ *
+ * @param config          - The loaded KB config.
+ * @param storedPreference - The raw value of `localStorage.getItem('kbe-hud-collapsed')`,
+ *                           or `null` if the key is absent / localStorage is
+ *                           unavailable.
+ * @returns `true` if the HUD should start collapsed.
+ */
+export function resolveLandingHudCollapsed(
+  config: KBConfig,
+  storedPreference: string | null,
+): boolean {
+  // User preference wins after first interaction.
+  if (storedPreference !== null) {
+    return storedPreference === 'true';
+  }
+
+  // No stored preference: honor the config.
+  return config.landing?.graph === 'collapsed';
+}

--- a/src/landing/resolveLanding.ts
+++ b/src/landing/resolveLanding.ts
@@ -8,19 +8,17 @@
 import type { KBConfig } from '../types';
 
 /**
- * The resolved initial destination for the app when the user lands at `/`
- * with no deep-link hash.
- */
-export interface LandingDestination {
-  /** Hash-router path, e.g. `/node/home` or `/overview`. */
-  path: string;
-}
-
-/**
  * Resolve the initial route path from the landing config.
  *
  * Called only when the user arrives at `/` (no deep-link hash).
  * Deep links (`#/node/x`, `#/overview`) bypass this entirely.
+ *
+ * Two distinct node defaults, because `/node/home` is a special route:
+ *  - `'graph'` (and the no-config default) → `/node/home`, the graph-first
+ *    **HomePage** (hero + graph), preserving today's behavior.
+ *  - `'reading'` → `/node/readme`, a content node rendered by the normal
+ *    **ReadingView**. Defaulting reading to `home` would land on the very
+ *    graph-first homepage that reading-first mode exists to replace.
  *
  * @param config - The loaded KB config.
  * @returns The hash-router path to navigate to.
@@ -32,11 +30,14 @@ export function resolveLandingPath(config: KBConfig): string {
   switch (landing.view) {
     case 'overview':
       return '/overview';
-    case 'reading':
+    case 'reading': {
+      // Reading-first: a content node in ReadingView, NOT the graph HomePage.
+      const nodeId = landing.node ?? 'readme';
+      return `/node/${encodeURIComponent(nodeId)}`;
+    }
     case 'graph':
     default: {
-      // Both 'reading' and 'graph' land on a node; 'graph' just leaves the
-      // HUD expanded (handled separately in resolveLandingHudCollapsed).
+      // Graph-first: the HomePage route leaves the graph immediately visible.
       const nodeId = landing.node ?? 'home';
       return `/node/${encodeURIComponent(nodeId)}`;
     }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1071,18 +1071,21 @@ export interface KBConfig {
   landing?: {
     /**
      * Which view to land on:
-     * - `'reading'` — a reading-view node (use `node` to pick which one;
-     *    defaults to the `home`/`readme` node).
+     * - `'reading'` — a content node in the normal ReadingView (use `node` to
+     *    pick which one; defaults to the `readme` content node, NOT the
+     *    graph-first HomePage).
      * - `'overview'` — the card-grid overview (`/overview`).
-     * - `'graph'` — the constellation graph (current default; navigates to
+     * - `'graph'` — the graph-first HomePage (current default; navigates to
      *    `/node/home` with the HUD expanded so the graph is immediately
      *    visible).
      * Unset is equivalent to `'graph'`.
      */
     view?: 'reading' | 'overview' | 'graph';
     /**
-     * Node ID to land on when `view` is `'reading'` (or `'graph'`).
-     * Defaults to `'home'` (the home/README node). Ignored for `'overview'`.
+     * Node ID to land on for `'reading'` and `'graph'`. Ignored for
+     * `'overview'`. The default differs by view because `/node/home` is the
+     * special graph-first HomePage route: `'reading'` defaults to `'readme'`
+     * (a content node), `'graph'` defaults to `'home'` (the HomePage).
      */
     node?: string;
     /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1057,6 +1057,44 @@ export interface KBConfig {
      */
     minActiveItems?: number;
   };
+  /**
+   * Landing-mode configuration (#238).
+   *
+   * Controls the initial view and HUD state when the user arrives at `/` with
+   * no deep-link hash. Deep links (`#/node/x`, `#/overview`) are always
+   * honored unchanged. localStorage user preferences win after first
+   * interaction (e.g. once the user expands the HUD, that choice persists).
+   *
+   * All three sub-fields are optional and additive — omit the block entirely
+   * to keep the current behavior (redirects to `/node/home`, HUD expanded).
+   */
+  landing?: {
+    /**
+     * Which view to land on:
+     * - `'reading'` — a reading-view node (use `node` to pick which one;
+     *    defaults to the `home`/`readme` node).
+     * - `'overview'` — the card-grid overview (`/overview`).
+     * - `'graph'` — the constellation graph (current default; navigates to
+     *    `/node/home` with the HUD expanded so the graph is immediately
+     *    visible).
+     * Unset is equivalent to `'graph'`.
+     */
+    view?: 'reading' | 'overview' | 'graph';
+    /**
+     * Node ID to land on when `view` is `'reading'` (or `'graph'`).
+     * Defaults to `'home'` (the home/README node). Ignored for `'overview'`.
+     */
+    node?: string;
+    /**
+     * Initial HUD state for the constellation graph panel:
+     * - `'collapsed'` — HUD starts collapsed to its rail; one click expands.
+     * - `'expanded'` — HUD starts fully expanded (current default).
+     * Only applies when the user has **no** stored `kbe-hud-collapsed`
+     * preference in localStorage — user choice always wins after first
+     * interaction.
+     */
+    graph?: 'collapsed' | 'expanded';
+  };
   bluf?: {
     audio?: string;
     quote?: string;


### PR DESCRIPTION
Closes #238

## Summary

- Adds `landing?` config block to `KBConfig` (append-only, all fields optional): `view` (`reading | overview | graph`), `node` (node ID for the landing node), `graph` (`collapsed | expanded` HUD initial state).
- The `/` route now resolves via `resolveLandingPath(config)` — `view: reading` navigates to a reading-view node (configurable via `node`), `view: overview` goes to `/overview`, `view: graph` (or unset) keeps the current default (`/node/home`).
- HUD starts collapsed when `landing.graph: collapsed` AND the user has no stored `kbe-hud-collapsed` localStorage preference. localStorage wins after first interaction (the `initialCollapsed` prop is passed to HUD on its first render; the HUD's own `useState` uses it only at mount).
- Deep links (`#/node/x`, `#/overview`) are unchanged — they always bypass the landing redirect.
- New `src/landing/resolveLanding.ts` pure module with two exported functions: `resolveLandingPath` and `resolveLandingHudCollapsed`.
- 16 unit tests (vitest) covering all config / localStorage precedence combinations.
- 5 e2e tests (Playwright): collapsed-HUD landing, custom-node landing, overview landing, deep-link bypass, localStorage-wins-over-config.
- Configuration reference (`configuration.md`) updated with the `landing` block.

## Test plan

- [x] `npx vitest run` — 608 tests pass (46 test files).
- [x] `npm run build` — succeeds, no TypeScript errors.
- [x] `npx playwright test --project=chromium e2e/landing-mode.spec.ts` — 5/5 pass.
- [x] `npx playwright test --project=chromium` (full suite) — 71/71 pass.

> Note: local unauthenticated GitHub API calls may surface 429 console noise on unrelated specs in CI (pre-existing, not introduced by this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)