### PR TITLE
test(gitea): work-graph mutations (team/workstream/release) reflected on refresh

### DIFF
--- a/e2e/gitea/workgraph-mutations.spec.ts
+++ b/e2e/gitea/workgraph-mutations.spec.ts
@@ -1,0 +1,310 @@
+import { test, expect, type Page, request as pwRequest } from '@playwright/test';
+import { editSource } from '../../twins/gitea/actors/edit-source.mjs';
+import { cutRelease } from '../../twins/gitea/actors/cut-release.mjs';
+import {
+  coords,
+  getContents,
+  mergePull,
+} from '../../twins/gitea/gitea-client.mjs';
+
+/**
+ * Work-graph DTU scenarios: team / workstream / release mutations reflected on
+ * refresh (issue #256).
+ *
+ * ## Substrate
+ *
+ * The Gitea twin serves three distinct surfaces the app reads:
+ *
+ *   1. `contents` / `git/trees` — raw YAML files (team, workstream descriptors).
+ *      The adapter proxies these byte-for-byte; any merged edit appears on the
+ *      next cache-fresh load.
+ *
+ *   2. `releases` — the `fetchReleases()` path, now proxied by the adapter
+ *      (see `adapter.mjs` `normalizeRelease`). `cutRelease()` creates a real
+ *      Gitea release; the app renders it as a release node (cluster `releases`).
+ *
+ *   3. Content-model semantic nodes (cluster `team`, `workstream`) are derived by
+ *      `ContentModelProvider`, which is registered as a **safe no-op**
+ *      (`new ContentModelProvider(null)`) in `loadRemoteKnowledgeBase()` — the
+ *      remote content-model fetch path is not yet wired. This means team /
+ *      workstream nodes from `content-model/teams/*.yaml` and
+ *      `content-model/workstreams/*.yaml` do NOT appear in the live app as
+ *      semantic cluster nodes.
+ *
+ * ## Gap (honest)
+ *
+ * Semantic team/workstream nodes are not rendered in remote mode until the
+ * content-model fetch path lands in `loadRemoteKnowledgeBase` (the
+ * `ContentModelProvider(null)` registration becomes live). The specs below
+ * validate the **complete live path** for releases and the **proxy layer** for
+ * team/workstream edits (updated YAML on `main` is reflected in the adapter's
+ * `contents` response). The semantic graph assertion for teams/workstreams is
+ * marked `.fixme` with a comment explaining the gap so it is visible to CI and
+ * can be unfixme'd when the feature lands.
+ */
+
+const TWIN_PORT = Number(process.env.DTU_TWIN_PORT ?? 3557);
+const TWIN_BASE = `http://localhost:${TWIN_PORT}`;
+
+async function freshLoad(page: Page, hash: string) {
+  await page.goto(`/#${hash}`, { waitUntil: 'networkidle', timeout: 60_000 });
+}
+
+async function clearCacheAndReload(page: Page) {
+  await page.evaluate(() => localStorage.clear());
+  await page.reload({ waitUntil: 'networkidle' });
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Release scenarios
+// ────────────────────────────────────────────────────────────────────────────
+
+test.describe('Gitea DTU — release mutations', () => {
+  test('a new release appears as a release node on a cache-fresh load', async ({ page }) => {
+    const tag = `dtu-v9-${Date.now()}`;
+    const releaseName = `DTU Release ${tag}`;
+
+    const rel = await cutRelease({ tag, name: releaseName });
+    expect(rel.tag).toBe(tag);
+    expect(rel.prerelease).toBe(false);
+
+    // Fresh context — empty localStorage — fetches live releases.
+    await freshLoad(page, '/overview');
+
+    // The release node should be visible by its display name.
+    await expect(page.getByText(releaseName).first()).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('a pre-release is reflected as a separate release node', async ({ page }) => {
+    const tag = `dtu-pre-${Date.now()}`;
+    const relName = `DTU Pre-Release ${tag}`;
+
+    const rel = await cutRelease({ tag, name: relName, prerelease: true });
+    expect(rel.prerelease).toBe(true);
+
+    await freshLoad(page, '/overview');
+
+    await expect(page.getByText(relName).first()).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('adapter release endpoint: normalizes Gitea release to GitHub shape', async () => {
+    /**
+     * Request-level check: the adapter's /releases route returns a response with
+     * the GitHub-shaped fields the app's `fetchReleases()` reads (`tag_name`,
+     * `name`, `published_at`, `prerelease`). Validates `normalizeRelease`.
+     */
+    const { owner, repo } = coords();
+    const tag = `dtu-shape-${Date.now()}`;
+    const relName = `DTU Shape Check ${tag}`;
+
+    await cutRelease({ tag, name: relName });
+
+    const ctx = await pwRequest.newContext({ baseURL: TWIN_BASE });
+    try {
+      const releasesPath = `/repos/${owner}/${repo}/releases?per_page=30`;
+      const res = await ctx.get(releasesPath);
+      expect(res.status()).toBe(200);
+
+      const data = await res.json() as Array<Record<string, unknown>>;
+      expect(Array.isArray(data)).toBe(true);
+
+      const mine = data.find((r) => r['tag_name'] === tag);
+      expect(mine).toBeDefined();
+      // GitHub-shape fields the app reads:
+      expect(typeof mine!['tag_name']).toBe('string');
+      expect(typeof mine!['name']).toBe('string');
+      expect(typeof mine!['published_at']).toBe('string');
+      expect(typeof mine!['prerelease']).toBe('boolean');
+      expect(typeof mine!['html_url']).toBe('string');
+
+      // ETag header present (enables 304 caching in the app).
+      expect(res.headers()['etag']).toBeTruthy();
+    } finally {
+      await ctx.dispose();
+    }
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// Team YAML mutation scenarios
+// ────────────────────────────────────────────────────────────────────────────
+
+test.describe('Gitea DTU — team YAML mutations', () => {
+  test(
+    'editing a team YAML and merging updates the file on main via the adapter contents route',
+    async ({ page }) => {
+      /**
+       * Validates the full proxy layer: actor edits teams/graph-platform.yaml,
+       * merges, and the updated YAML is served by the adapter's `contents` route
+       * (same path the app uses for `fetchFile`). The file-tree directory node for
+       * `content-model/teams/` also refreshes its ETag.
+       *
+       * Semantic team cluster node assertion: see `.fixme` test below.
+       */
+      const { owner, repo, branch } = coords();
+      const marker = `DTU-TEAM-${Date.now()}`;
+
+      // 1) Actor edits teams/graph-platform.yaml — appends a marker comment.
+      const { pr: prNumber, path: editPath } = await editSource({
+        path: 'content-model/teams/graph-platform.yaml',
+        marker,
+        title: `DTU team edit ${marker}`,
+      });
+      expect(prNumber).toBeGreaterThan(0);
+
+      // 2) Merge the PR to advance main.
+      const merge = await mergePull(owner, repo, prNumber, { style: 'merge' });
+      expect(merge.merged).toBe(true);
+
+      // 3) Verify the updated YAML is on main.
+      const onMain = await getContents(owner, repo, editPath, branch);
+      const mainText = Buffer.from(onMain.content, 'base64').toString('utf8');
+      expect(mainText).toContain(marker);
+
+      // 4) Adapter's `contents` route returns the updated file with a fresh ETag.
+      const ctx = await pwRequest.newContext({ baseURL: TWIN_BASE });
+      try {
+        const contentsPath = `/repos/${owner}/${repo}/contents/${editPath}?ref=${branch}`;
+        const res = await ctx.get(contentsPath);
+        expect(res.status()).toBe(200);
+
+        const data = await res.json() as Record<string, unknown>;
+        expect(data['encoding']).toBe('base64');
+        const decoded = Buffer.from(data['content'] as string, 'base64').toString('utf8');
+        expect(decoded).toContain(marker);
+      } finally {
+        await ctx.dispose();
+      }
+
+      // 5) App: after clearing the cache, the file tree reflects the updated tree.
+      //    We verify the app loads without error (regression guard) and that the
+      //    content-model/teams directory node is still present.
+      await clearCacheAndReload(page);
+      await freshLoad(page, '/overview');
+      // The directory node title "content-model/teams/" appears in the file-tree region.
+      await expect(page.getByText('content-model/teams/').first()).toBeVisible({ timeout: 15_000 });
+    },
+  );
+
+  /**
+   * GAP: semantic team cluster node does not appear in remote mode.
+   *
+   * `ContentModelProvider` is registered as `new ContentModelProvider(null)` in
+   * `loadRemoteKnowledgeBase()` (src/engine/remote-loader.ts:220) — the content-
+   * model fetch path is not yet wired for remote/live operation. Until that
+   * feature lands, `team` cluster nodes from `content-model/teams/*.yaml` are
+   * absent from the live app, so we cannot assert `page.getByText('Graph Platform')`.
+   *
+   * Unfix this test when the remote content-model fetch path is wired.
+   */
+  test.fixme(
+    'team name change is reflected as a renamed team node in the graph (remote content-model gap)',
+    async ({ page }) => {
+      const { owner, repo, branch } = coords();
+      const newName = `Graph Platform DTU ${Date.now()}`;
+      const marker = newName;
+
+      const { pr: prNumber } = await editSource({
+        path: 'content-model/teams/graph-platform.yaml',
+        set: { name: `"${newName}"` },
+        title: `DTU team rename ${Date.now()}`,
+      });
+      const merge = await mergePull(owner, repo, prNumber, { style: 'merge' });
+      expect(merge.merged).toBe(true);
+
+      // Confirm the twin's main has the new name.
+      const onMain = await getContents(owner, repo, 'content-model/teams/graph-platform.yaml', branch);
+      const mainText = Buffer.from(onMain.content, 'base64').toString('utf8');
+      expect(mainText).toContain(marker);
+
+      // Semantic assertion: team node should appear in the overview.
+      // (Currently fails because ContentModelProvider is a no-op in remote mode.)
+      await clearCacheAndReload(page);
+      await freshLoad(page, '/overview');
+      await expect(page.getByText(newName).first()).toBeVisible({ timeout: 15_000 });
+    },
+  );
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// Workstream YAML mutation scenarios
+// ────────────────────────────────────────────────────────────────────────────
+
+test.describe('Gitea DTU — workstream YAML mutations', () => {
+  test(
+    'editing a workstream YAML and merging updates the file on main via the adapter',
+    async ({ page }) => {
+      /**
+       * Same proxy-layer check as the team scenario, for workstreams.
+       * Merges an edit to workstreams/kb-explorer.yaml and confirms the adapter
+       * serves the updated content via the `contents` route.
+       */
+      const { owner, repo, branch } = coords();
+      const marker = `DTU-WS-${Date.now()}`;
+
+      const { pr: prNumber, path: editPath } = await editSource({
+        path: 'content-model/workstreams/kb-explorer.yaml',
+        marker,
+        title: `DTU workstream edit ${marker}`,
+      });
+      expect(prNumber).toBeGreaterThan(0);
+
+      const merge = await mergePull(owner, repo, prNumber, { style: 'merge' });
+      expect(merge.merged).toBe(true);
+
+      // Confirm file updated on main.
+      const onMain = await getContents(owner, repo, editPath, branch);
+      const mainText = Buffer.from(onMain.content, 'base64').toString('utf8');
+      expect(mainText).toContain(marker);
+
+      // Adapter contents route reflects the change.
+      const ctx = await pwRequest.newContext({ baseURL: TWIN_BASE });
+      try {
+        const contentsPath = `/repos/${owner}/${repo}/contents/${editPath}?ref=${branch}`;
+        const res = await ctx.get(contentsPath);
+        expect(res.status()).toBe(200);
+        const data = await res.json() as Record<string, unknown>;
+        const decoded = Buffer.from(data['content'] as string, 'base64').toString('utf8');
+        expect(decoded).toContain(marker);
+      } finally {
+        await ctx.dispose();
+      }
+
+      // App-level: directory node still visible after cache clear.
+      await clearCacheAndReload(page);
+      await freshLoad(page, '/overview');
+      await expect(page.getByText('content-model/workstreams/').first()).toBeVisible({ timeout: 15_000 });
+    },
+  );
+
+  /**
+   * GAP: semantic workstream cluster node not present in remote mode.
+   * Same root cause as the team gap above — ContentModelProvider(null) no-op.
+   *
+   * Unfix when the remote content-model fetch path lands.
+   */
+  test.fixme(
+    'workstream description edit is reflected as an updated workstream node (remote content-model gap)',
+    async ({ page }) => {
+      const { owner, repo, branch } = coords();
+      const newDesc = `DTU workstream updated ${Date.now()}`;
+
+      const { pr: prNumber } = await editSource({
+        path: 'content-model/workstreams/kb-explorer.yaml',
+        set: { description: `"${newDesc}"` },
+        title: `DTU workstream desc ${Date.now()}`,
+      });
+      const merge = await mergePull(owner, repo, prNumber, { style: 'merge' });
+      expect(merge.merged).toBe(true);
+
+      const onMain = await getContents(owner, repo, 'content-model/workstreams/kb-explorer.yaml', branch);
+      const mainText = Buffer.from(onMain.content, 'base64').toString('utf8');
+      expect(mainText).toContain(newDesc);
+
+      // Semantic assertion: workstream node visible with updated description.
+      await clearCacheAndReload(page);
+      await freshLoad(page, '/overview');
+      await expect(page.getByText(newDesc).first()).toBeVisible({ timeout: 15_000 });
+    },
+  );
+});

--- a/e2e/gitea/workgraph-mutations.spec.ts
+++ b/e2e/gitea/workgraph-mutations.spec.ts
@@ -51,6 +51,12 @@ async function freshLoad(page: Page, hash: string) {
 }
 
 async function clearCacheAndReload(page: Page) {
+  // localStorage is origin-scoped. On a fresh page (about:blank) there is no app
+  // origin yet, so navigate to the app first — otherwise clear()/reload() act on
+  // about:blank and are a no-op. Idempotent when already on the app.
+  if (!page.url().includes('#/')) {
+    await page.goto('/#/overview', { waitUntil: 'networkidle', timeout: 60_000 });
+  }
   await page.evaluate(() => localStorage.clear());
   await page.reload({ waitUntil: 'networkidle' });
 }

--- a/twins/gitea/__tests__/adapter.test.mjs
+++ b/twins/gitea/__tests__/adapter.test.mjs
@@ -4,6 +4,7 @@ import {
   parseRoute,
   translatePath,
   normalizeIssue,
+  normalizeRelease,
   paginate,
   buildLinkHeader,
   computeEtag,
@@ -42,6 +43,8 @@ describe('parseRoute', () => {
     expect(parseRoute('/repos/o/r/issues')).toMatchObject({ kind: 'issues' });
     expect(parseRoute('/repos/o/r/pulls')).toMatchObject({ kind: 'pulls' });
     expect(parseRoute('/repos/o/r/commits')).toMatchObject({ kind: 'commits' });
+    expect(parseRoute('/repos/o/r/releases')).toMatchObject({ kind: 'releases', owner: 'o', repo: 'r' });
+    expect(parseRoute('/repos/o/r/releases/')).toMatchObject({ kind: 'releases', owner: 'o', repo: 'r' });
   });
 
   it('decodes a URL-encoded tree ref', () => {
@@ -61,6 +64,39 @@ describe('translatePath', () => {
     expect(translatePath({ kind: 'issues', owner: 'o', repo: 'r' })).toBe('/api/v1/repos/o/r/issues');
     expect(translatePath({ kind: 'pulls', owner: 'o', repo: 'r' })).toBe('/api/v1/repos/o/r/pulls');
     expect(translatePath({ kind: 'commits', owner: 'o', repo: 'r' })).toBe('/api/v1/repos/o/r/commits');
+    expect(translatePath({ kind: 'releases', owner: 'o', repo: 'r' })).toBe('/api/v1/repos/o/r/releases');
+  });
+});
+
+describe('normalizeRelease', () => {
+  it('maps Gitea created_at → GitHub published_at', () => {
+    const ts = '2026-01-15T10:00:00Z';
+    const norm = normalizeRelease({ tag_name: 'v1.0', name: 'Release 1.0', body: 'notes', html_url: 'https://x', created_at: ts, is_prerelease: false, is_draft: false });
+    expect(norm.published_at).toBe(ts);
+    expect(norm.prerelease).toBe(false);
+    expect(norm.draft).toBe(false);
+    expect(norm.tag_name).toBe('v1.0');
+    expect(norm.name).toBe('Release 1.0');
+  });
+
+  it('prefers published_at over created_at when both present', () => {
+    const norm = normalizeRelease({ tag_name: 'v2', published_at: '2026-02-01T00:00:00Z', created_at: '2026-01-01T00:00:00Z', is_prerelease: false, is_draft: false });
+    expect(norm.published_at).toBe('2026-02-01T00:00:00Z');
+  });
+
+  it('normalises Gitea is_prerelease boolean to prerelease', () => {
+    const norm = normalizeRelease({ tag_name: 'v0.1-beta', is_prerelease: true, is_draft: false });
+    expect(norm.prerelease).toBe(true);
+  });
+
+  it('defaults missing fields to empty strings / false', () => {
+    const norm = normalizeRelease({ tag_name: 'v3' });
+    expect(norm.name).toBe('v3');
+    expect(norm.body).toBe('');
+    expect(norm.html_url).toBe('');
+    expect(norm.published_at).toBe('');
+    expect(norm.prerelease).toBe(false);
+    expect(norm.draft).toBe(false);
   });
 });
 
@@ -223,6 +259,33 @@ describe('createGiteaHandler (mocked upstream)', () => {
     const missing = makeRes();
     await handle({ method: 'GET', url: '/repos/o/r/contents/missing.yaml?ref=main', headers: {} }, missing);
     expect(missing.statusCode).toBe(404);
+  });
+
+  it('proxies releases: normalises to GitHub shape, filters drafts, sorts newest-first', async () => {
+    const releases = [
+      { id: 1, tag_name: 'v1.0', name: 'Release 1.0', body: 'notes', html_url: 'https://x/1', published_at: '2026-01-01T00:00:00Z', is_prerelease: false, is_draft: false },
+      { id: 2, tag_name: 'v2.0', name: 'Release 2.0', body: '', html_url: 'https://x/2', published_at: '2026-02-01T00:00:00Z', is_prerelease: false, is_draft: false },
+      { id: 3, tag_name: 'v3.0-draft', name: 'Draft', body: '', html_url: 'https://x/3', published_at: '2026-03-01T00:00:00Z', is_prerelease: false, is_draft: true },
+    ];
+    const handle = handlerWith({
+      '/api/v1/repos/o/r/releases': (page) => page === 1 ? jsonResponse(releases) : jsonResponse([]),
+    });
+    const res = makeRes();
+    await handle({ method: 'GET', url: '/repos/o/r/releases?per_page=30', headers: {} }, res);
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    // Draft filtered out.
+    expect(body).toHaveLength(2);
+    // Sorted newest-first.
+    expect(body[0].tag_name).toBe('v2.0');
+    expect(body[1].tag_name).toBe('v1.0');
+    // GitHub-shaped fields.
+    expect(typeof body[0].published_at).toBe('string');
+    expect(typeof body[0].prerelease).toBe('boolean');
+    // ETag present.
+    expect(res.headers.ETag).toMatch(/^"[0-9a-f]{40}"$/);
+    // X-Total-Count reflects non-draft count.
+    expect(res.headers['X-Total-Count']).toBe('2');
   });
 
   it('ignores non-/repos paths so the host server can 404 them', async () => {

--- a/twins/gitea/actors/cut-release.mjs
+++ b/twins/gitea/actors/cut-release.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+/**
+ * Actor: create a Gitea release (non-draft, non-prerelease by default).
+ *
+ * Gitea releases map to the GitHub Releases API shape the app fetches via
+ * `fetchReleases()`. Cutting a release here mutates the twin so the app
+ * reflects the new release node on a cache-fresh load.
+ *
+ * Importable as `cutRelease()` or runnable as a CLI:
+ *   node twins/gitea/actors/cut-release.mjs --tag v9.9.0 --name "DTU Release"
+ */
+import { coords, gitea } from '../gitea-client.mjs';
+import { parseArgs, nonce } from './_args.mjs';
+
+/**
+ * @param {object} opts
+ * @param {string} [opts.tag]        Tag name to create (default `dtu-v<nonce>`).
+ * @param {string} [opts.name]       Release display name (default same as tag).
+ * @param {string} [opts.body]       Release notes body.
+ * @param {boolean} [opts.prerelease] Mark as pre-release (default false).
+ * @param {string} [opts.target]     Target commit-ish for the tag (default `main`).
+ */
+export async function cutRelease({ tag, name, body, prerelease, target } = {}) {
+  const { owner, repo, branch } = coords();
+  const n = nonce();
+  const tagName = tag ?? `dtu-v${n}`;
+  const relName = name ?? tagName;
+  const relBody = body ?? `DTU actor release ${n}. Validates release-node reflection on refresh.`;
+
+  const res = await gitea('POST', `/repos/${owner}/${repo}/releases`, {
+    tag_name: tagName,
+    name: relName,
+    body: relBody,
+    draft: false,
+    prerelease: Boolean(prerelease),
+    target_commitish: target ?? branch,
+  });
+
+  if (!res.ok) {
+    throw new Error(`cutRelease("${tagName}") failed: ${res.status} ${res.text}`);
+  }
+
+  return {
+    tag: res.json.tag_name,
+    name: res.json.name,
+    id: res.json.id,
+    url: res.json.html_url,
+    prerelease: res.json.prerelease,
+  };
+}
+
+if (process.argv[1]?.endsWith('cut-release.mjs')) {
+  const args = parseArgs(process.argv.slice(2));
+  cutRelease({
+    tag: args.tag,
+    name: args.name,
+    body: args.body,
+    prerelease: args.prerelease === 'true' || args.prerelease === true,
+    target: args.target,
+  })
+    .then((r) => console.log(JSON.stringify(r)))
+    .catch((err) => { console.error(`[cut-release] FAILED: ${err.message}`); process.exit(1); });
+}

--- a/twins/gitea/actors/edit-source.mjs
+++ b/twins/gitea/actors/edit-source.mjs
@@ -39,7 +39,9 @@ export async function editSource({ path, set, marker, title } = {}) {
       content = re.test(content) ? content.replace(re, line) : `${content.replace(/\s*$/, '')}\n${line}\n`;
     }
   } else {
-    content = `${content.replace(/\s*$/, '')}\n# touched by DTU actor ${n}\n`;
+    // Use the caller-supplied marker (for spec assertions) or fall back to the nonce.
+    const tag = marker ?? `touched by DTU actor ${n}`;
+    content = `${content.replace(/\s*$/, '')}\n# ${tag}\n`;
   }
 
   await putFile(owner, repo, targetPath, {

--- a/twins/gitea/adapter.mjs
+++ b/twins/gitea/adapter.mjs
@@ -72,6 +72,9 @@ export function parseRoute(pathname) {
   if ((m = pathname.match(/^\/repos\/([^/]+)\/([^/]+)\/commits\/?$/))) {
     return { kind: 'commits', owner: m[1], repo: m[2] };
   }
+  if ((m = pathname.match(/^\/repos\/([^/]+)\/([^/]+)\/releases\/?$/))) {
+    return { kind: 'releases', owner: m[1], repo: m[2] };
+  }
   return null;
 }
 
@@ -89,6 +92,8 @@ export function translatePath(route) {
       return `${base}/pulls`;
     case 'commits':
       return `${base}/commits`;
+    case 'releases':
+      return `${base}/releases`;
     default:
       return base;
   }
@@ -106,6 +111,27 @@ export function normalizeIssue(issue) {
     ...issue,
     assignees: Array.isArray(issue.assignees) ? issue.assignees : [],
     labels: Array.isArray(issue.labels) ? issue.labels : [],
+  };
+}
+
+/**
+ * Normalise a Gitea release object to the GitHub Releases API shape.
+ *
+ * Key differences:
+ * - Gitea uses `created_at` for the publication timestamp; GitHub uses `published_at`.
+ *   The app reads `published_at` (GHRelease type), so we map it here.
+ * - Gitea's `is_draft` / `is_prerelease` booleans correspond to GitHub's `draft` / `prerelease`.
+ * - `tag_name`, `name`, `body`, and `html_url` are structurally identical.
+ */
+export function normalizeRelease(r) {
+  return {
+    tag_name: r.tag_name ?? '',
+    name: r.name ?? r.tag_name ?? '',
+    body: r.body ?? '',
+    html_url: r.html_url ?? '',
+    published_at: r.published_at ?? r.created_at ?? '',
+    prerelease: Boolean(r.prerelease ?? r.is_prerelease),
+    draft: Boolean(r.draft ?? r.is_draft),
   };
 }
 
@@ -260,6 +286,26 @@ export function createGiteaHandler(opts = {}) {
         if (!r.ok) { ghError(res, r.status, 'Gitea contents error'); return true; }
         const data = await r.json();
         notModifiedOr(res, req, JSON.stringify(data));
+        return true;
+      }
+
+      // Releases: aggregate, normalise to GitHub shape (filter drafts, newest-first).
+      if (route.kind === 'releases') {
+        const upstream = translatePath(route);
+        const agg = await giteaGetAll(upstream, new URLSearchParams());
+        if (!agg.ok) { ghError(res, agg.status, 'Gitea releases error'); return true; }
+        const inParams = new URLSearchParams(search ?? '');
+        const perPage = Number(inParams.get('per_page') ?? 30);
+        const page = Number(inParams.get('page') ?? 1);
+        const allReleases = agg.items
+          .map(normalizeRelease)
+          .filter(r => !r.draft)
+          .sort((a, b) => new Date(b.published_at ?? 0).getTime() - new Date(a.published_at ?? 0).getTime());
+        const { slice, hasNext } = paginate(allReleases, page, perPage);
+        const link = buildLinkHeader(selfBase, pathname, page, perPage, hasNext);
+        const extra = { 'X-Total-Count': String(allReleases.length) };
+        if (link) extra.Link = link;
+        notModifiedOr(res, req, JSON.stringify(slice), extra);
         return true;
       }
 

--- a/twins/gitea/adapter.mjs
+++ b/twins/gitea/adapter.mjs
@@ -300,7 +300,9 @@ export function createGiteaHandler(opts = {}) {
         const allReleases = agg.items
           .map(normalizeRelease)
           .filter(r => !r.draft)
-          .sort((a, b) => new Date(b.published_at ?? 0).getTime() - new Date(a.published_at ?? 0).getTime());
+          // Date.parse('') / invalid → NaN; `|| 0` keeps the comparator stable
+          // when published_at is missing/empty (normalizeRelease can emit '').
+          .sort((a, b) => (Date.parse(b.published_at ?? '') || 0) - (Date.parse(a.published_at ?? '') || 0));
         const { slice, hasNext } = paginate(allReleases, page, perPage);
         const link = buildLinkHeader(selfBase, pathname, page, perPage, hasNext);
         const extra = { 'X-Total-Count': String(allReleases.length) };


### PR DESCRIPTION
Closes #256

## Summary

Extends the live-twin scenario suite (`e2e/gitea/`) to the org layer shipped in #232 — team, workstream, and release mutations — per the requirements in #256.

- **`cut-release` actor** (`twins/gitea/actors/cut-release.mjs`): creates a Gitea release via the Gitea REST API. Runnable as CLI or importable from specs.
- **Adapter `releases` route** (`twins/gitea/adapter.mjs`): proxies `/repos/{owner}/{repo}/releases` → Gitea's equivalent, with a `normalizeRelease` helper that maps Gitea's `created_at`/`is_prerelease`/`is_draft` fields to the GitHub `GHRelease` shape the app reads. Drafts are filtered; results are sorted newest-first. ETag synthesis and 304 revalidation work identically to other list routes.
- **`editSource` actor** (bugfix): the `marker` param was accepted but silently ignored; the else-branch now appends `# <marker>` so specs can assert on a known string.
- **Spec `e2e/gitea/workgraph-mutations.spec.ts`**: six scenarios across three describe blocks.
- **Adapter unit tests**: `parseRoute`, `translatePath`, `normalizeRelease` function, and handler mock for the releases route added to the existing test file.

## Substrate and gap

The spec targets three surfaces:

| Surface | Live? | Notes |
|---|---|---|
| `releases` endpoint | **Yes** | `cutRelease()` → adapter `normalizeRelease` → app `fetchReleases()` → release node in `releases` cluster |
| `contents` / `git/trees` (team/workstream YAML) | **Yes** | `editSource()` + `mergePull()` → file updated on `main` → adapter `contents` route serves updated YAML |
| Semantic team/workstream cluster nodes | **Gap — `.fixme`** | `ContentModelProvider` is registered as `new ContentModelProvider(null)` in `loadRemoteKnowledgeBase()` (line 220) — the remote content-model fetch path is not yet wired. Until that feature lands, `team`/`workstream` cluster nodes are absent from the live app. The two `.fixme` tests document this gap and can be unfixme'd when the remote content-model path lands. |

## Definition of done checklist

- [x] New specs pass: 5 live assertions + 2 `.fixme` (documented gap)
- [x] Existing tests green: `npm test` — 619 tests pass
- [x] `npm run build` clean
- [x] Default fast gate unaffected: `npx playwright test --config playwright.config.ts --list` shows no `workgraph-mutations` tests (the spec is under `e2e/gitea/**` which is in `testIgnore`)
- [x] New specs appear in `npx playwright test --config playwright.gitea.config.ts --list` (12 tests total, 7 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)