### PR TITLE
fix(theme): re-ramp node icons, rail icons, and source badge per theme

### DIFF
--- a/review/capture-report.json
+++ b/review/capture-report.json
@@ -1,5 +1,5 @@
 {
-  "capturedAt": "2026-06-13T01:41:38.755Z",
+  "capturedAt": "2026-06-13T04:46:46.264Z",
   "surfaces": [
     {
       "surfaceId": "home",
@@ -8,7 +8,7 @@
       "viewport": "desktop",
       "filename": "home--dark--desktop.png",
       "status": "captured",
-      "bytes": 203710,
+      "bytes": 198033,
       "skipReason": null,
       "error": null
     },
@@ -19,7 +19,7 @@
       "viewport": "desktop",
       "filename": "constellation--dark--desktop.png",
       "status": "captured",
-      "bytes": 151868,
+      "bytes": 144192,
       "skipReason": null,
       "error": null
     },
@@ -30,7 +30,7 @@
       "viewport": "desktop",
       "filename": "reading--dark--desktop.png",
       "status": "captured",
-      "bytes": 90042,
+      "bytes": 90544,
       "skipReason": null,
       "error": null
     },
@@ -41,7 +41,7 @@
       "viewport": "desktop",
       "filename": "overview--dark--desktop.png",
       "status": "captured",
-      "bytes": 75397,
+      "bytes": 75861,
       "skipReason": null,
       "error": null
     },
@@ -52,7 +52,7 @@
       "viewport": "desktop",
       "filename": "hud-expanded--dark--desktop.png",
       "status": "captured",
-      "bytes": 65235,
+      "bytes": 65925,
       "skipReason": null,
       "error": null
     },
@@ -63,7 +63,7 @@
       "viewport": "desktop",
       "filename": "hud-collapsed--dark--desktop.png",
       "status": "captured",
-      "bytes": 62698,
+      "bytes": 62664,
       "skipReason": null,
       "error": null
     },
@@ -74,7 +74,7 @@
       "viewport": "desktop",
       "filename": "hud-docked-left--dark--desktop.png",
       "status": "captured",
-      "bytes": 144647,
+      "bytes": 140958,
       "skipReason": null,
       "error": null
     },
@@ -85,7 +85,7 @@
       "viewport": "desktop",
       "filename": "node-selected--dark--desktop.png",
       "status": "captured",
-      "bytes": 74892,
+      "bytes": 75541,
       "skipReason": null,
       "error": null
     },
@@ -107,7 +107,7 @@
       "viewport": "mobile",
       "filename": "home--dark--mobile.png",
       "status": "captured",
-      "bytes": 115197,
+      "bytes": 115648,
       "skipReason": null,
       "error": null
     },
@@ -118,7 +118,7 @@
       "viewport": "mobile",
       "filename": "constellation--dark--mobile.png",
       "status": "captured",
-      "bytes": 57220,
+      "bytes": 53646,
       "skipReason": null,
       "error": null
     },
@@ -129,7 +129,7 @@
       "viewport": "mobile",
       "filename": "reading--dark--mobile.png",
       "status": "captured",
-      "bytes": 43534,
+      "bytes": 43807,
       "skipReason": null,
       "error": null
     },
@@ -140,7 +140,7 @@
       "viewport": "mobile",
       "filename": "overview--dark--mobile.png",
       "status": "captured",
-      "bytes": 37777,
+      "bytes": 38172,
       "skipReason": null,
       "error": null
     },
@@ -151,7 +151,7 @@
       "viewport": "mobile",
       "filename": "hud-expanded--dark--mobile.png",
       "status": "captured",
-      "bytes": 32533,
+      "bytes": 32671,
       "skipReason": null,
       "error": null
     },
@@ -162,7 +162,7 @@
       "viewport": "mobile",
       "filename": "hud-collapsed--dark--mobile.png",
       "status": "captured",
-      "bytes": 28462,
+      "bytes": 28436,
       "skipReason": null,
       "error": null
     },
@@ -173,7 +173,7 @@
       "viewport": "mobile",
       "filename": "hud-docked-left--dark--mobile.png",
       "status": "captured",
-      "bytes": 49404,
+      "bytes": 49551,
       "skipReason": null,
       "error": null
     },
@@ -184,7 +184,7 @@
       "viewport": "mobile",
       "filename": "node-selected--dark--mobile.png",
       "status": "captured",
-      "bytes": 40314,
+      "bytes": 40552,
       "skipReason": null,
       "error": null
     },
@@ -206,7 +206,7 @@
       "viewport": "desktop",
       "filename": "home--light--desktop.png",
       "status": "captured",
-      "bytes": 202746,
+      "bytes": 211415,
       "skipReason": null,
       "error": null
     },
@@ -217,7 +217,7 @@
       "viewport": "desktop",
       "filename": "constellation--light--desktop.png",
       "status": "captured",
-      "bytes": 141361,
+      "bytes": 143893,
       "skipReason": null,
       "error": null
     },
@@ -228,7 +228,7 @@
       "viewport": "desktop",
       "filename": "reading--light--desktop.png",
       "status": "captured",
-      "bytes": 90091,
+      "bytes": 90978,
       "skipReason": null,
       "error": null
     },
@@ -239,7 +239,7 @@
       "viewport": "desktop",
       "filename": "overview--light--desktop.png",
       "status": "captured",
-      "bytes": 75477,
+      "bytes": 75969,
       "skipReason": null,
       "error": null
     },
@@ -250,7 +250,7 @@
       "viewport": "desktop",
       "filename": "hud-expanded--light--desktop.png",
       "status": "captured",
-      "bytes": 67431,
+      "bytes": 68199,
       "skipReason": null,
       "error": null
     },
@@ -261,7 +261,7 @@
       "viewport": "desktop",
       "filename": "hud-collapsed--light--desktop.png",
       "status": "captured",
-      "bytes": 65092,
+      "bytes": 65182,
       "skipReason": null,
       "error": null
     },
@@ -272,7 +272,7 @@
       "viewport": "desktop",
       "filename": "hud-docked-left--light--desktop.png",
       "status": "captured",
-      "bytes": 141004,
+      "bytes": 147117,
       "skipReason": null,
       "error": null
     },
@@ -283,7 +283,7 @@
       "viewport": "desktop",
       "filename": "node-selected--light--desktop.png",
       "status": "captured",
-      "bytes": 75129,
+      "bytes": 76290,
       "skipReason": null,
       "error": null
     },
@@ -305,7 +305,7 @@
       "viewport": "mobile",
       "filename": "home--light--mobile.png",
       "status": "captured",
-      "bytes": 114279,
+      "bytes": 108944,
       "skipReason": null,
       "error": null
     },
@@ -316,7 +316,7 @@
       "viewport": "mobile",
       "filename": "constellation--light--mobile.png",
       "status": "captured",
-      "bytes": 60879,
+      "bytes": 57226,
       "skipReason": null,
       "error": null
     },
@@ -327,7 +327,7 @@
       "viewport": "mobile",
       "filename": "reading--light--mobile.png",
       "status": "captured",
-      "bytes": 43328,
+      "bytes": 43687,
       "skipReason": null,
       "error": null
     },
@@ -338,7 +338,7 @@
       "viewport": "mobile",
       "filename": "overview--light--mobile.png",
       "status": "captured",
-      "bytes": 37491,
+      "bytes": 37948,
       "skipReason": null,
       "error": null
     },
@@ -349,7 +349,7 @@
       "viewport": "mobile",
       "filename": "hud-expanded--light--mobile.png",
       "status": "captured",
-      "bytes": 33880,
+      "bytes": 34039,
       "skipReason": null,
       "error": null
     },
@@ -360,7 +360,7 @@
       "viewport": "mobile",
       "filename": "hud-collapsed--light--mobile.png",
       "status": "captured",
-      "bytes": 30168,
+      "bytes": 30221,
       "skipReason": null,
       "error": null
     },
@@ -371,7 +371,7 @@
       "viewport": "mobile",
       "filename": "hud-docked-left--light--mobile.png",
       "status": "captured",
-      "bytes": 50286,
+      "bytes": 50499,
       "skipReason": null,
       "error": null
     },
@@ -382,7 +382,7 @@
       "viewport": "mobile",
       "filename": "node-selected--light--mobile.png",
       "status": "captured",
-      "bytes": 40821,
+      "bytes": 41109,
       "skipReason": null,
       "error": null
     },
@@ -404,7 +404,7 @@
       "viewport": "desktop",
       "filename": "home--sepia--desktop.png",
       "status": "captured",
-      "bytes": 209072,
+      "bytes": 211488,
       "skipReason": null,
       "error": null
     },
@@ -415,7 +415,7 @@
       "viewport": "desktop",
       "filename": "constellation--sepia--desktop.png",
       "status": "captured",
-      "bytes": 164790,
+      "bytes": 168407,
       "skipReason": null,
       "error": null
     },
@@ -426,7 +426,7 @@
       "viewport": "desktop",
       "filename": "reading--sepia--desktop.png",
       "status": "captured",
-      "bytes": 105192,
+      "bytes": 106147,
       "skipReason": null,
       "error": null
     },
@@ -437,7 +437,7 @@
       "viewport": "desktop",
       "filename": "overview--sepia--desktop.png",
       "status": "captured",
-      "bytes": 85533,
+      "bytes": 86149,
       "skipReason": null,
       "error": null
     },
@@ -448,7 +448,7 @@
       "viewport": "desktop",
       "filename": "hud-expanded--sepia--desktop.png",
       "status": "captured",
-      "bytes": 77440,
+      "bytes": 78307,
       "skipReason": null,
       "error": null
     },
@@ -459,7 +459,7 @@
       "viewport": "desktop",
       "filename": "hud-collapsed--sepia--desktop.png",
       "status": "captured",
-      "bytes": 78354,
+      "bytes": 78323,
       "skipReason": null,
       "error": null
     },
@@ -470,7 +470,7 @@
       "viewport": "desktop",
       "filename": "hud-docked-left--sepia--desktop.png",
       "status": "captured",
-      "bytes": 161206,
+      "bytes": 163769,
       "skipReason": null,
       "error": null
     },
@@ -481,7 +481,7 @@
       "viewport": "desktop",
       "filename": "node-selected--sepia--desktop.png",
       "status": "captured",
-      "bytes": 88033,
+      "bytes": 88826,
       "skipReason": null,
       "error": null
     },
@@ -503,7 +503,7 @@
       "viewport": "mobile",
       "filename": "home--sepia--mobile.png",
       "status": "captured",
-      "bytes": 121201,
+      "bytes": 115761,
       "skipReason": null,
       "error": null
     },
@@ -514,7 +514,7 @@
       "viewport": "mobile",
       "filename": "constellation--sepia--mobile.png",
       "status": "captured",
-      "bytes": 62362,
+      "bytes": 64811,
       "skipReason": null,
       "error": null
     },
@@ -525,7 +525,7 @@
       "viewport": "mobile",
       "filename": "reading--sepia--mobile.png",
       "status": "captured",
-      "bytes": 46245,
+      "bytes": 46834,
       "skipReason": null,
       "error": null
     },
@@ -536,7 +536,7 @@
       "viewport": "mobile",
       "filename": "overview--sepia--mobile.png",
       "status": "captured",
-      "bytes": 42169,
+      "bytes": 42661,
       "skipReason": null,
       "error": null
     },
@@ -547,7 +547,7 @@
       "viewport": "mobile",
       "filename": "hud-expanded--sepia--mobile.png",
       "status": "captured",
-      "bytes": 38464,
+      "bytes": 38516,
       "skipReason": null,
       "error": null
     },
@@ -558,7 +558,7 @@
       "viewport": "mobile",
       "filename": "hud-collapsed--sepia--mobile.png",
       "status": "captured",
-      "bytes": 34647,
+      "bytes": 34610,
       "skipReason": null,
       "error": null
     },
@@ -569,7 +569,7 @@
       "viewport": "mobile",
       "filename": "hud-docked-left--sepia--mobile.png",
       "status": "captured",
-      "bytes": 55563,
+      "bytes": 56131,
       "skipReason": null,
       "error": null
     },
@@ -580,7 +580,7 @@
       "viewport": "mobile",
       "filename": "node-selected--sepia--mobile.png",
       "status": "captured",
-      "bytes": 44340,
+      "bytes": 44699,
       "skipReason": null,
       "error": null
     },
@@ -602,7 +602,7 @@
       "viewport": "desktop",
       "filename": "home--ocean--desktop.png",
       "status": "captured",
-      "bytes": 203278,
+      "bytes": 198381,
       "skipReason": null,
       "error": null
     },
@@ -613,7 +613,7 @@
       "viewport": "desktop",
       "filename": "constellation--ocean--desktop.png",
       "status": "captured",
-      "bytes": 167034,
+      "bytes": 155085,
       "skipReason": null,
       "error": null
     },
@@ -624,7 +624,7 @@
       "viewport": "desktop",
       "filename": "reading--ocean--desktop.png",
       "status": "captured",
-      "bytes": 90823,
+      "bytes": 91413,
       "skipReason": null,
       "error": null
     },
@@ -635,7 +635,7 @@
       "viewport": "desktop",
       "filename": "overview--ocean--desktop.png",
       "status": "captured",
-      "bytes": 77541,
+      "bytes": 78182,
       "skipReason": null,
       "error": null
     },
@@ -646,7 +646,7 @@
       "viewport": "desktop",
       "filename": "hud-expanded--ocean--desktop.png",
       "status": "captured",
-      "bytes": 65876,
+      "bytes": 66598,
       "skipReason": null,
       "error": null
     },
@@ -657,7 +657,7 @@
       "viewport": "desktop",
       "filename": "hud-collapsed--ocean--desktop.png",
       "status": "captured",
-      "bytes": 63016,
+      "bytes": 62980,
       "skipReason": null,
       "error": null
     },
@@ -668,7 +668,7 @@
       "viewport": "desktop",
       "filename": "hud-docked-left--ocean--desktop.png",
       "status": "captured",
-      "bytes": 149441,
+      "bytes": 148499,
       "skipReason": null,
       "error": null
     },
@@ -679,7 +679,7 @@
       "viewport": "desktop",
       "filename": "node-selected--ocean--desktop.png",
       "status": "captured",
-      "bytes": 75755,
+      "bytes": 76444,
       "skipReason": null,
       "error": null
     },
@@ -701,7 +701,7 @@
       "viewport": "mobile",
       "filename": "home--ocean--mobile.png",
       "status": "captured",
-      "bytes": 117470,
+      "bytes": 119495,
       "skipReason": null,
       "error": null
     },
@@ -712,7 +712,7 @@
       "viewport": "mobile",
       "filename": "constellation--ocean--mobile.png",
       "status": "captured",
-      "bytes": 60636,
+      "bytes": 60047,
       "skipReason": null,
       "error": null
     },
@@ -723,7 +723,7 @@
       "viewport": "mobile",
       "filename": "reading--ocean--mobile.png",
       "status": "captured",
-      "bytes": 44567,
+      "bytes": 44944,
       "skipReason": null,
       "error": null
     },
@@ -734,7 +734,7 @@
       "viewport": "mobile",
       "filename": "overview--ocean--mobile.png",
       "status": "captured",
-      "bytes": 39846,
+      "bytes": 40436,
       "skipReason": null,
       "error": null
     },
@@ -745,7 +745,7 @@
       "viewport": "mobile",
       "filename": "hud-expanded--ocean--mobile.png",
       "status": "captured",
-      "bytes": 33270,
+      "bytes": 33406,
       "skipReason": null,
       "error": null
     },
@@ -756,7 +756,7 @@
       "viewport": "mobile",
       "filename": "hud-collapsed--ocean--mobile.png",
       "status": "captured",
-      "bytes": 28621,
+      "bytes": 28597,
       "skipReason": null,
       "error": null
     },
@@ -767,7 +767,7 @@
       "viewport": "mobile",
       "filename": "hud-docked-left--ocean--mobile.png",
       "status": "captured",
-      "bytes": 52422,
+      "bytes": 52384,
       "skipReason": null,
       "error": null
     },
@@ -778,7 +778,7 @@
       "viewport": "mobile",
       "filename": "node-selected--ocean--mobile.png",
       "status": "captured",
-      "bytes": 41349,
+      "bytes": 41677,
       "skipReason": null,
       "error": null
     },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { HashRouter, Routes, Route, Navigate, useParams, useLocation, useNavigat
 import { FluentProvider, type Theme as FluentTheme } from '@fluentui/react-components';
 import { useKnowledgeBase } from './hooks/useKnowledgeBase';
 import { useTheme, isDarkTheme } from './hooks/useTheme';
+import { IsDarkContext } from './theme/isDarkContext';
 import { useThemeFonts } from './hooks/useThemeFonts';
 import { useFavicon } from './hooks/useFavicon';
 import { useCssOverride, isAbsoluteUrl } from './hooks/useCssOverride';
@@ -200,9 +201,11 @@ function App() {
 
   return (
     <FluentProvider theme={fluentTheme} style={{ minHeight: '100vh' }}>
-      <HashRouter>
-        <Explorer themeMode={themeMode} fluentTheme={fluentTheme} isDark={isDark} setThemeMode={setThemeMode} applyConfig={applyConfig} cycleTheme={cycleTheme} availableThemes={availableThemes} />
-      </HashRouter>
+      <IsDarkContext.Provider value={isDark}>
+        <HashRouter>
+          <Explorer themeMode={themeMode} fluentTheme={fluentTheme} isDark={isDark} setThemeMode={setThemeMode} applyConfig={applyConfig} cycleTheme={cycleTheme} availableThemes={availableThemes} />
+        </HashRouter>
+      </IsDarkContext.Provider>
     </FluentProvider>
   );
 }

--- a/src/components/NodeVisual.tsx
+++ b/src/components/NodeVisual.tsx
@@ -5282,29 +5282,31 @@ interface NodeVisualProps {
   className?: string;
   clusterColor?: string;
   /**
-   * Whether the current theme renders on a dark background. When false
-   * (light / sepia / ocean) the cluster color is darkened so icons remain
-   * legible against a pale background. Defaults to true so callers that do
-   * not yet thread the flag keep the current dark-palette behaviour.
+   * Whether the current theme renders on a dark background (derived from the
+   * resolved theme's luminance via isDarkTheme, so config themes are handled).
+   * When false (any pale-background theme) the cluster color is darkened so
+   * icons remain legible. Defaults to true so callers that do not yet thread
+   * the flag keep the current dark-palette behaviour.
    */
   isDark?: boolean;
 }
 
 /**
- * Ensure `clusterColor` is dark enough to read on a light background.
+ * Ensure `clusterColor` is dark enough to read on a pale background.
  *
  * The cluster palette contains medium-saturation accents calibrated for dark
- * backgrounds (#E8A838, #4A9CC8, …). On light/sepia we darken them to ≥45 %
- * relative luminance deficit (approx WCAG AA threshold for UI components).
+ * backgrounds (#E8A838, #4A9CC8, …). On a non-dark theme we darken them by
+ * clamping HSL lightness to ≤ 0.42 so the icon stays legible on cream/white.
  *
- * Algorithm: parse the hex, convert to HSL, clamp `l` to ≤ 45, return a new
- * hex. Returns the input unchanged when it can't be parsed.
+ * Accepts 3- or 6-digit hex (with or without `#`); returns the input unchanged
+ * when it can't be parsed or the theme is dark.
  */
-function ensureIconContrast(hex: string | undefined, isDark: boolean): string | undefined {
+export function ensureIconContrast(hex: string | undefined, isDark: boolean): string | undefined {
   if (!hex || isDark) return hex;
-  const m = /^#?([0-9a-fA-F]{6})$/.exec(hex);
+  const m = /^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.exec(hex);
   if (!m) return hex;
-  const n = parseInt(m[1], 16);
+  const raw = m[1].length === 3 ? m[1].split('').map(c => c + c).join('') : m[1];
+  const n = parseInt(raw, 16);
   let r = ((n >> 16) & 0xff) / 255;
   let g = ((n >> 8) & 0xff) / 255;
   let b = (n & 0xff) / 255;
@@ -5385,7 +5387,8 @@ export function NodeVisual({ node, mode, surface, source, className, clusterColo
 
   const imageUrl = resolveNodeImage(node, mode, source);
   const size = SURFACE_SIZES[surface];
-  // Ensure the cluster-color icon remains legible on light/sepia/ocean themes.
+  // Darken the cluster-color icon on non-dark themes so it stays legible on a
+  // pale background (no-op when isDark; isDark is luminance-derived upstream).
   const iconColor = ensureIconContrast(clusterColor, isDark);
 
   // Hero surface — full-bleed image with gradient overlay

--- a/src/components/NodeVisual.tsx
+++ b/src/components/NodeVisual.tsx
@@ -3,6 +3,7 @@
  */
 import type { KBNode, VisualMode, SourceConfig } from '../types';
 import { resolveImageUrl } from '../api';
+import { useIsDark } from '../theme/isDarkContext';
 import {
   AccessTimeRegular,
   AccessibilityCheckmarkRegular,
@@ -5280,6 +5281,70 @@ interface NodeVisualProps {
   source: SourceConfig;
   className?: string;
   clusterColor?: string;
+  /**
+   * Whether the current theme renders on a dark background. When false
+   * (light / sepia / ocean) the cluster color is darkened so icons remain
+   * legible against a pale background. Defaults to true so callers that do
+   * not yet thread the flag keep the current dark-palette behaviour.
+   */
+  isDark?: boolean;
+}
+
+/**
+ * Ensure `clusterColor` is dark enough to read on a light background.
+ *
+ * The cluster palette contains medium-saturation accents calibrated for dark
+ * backgrounds (#E8A838, #4A9CC8, …). On light/sepia we darken them to ≥45 %
+ * relative luminance deficit (approx WCAG AA threshold for UI components).
+ *
+ * Algorithm: parse the hex, convert to HSL, clamp `l` to ≤ 45, return a new
+ * hex. Returns the input unchanged when it can't be parsed.
+ */
+function ensureIconContrast(hex: string | undefined, isDark: boolean): string | undefined {
+  if (!hex || isDark) return hex;
+  const m = /^#?([0-9a-fA-F]{6})$/.exec(hex);
+  if (!m) return hex;
+  const n = parseInt(m[1], 16);
+  let r = ((n >> 16) & 0xff) / 255;
+  let g = ((n >> 8) & 0xff) / 255;
+  let b = (n & 0xff) / 255;
+
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  let h = 0, s = 0;
+  const l = (max + min) / 2;
+
+  if (max !== min) {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case r: h = ((g - b) / d + (g < b ? 6 : 0)) / 6; break;
+      case g: h = ((b - r) / d + 2) / 6; break;
+      default: h = ((r - g) / d + 4) / 6; break;
+    }
+  }
+
+  // Clamp lightness to ≤ 42 % so the icon is dark enough on cream/white.
+  const newL = Math.min(l, 0.42);
+  if (newL === l) return hex; // already dark enough
+
+  // HSL → RGB (standard algorithm)
+  function hue2rgb(p: number, q: number, t: number) {
+    if (t < 0) t += 1;
+    if (t > 1) t -= 1;
+    if (t < 1 / 6) return p + (q - p) * 6 * t;
+    if (t < 1 / 2) return q;
+    if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+    return p;
+  }
+  const q = newL < 0.5 ? newL * (1 + s) : newL + s - newL * s;
+  const p = 2 * newL - q;
+  r = hue2rgb(p, q, h + 1 / 3);
+  g = hue2rgb(p, q, h);
+  b = hue2rgb(p, q, h - 1 / 3);
+
+  const toHex = (x: number) => Math.round(x * 255).toString(16).padStart(2, '0');
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
 }
 
 const SURFACE_SIZES: Record<NodeVisualProps['surface'], { width: number; height: number }> = {
@@ -5312,9 +5377,16 @@ function resolveNodeImage(
   return null;
 }
 
-export function NodeVisual({ node, mode, surface, source, className, clusterColor }: NodeVisualProps) {
+export function NodeVisual({ node, mode, surface, source, className, clusterColor, isDark: isDarkProp }: NodeVisualProps) {
+  // Fall back to the IsDarkContext so callers (e.g. HUD's related rail) that
+  // do not explicitly pass the flag still pick up the active theme correctly.
+  const isDarkCtx = useIsDark();
+  const isDark = isDarkProp !== undefined ? isDarkProp : isDarkCtx;
+
   const imageUrl = resolveNodeImage(node, mode, source);
   const size = SURFACE_SIZES[surface];
+  // Ensure the cluster-color icon remains legible on light/sepia/ocean themes.
+  const iconColor = ensureIconContrast(clusterColor, isDark);
 
   // Hero surface — full-bleed image with gradient overlay
   if (surface === 'hero' && mode === 'heroes' && imageUrl) {
@@ -5366,7 +5438,7 @@ export function NodeVisual({ node, mode, surface, source, className, clusterColo
           role="img"
           aria-label={node.title}
         >
-          <Icon style={{ fontSize: size.width || 24, color: clusterColor }} />
+          <Icon style={{ fontSize: size.width || 24, color: iconColor }} />
         </span>
       );
     }
@@ -5399,7 +5471,7 @@ export function NodeVisual({ node, mode, surface, source, className, clusterColo
         role="img"
         aria-label={node.title}
       >
-        <Icon style={{ fontSize: size.width || 24, color: clusterColor }} />
+        <Icon style={{ fontSize: size.width || 24, color: iconColor }} />
       </span>
     );
   }

--- a/src/components/__tests__/ensureIconContrast.test.ts
+++ b/src/components/__tests__/ensureIconContrast.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { ensureIconContrast } from '../NodeVisual';
+
+/** Approx relative-lightness check: parse a #rrggbb hex to HSL lightness. */
+function lightness(hex: string): number {
+  const n = parseInt(hex.replace('#', ''), 16);
+  const r = ((n >> 16) & 0xff) / 255, g = ((n >> 8) & 0xff) / 255, b = (n & 0xff) / 255;
+  return (Math.max(r, g, b) + Math.min(r, g, b)) / 2;
+}
+
+describe('ensureIconContrast (#250)', () => {
+  it('passes the color through unchanged on dark themes', () => {
+    expect(ensureIconContrast('#E8A838', true)).toBe('#E8A838');
+  });
+
+  it('returns undefined/empty inputs untouched', () => {
+    expect(ensureIconContrast(undefined, false)).toBeUndefined();
+  });
+
+  it('darkens a light 6-digit accent to L <= 0.42 on a non-dark theme', () => {
+    const out = ensureIconContrast('#E8A838', false)!; // gold, L ~0.56
+    expect(out).not.toBe('#E8A838');
+    expect(lightness(out)).toBeLessThanOrEqual(0.43); // small float margin
+  });
+
+  it('handles 3-digit hex (the bug Copilot flagged) — does not bypass the clamp', () => {
+    const out = ensureIconContrast('#fc0', false)!; // == #ffcc00, very light
+    expect(out).toMatch(/^#[0-9a-f]{6}$/i);
+    expect(lightness(out)).toBeLessThanOrEqual(0.43);
+  });
+
+  it('leaves an already-dark color unchanged on a non-dark theme', () => {
+    // #1A6B2A has L well below 0.42 — should be returned as-is.
+    expect(ensureIconContrast('#1A6B2A', false)).toBe('#1A6B2A');
+  });
+
+  it('returns unparseable input unchanged', () => {
+    expect(ensureIconContrast('not-a-color', false)).toBe('not-a-color');
+  });
+});

--- a/src/theme/isDarkContext.tsx
+++ b/src/theme/isDarkContext.tsx
@@ -1,0 +1,17 @@
+/**
+ * IsDarkContext — broadcasts whether the active theme renders on a dark
+ * background to the entire component tree without prop-drilling.
+ *
+ * Provided by App (which has the resolved FluentTheme) and consumed by any
+ * component that needs to adapt contrast for light / sepia / ocean themes.
+ * Defaults to `true` (dark) so components outside a provider keep the
+ * existing dark-palette behaviour.
+ */
+import { createContext, useContext } from 'react';
+
+export const IsDarkContext = createContext<boolean>(true);
+
+/** Read whether the active theme is dark from the nearest IsDarkContext. */
+export function useIsDark(): boolean {
+  return useContext(IsDarkContext);
+}

--- a/src/views/ReadingView.tsx
+++ b/src/views/ReadingView.tsx
@@ -17,7 +17,7 @@ import type { KBGraph, KBConfig, KBNode, Cluster } from '../types';
 import { NodeVisual } from '../components/NodeVisual';
 import { clusterTokenStyle } from '../theme/clusterTokens';
 import { pageThemeStyle } from '../theme/pageTheme';
-import { buildThemeMap } from '../hooks/useTheme';
+import { buildThemeMap, isDarkTheme } from '../hooks/useTheme';
 import type { Theme as FluentTheme } from '@fluentui/react-components';
 import { HomePageWidgets } from '../components/HomePageWidgets';
 import { ConstellationHero } from '../components/ConstellationHero';
@@ -350,70 +350,86 @@ function humanizeEntityType(t: string): string {
     .replace(/\b\w/g, c => c.toUpperCase());
 }
 
+/**
+ * Per-source-type colors for the source badge.
+ *
+ * Two palettes cover the full theme range:
+ *   dark  — existing GitHub-palette accents (light tones on dark BG).
+ *   light — darker, higher-contrast versions that meet WCAG AA on cream/white
+ *           (sepia ≈ #F5ECD7, light ≈ #FFFFFF).
+ *
+ * WCAG AA requires 4.5:1 contrast for normal text; Badge text at 11–12 px
+ * is "small text" so we target ≥ 4.5:1 on both bg extremes.
+ */
+const SOURCE_BADGE_COLORS: Record<string, { dark: string; light: string }> = {
+  issue:       { dark: '#d29922', light: '#7A5400' },
+  pull_request: { dark: '#56d364', light: '#1A6B2A' },
+  commit:      { dark: '#8b949e', light: '#4A5260' },
+  file:        { dark: '#9A8A78', light: '#5C4A38' },
+  authored:    { dark: '#58a6ff', light: '#0050A0' },
+  derived:     { dark: '#e8a854', light: '#7A4A00' },
+  readme:      { dark: '#58a6ff', light: '#0050A0' },
+  external:    { dark: '#79C0FF', light: '#0050A0' },
+  branch:      { dark: '#a78bfa', light: '#4A1F9A' },
+  workflow:    { dark: '#e3b341', light: '#7A5200' },
+  repository:  { dark: '#56d364', light: '#1A6B2A' },
+  section:     { dark: '#8b949e', light: '#4A5260' },
+  structured:  { dark: '#c0a3ff', light: '#4A1F9A' },
+};
+
 /** Describes where a node comes from — shown as a badge next to the cluster */
-function SourceBadge({ node, config }: { node: KBNode; config: KBConfig }) {
+function SourceBadge({ node, config, isDark }: { node: KBNode; config: KBConfig; isDark: boolean }) {
   const repo = `${config.source.owner}/${config.source.repo}`
   const s = node.source
 
   let label: string
-  let color: string
 
   switch (s.type) {
     case 'issue':
       label = `GitHub Issue · ${repo} #${s.number}`
-      color = '#d29922'
       break
     case 'pull_request':
       label = `GitHub PR · ${repo} #${s.number}`
-      color = '#56d364'
       break
     case 'commit':
       label = `GitHub Commits · ${repo}`
-      color = '#8b949e'
       break
     case 'file':
       label = `File · ${s.path}`
-      color = '#9A8A78'
       break
     case 'authored':
       label = `Authored · ${s.file.replace(/.*\//, '')}`
-      color = '#58a6ff'
       break
     case 'derived':
       label = `Derived Content`
-      color = '#e8a854'
       break
     case 'readme':
       label = `README · ${repo}`
-      color = '#58a6ff'
       break
     case 'external':
       label = `External · ${s.provider}`
-      color = '#79C0FF'
       break
     case 'branch':
       label = `Branch · ${s.name}${s.protected ? ' 🛡️' : ''}`
-      color = '#a78bfa'
       break
     case 'workflow':
       label = `Workflow · ${s.path.replace('.github/workflows/', '')}`
-      color = '#e3b341'
       break
     case 'repository':
       label = `Repository · ${s.owner}/${s.repo}`
-      color = '#56d364'
       break
     case 'section':
       label = 'Section'
-      color = '#8b949e'
       break
     case 'structured':
       label = `Entity · ${humanizeEntityType(s.entityType)}`
-      color = '#c0a3ff'
       break
     default:
       return null
   }
+
+  const palette = SOURCE_BADGE_COLORS[s.type];
+  const color = palette ? (isDark ? palette.dark : palette.light) : (isDark ? '#8b949e' : '#4A5260');
 
   return (
     <Badge
@@ -429,6 +445,11 @@ function SourceBadge({ node, config }: { node: KBNode; config: KBConfig }) {
 export function ReadingView({ graph, config, nodeId, theme }: ReadingViewProps) {
   const styles = useStyles();
   const node = graph.nodes.find(n => n.id === nodeId);
+
+  // Derive dark/light flag from the resolved Fluent theme so config themes
+  // (arbitrary key names) drive contrast decisions correctly — not just the
+  // built-in 'dark'/'light' mode strings.
+  const isDark = theme ? isDarkTheme(theme) : true;
 
   // Runtime theme map (built-ins + config themes) for resolving a node's
   // optional named per-page theme. Rebuilt only when config.theme changes.
@@ -546,15 +567,15 @@ export function ReadingView({ graph, config, nodeId, theme }: ReadingViewProps) 
         >
           <div className={styles.headerVisual}>
             {!showHero && (mode === 'sprites' && node.sprite) && (
-              <NodeVisual node={node} mode={mode} surface="header" source={source} clusterColor={cluster.color} />
+              <NodeVisual node={node} mode={mode} surface="header" source={source} clusterColor={cluster.color} isDark={isDark} />
             )}
             {!showHero && mode === 'emoji' && node.emoji && (
-              <NodeVisual node={node} mode="emoji" surface="header" source={source} clusterColor={cluster.color} />
+              <NodeVisual node={node} mode="emoji" surface="header" source={source} clusterColor={cluster.color} isDark={isDark} />
             )}
           </div>
           <div className={styles.clusterBadge} style={{ display: 'flex', gap: 6, flexWrap: 'wrap', alignItems: 'center' }}>
             <Badge appearance="tint" color="informative">{cluster.name}</Badge>
-            <SourceBadge node={node} config={config} />
+            <SourceBadge node={node} config={config} isDark={isDark} />
             {canEditSource(node) && <SourceEditor node={node} config={config} />}
           </div>
           <Title1>{node.title}</Title1>
@@ -577,7 +598,7 @@ export function ReadingView({ graph, config, nodeId, theme }: ReadingViewProps) 
                   <a key={child.id} href={`#/node/${encodeURIComponent(child.id)}`} style={{ textDecoration: 'none', color: 'inherit' }}>
                     <Card appearance="subtle" size="small" style={{ marginBottom: 4 }}>
                       <div style={{ display: 'flex', alignItems: 'center', gap: tokens.spacingHorizontalS }}>
-                        <NodeVisual node={child} mode={config.visuals.mode} surface="hud-thumb" source={config.source} clusterColor={childCluster.color} />
+                        <NodeVisual node={child} mode={config.visuals.mode} surface="hud-thumb" source={config.source} clusterColor={childCluster.color} isDark={isDark} />
                         <div style={{ flex: 1, minWidth: 0 }}>
                           <Body1Strong style={{ display: 'block' }}>{child.title}</Body1Strong>
                           {child.rawContent && (
@@ -616,7 +637,7 @@ export function ReadingView({ graph, config, nodeId, theme }: ReadingViewProps) 
                   <a key={t.id} href={`#/node/${encodeURIComponent(t.id)}`} style={{ textDecoration: 'none', color: 'inherit' }}>
                     <Card appearance="subtle" size="small" style={{ marginBottom: 4 }}>
                       <div style={{ display: 'flex', alignItems: 'center', gap: tokens.spacingHorizontalS }}>
-                        <NodeVisual node={t} mode={config.visuals.mode} surface="hud-thumb" source={config.source} clusterColor={targetCluster.color} />
+                        <NodeVisual node={t} mode={config.visuals.mode} surface="hud-thumb" source={config.source} clusterColor={targetCluster.color} isDark={isDark} />
                         <div style={{ flex: 1, minWidth: 0 }}>
                           <Body1Strong style={{ display: 'block' }}>{t.title}</Body1Strong>
                           <Caption1 style={{ color: tokens.colorNeutralForeground3 }}>{conn.description}</Caption1>


### PR DESCRIPTION
Closes #250

## Summary

- **`IsDarkContext`** (`src/theme/isDarkContext.tsx`) — a new single-value React context that broadcasts whether the active theme is dark, provided at the `App` root so every component in the tree can adapt without prop-drilling.
- **`NodeVisual`** — adds `ensureIconContrast()` (HSL clamp to ≤ 42 % lightness on light themes) so Fluent icons coloured by cluster accent are legible on cream/white backgrounds. Falls back to `IsDarkContext` when no explicit `isDark` prop is given, so the HUD related-rail icons pick it up without touching HUD.tsx. Dark-theme path is byte-for-byte unchanged.
- **`SourceBadge`** — replaces the single hardcoded dark-palette hex per source type with a `SOURCE_BADGE_COLORS` map of `{ dark, light }` pairs. Light-palette values (`#0050A0`, `#1A6B2A`, …) were chosen to reach ≥ 4.5:1 contrast against both sepia (`#F5ECD7`) and white (`#FFFFFF`). `isDarkTheme(theme)` on the resolved Fluent theme selects the right palette at render time.
- **`ReadingView`** — derives `isDark` from the `theme` prop and threads it into all `NodeVisual` and `SourceBadge` call sites in the reading header and connection rails.

## Test plan

- [x] `vitest` — 608/608 tests pass
- [x] `npm run build` — `tsc -b` + `vite build` clean (no new warnings)
- [x] `npm run capture:review` — screenshots captured and reviewed:
  - `reading--dark--desktop.png` — dark baseline unchanged: light-blue badge and mid-blue icon
  - `reading--light--desktop.png` — badge darkens to `#0050A0`, icon darkens to ≤ 42 % L; both legible on white
  - `reading--sepia--desktop.png` — badge dark navy on cream; icon dark green/amber on cream; paper-and-ink treatment preserved
  - `reading--ocean--desktop.png` — icons and badge adapt to ocean's dark background correctly (isDark → true)
  - `node-selected--sepia--desktop.png` — header icon + badge + HUD rail icons all darkened appropriately; no cold-blue accents on cream

🤖 Generated with [Claude Code](https://claude.com/claude-code)