### PR TITLE
chore(release): pin template to v0.2.0 + compatibility matrix

### DIFF
--- a/.github/skills/kbexplorer/SKILL.md
+++ b/.github/skills/kbexplorer/SKILL.md
@@ -60,6 +60,17 @@ The agent performs these steps in order:
    It creates `.env.kbexplorer`, `content/config.yaml`, adds npm scripts, and
    installs dependencies automatically.
 
+   **Pin to a release tag (reproducible installs).** After adding the submodule,
+   check it out at an immutable tag rather than leaving it on `main`:
+   ```bash
+   git -C .kbexplorer checkout v0.2.0    # see docs/compatibility.md for valid tags
+   git add .kbexplorer && git commit -m "chore: pin kbexplorer to v0.2.0"
+   ```
+   A tag-pinned checkout is reproducible and is treated as **satisfied** by
+   `kbexplorer doctor` (no branch-tracking warning). See the
+   [compatibility matrix](../../../docs/compatibility.md) for which template tag
+   works with which CLI version.
+
 3. **Start the explorer** (agent runs this):
    ```bash
    npm run kb:dev
@@ -163,6 +174,17 @@ Inform the user that automated validation requires playwright-cli:
 - **Build fails**: Run `npm run kb:install` to ensure dependencies are installed.
 - **Config not loading**: Ensure `content/config.yaml` exists in the target repo
   at the expected path.
+- **`doctor` warns "Template tracks branch …"**: the vendored checkout is on a
+  moving branch instead of a release tag. Pin it to an immutable tag to clear the
+  warning:
+  ```bash
+  git -C .kbexplorer fetch --tags
+  git -C .kbexplorer checkout v0.2.0
+  git add .kbexplorer && git commit -m "chore: pin kbexplorer to v0.2.0"
+  ```
+  Re-run `kbexplorer doctor` — the branch-tracking check now reports satisfied.
+  See [`docs/compatibility.md`](../../../docs/compatibility.md) for the full
+  pinning contract and the template ↔ CLI compatibility matrix.
 
 ## Content Generation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,49 @@
+# Changelog
+
+All notable changes to **kbexplorer-template** are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Releases are cut as immutable git tags (`vX.Y.Z`) plus a matching GitHub Release.
+Host repositories that vendor this template should **pin to a tag**, never track a
+moving branch — see [`docs/compatibility.md`](docs/compatibility.md) for the
+template ↔ kbexplorer CLI compatibility matrix and the pinning contract.
+
+## [Unreleased]
+
+_Nothing yet._
+
+## [0.2.0] - 2026-06-16
+
+First versioned release since the initial `v0.1.0` tag (143 commits). This release
+establishes reproducible **release pinning** for the template.
+
+### Added
+- `CHANGELOG.md` (this file) and a CLI ↔ template **compatibility matrix** at
+  [`docs/compatibility.md`](docs/compatibility.md).
+- Documented **pinning contract**: a host that vendors the template at an immutable
+  tag (`vX.Y.Z`) is the supported, reproducible install. `kbexplorer doctor` treats a
+  tag-pinned checkout as satisfied and does **not** emit the branch-tracking warning.
+- Digital Twin Universe (DTU) exploratory-agent harness and visual-regression review
+  gate (carried in since `v0.1.0`).
+
+### Changed
+- `package.json` / `package-lock.json` `version` bumped from the placeholder `0.0.0`
+  to `0.2.0` so vendored installs report a real, resolvable release.
+- Graph "sensemaking" passes: work nodes anchor to `repo-meta`, the work cluster folds,
+  and visual density is tuned (see `src/api/github.ts` `CACHE_VERSION` history).
+
+### Notes
+- `v0.1.0` remains the initial template release tag; it is immutable and is **not**
+  re-pointed. `0.2.0` supersedes it for new installs.
+
+## [0.1.0] - 2026-04-09
+
+### Added
+- Initial template release: repo-aware and authored content modes, constellation
+  graph, reading view, HUD/minimap, theme switching, and the agent-driven setup skill.
+
+[Unreleased]: https://github.com/anokye-labs/kbexplorer-template/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/anokye-labs/kbexplorer-template/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/anokye-labs/kbexplorer-template/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -313,6 +313,16 @@ The [graph provider architecture](spec-providers-overview) is the next major evo
 
 The [link assessment](spec-link-assessment) tool already provides graph health analysis — orphan detection, broken references, coverage gaps.
 
+## Releases & versioning
+
+Releases are cut as immutable git tags (`vX.Y.Z`) with matching GitHub Releases.
+Host repos that vendor this template should **pin to a tag**, not track `main`.
+
+- **[CHANGELOG.md](CHANGELOG.md)** — notable changes per release.
+- **[docs/compatibility.md](docs/compatibility.md)** — template ↔ kbexplorer CLI
+  compatibility matrix and the pinning contract (`kbexplorer doctor` treats a
+  tag-pinned install as satisfied).
+
 ## License
 
 [MIT](LICENSE)

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,8 +1,9 @@
 # Compatibility Matrix & Release Pinning
 
 This document defines how **kbexplorer-template** releases line up with the
-**kbexplorer CLI** (`anokye-labs/kbexplorer`), and the contract a host repository
-follows when it vendors the template.
+**kbexplorer CLI** — published as the [`@anokye-labs/kbexplorer`](https://www.npmjs.com/package/@anokye-labs/kbexplorer)
+npm package from the [`anokye-labs/kbexplorer-cli`](https://github.com/anokye-labs/kbexplorer-cli)
+repo — and the contract a host repository follows when it vendors the template.
 
 > **TL;DR** — Vendor the template at an **immutable tag** (`vX.Y.Z`), not a moving
 > branch. A tag-pinned install is reproducible and is treated as **satisfied** by
@@ -24,7 +25,8 @@ line, patch/minor CLI releases are expected to remain compatible; a new template
 When in doubt, pin **both** sides:
 
 - the template, to a tag in the table above, and
-- the CLI, to a released CLI tag (the CLI's `init --ref vX.Y.Z` selects it).
+- the CLI, to a released `@anokye-labs/kbexplorer` version (the CLI's
+  `init --ref vX.Y.Z` selects the template tag at bootstrap time).
 
 ---
 
@@ -37,18 +39,19 @@ at an **immutable git tag**:
   than leaving it on `main`:
 
   ```bash
-  git submodule add https://github.com/anokye-labs/kbexplorer.git .kbexplorer
+  git submodule add https://github.com/anokye-labs/kbexplorer-template.git .kbexplorer
   git -C .kbexplorer checkout v0.2.0          # pin to an immutable tag
-  git add .kbexplorer && git commit -m "chore: pin kbexplorer to v0.2.0"
+  git add .kbexplorer && git commit -m "chore: pin kbexplorer-template to v0.2.0"
   ```
 
-- **CLI bootstrap** — the kbexplorer CLI selects the same ref at init time:
+- **CLI bootstrap** — the kbexplorer CLI selects the same template ref at init time:
 
   ```bash
-  kbexplorer init --ref v0.2.0
+  npx @anokye-labs/kbexplorer init --ref v0.2.0
   ```
 
-  > The `init --ref` resolution itself lives in the CLI repo; this template only
+  > The `init --ref` resolution itself lives in the
+  > [CLI repo](https://github.com/anokye-labs/kbexplorer-cli); this template only
   > documents which tags are valid targets (see the matrix above).
 
 Tracking a branch (`main`) instead of a tag is **not** reproducible: the upstream
@@ -88,9 +91,15 @@ satisfied because the checkout now resolves to an immutable tag.
 
 ## Cutting a new template release (maintainers)
 
-Bumping `package.json` `version` is necessary but not sufficient — a release is only
-reproducible once an **immutable tag and GitHub Release** exist. After the version
-bump merges to `main`:
+The compatibility matrix above and [`CHANGELOG.md`](../CHANGELOG.md) are updated **in
+the same version-bump PR** as `package.json` `version`, so that the documented matrix
+and release notes are already correct on `main` before any tag exists. Bumping the
+version and updating these docs is necessary but not sufficient — a release is only
+*reproducible* once an **immutable tag and GitHub Release** also exist.
+
+After the version-bump PR (which already added this release's matrix row and CHANGELOG
+entry) merges to `main`, cut the tag and release so they reflect what `main` already
+documents:
 
 ```bash
 git checkout main && git pull
@@ -102,5 +111,6 @@ gh release create v0.2.0 \
   --notes-file <(sed -n '/^## \[0.2.0\]/,/^## \[0.1.0\]/p' CHANGELOG.md)
 ```
 
-Then add the new tag to the [compatibility matrix](#template--cli-compatibility-matrix)
-and the [`CHANGELOG.md`](../CHANGELOG.md) in the **next** change.
+Because the matrix and CHANGELOG were already updated in the merged PR, the pushed tag
+and its release notes are accurate the moment they are created — no follow-up doc edit
+is required for this release.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,0 +1,106 @@
+# Compatibility Matrix & Release Pinning
+
+This document defines how **kbexplorer-template** releases line up with the
+**kbexplorer CLI** (`anokye-labs/kbexplorer`), and the contract a host repository
+follows when it vendors the template.
+
+> **TL;DR** — Vendor the template at an **immutable tag** (`vX.Y.Z`), not a moving
+> branch. A tag-pinned install is reproducible and is treated as **satisfied** by
+> `kbexplorer doctor` (no branch-tracking warning).
+
+---
+
+## Template ↔ CLI compatibility matrix
+
+| Template tag | Status      | Compatible kbexplorer CLI | Notes |
+|--------------|-------------|---------------------------|-------|
+| `v0.2.0`     | **Current** | `>= 0.1.0`                | Adds release pinning, CHANGELOG, this matrix. Recommended for new installs. |
+| `v0.1.0`     | Superseded  | `>= 0.1.0`                | Initial template release. Immutable; not re-pointed. |
+
+Compatibility is expressed against the CLI's published releases. Within a `0.x`
+line, patch/minor CLI releases are expected to remain compatible; a new template
+**minor** (e.g. `0.2 → 0.3`) is the signal to re-check this table before upgrading.
+
+When in doubt, pin **both** sides:
+
+- the template, to a tag in the table above, and
+- the CLI, to a released CLI tag (the CLI's `init --ref vX.Y.Z` selects it).
+
+---
+
+## The pinning contract
+
+A *supported, reproducible* install of the template means a host repo references it
+at an **immutable git tag**:
+
+- **Submodule / vendor checkout** — add the dependency and check out a tag rather
+  than leaving it on `main`:
+
+  ```bash
+  git submodule add https://github.com/anokye-labs/kbexplorer.git .kbexplorer
+  git -C .kbexplorer checkout v0.2.0          # pin to an immutable tag
+  git add .kbexplorer && git commit -m "chore: pin kbexplorer to v0.2.0"
+  ```
+
+- **CLI bootstrap** — the kbexplorer CLI selects the same ref at init time:
+
+  ```bash
+  kbexplorer init --ref v0.2.0
+  ```
+
+  > The `init --ref` resolution itself lives in the CLI repo; this template only
+  > documents which tags are valid targets (see the matrix above).
+
+Tracking a branch (`main`) instead of a tag is **not** reproducible: the upstream
+ref moves, so two installs taken a day apart can render differently and cannot be
+audited. That is precisely the situation `kbexplorer doctor` flags.
+
+---
+
+## How `kbexplorer doctor` treats a pinned install
+
+`kbexplorer doctor` runs in the **host** repo and inspects how the template/CLI is
+vendored. Its branch-tracking check resolves as follows:
+
+| Vendored ref                          | doctor result | Guidance emitted |
+|---------------------------------------|---------------|------------------|
+| Immutable tag (`vX.Y.Z`)              | **Satisfied** | none — pinning requirement met |
+| Detached HEAD at a tagged commit      | **Satisfied** | none |
+| Moving branch (`main`, `master`, …)   | **Warning**   | *"Template tracks branch <name>; pin to a release tag for reproducible installs."* |
+
+To clear the warning, move the vendored checkout from the branch onto a tag from
+the matrix:
+
+```bash
+git -C .kbexplorer fetch --tags
+git -C .kbexplorer checkout v0.2.0
+git add .kbexplorer && git commit -m "chore: pin kbexplorer to v0.2.0"
+```
+
+After re-pinning, re-run `kbexplorer doctor`; the branch-tracking check reports
+satisfied because the checkout now resolves to an immutable tag.
+
+> The doctor command's source lives in the kbexplorer **CLI** repo. This document is
+> the template-side half of that contract: it enumerates the tags doctor accepts as
+> "pinned" and keeps the compatibility matrix authoritative.
+
+---
+
+## Cutting a new template release (maintainers)
+
+Bumping `package.json` `version` is necessary but not sufficient — a release is only
+reproducible once an **immutable tag and GitHub Release** exist. After the version
+bump merges to `main`:
+
+```bash
+git checkout main && git pull
+git tag -a v0.2.0 -m "v0.2.0 — release pinning, CHANGELOG, compatibility matrix"
+git push origin v0.2.0
+gh release create v0.2.0 \
+  --repo anokye-labs/kbexplorer-template \
+  --title "v0.2.0" \
+  --notes-file <(sed -n '/^## \[0.2.0\]/,/^## \[0.1.0\]/p' CHANGELOG.md)
+```
+
+Then add the new tag to the [compatibility matrix](#template--cli-compatibility-matrix)
+and the [`CHANGELOG.md`](../CHANGELOG.md) in the **next** change.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kbexplorer-template",
-  "version": "0.0.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kbexplorer-template",
-      "version": "0.0.0",
+      "version": "0.2.0",
       "dependencies": {
         "@fluentui/react-components": "^9.73.7",
         "@fluentui/react-icons": "^2.0.323",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kbexplorer-template",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Closes #276 — Task E under Epic #273. Establishes reproducible **release pinning** for the template.

## What changed
- **Version bump**: `package.json` + `package-lock.json` `version` `0.0.0` -> `0.2.0`. `v0.1.0` already exists (initial template release, commit `7bb138d`) with **143 commits since**, so `0.1.0` is taken -> next release is `0.2.0`.
- **CHANGELOG.md** (Keep a Changelog / SemVer) with `0.2.0` and `0.1.0` entries and compare links.
- **docs/compatibility.md**: template-tag <-> kbexplorer CLI compatibility matrix + the pinning contract.
- **doctor guidance alignment**: documented that a vendor-pinned install referencing an **immutable tag** is treated as *satisfied* by `kbexplorer doctor` (no branch-tracking warning), in `SKILL.md` setup + troubleshooting and in `docs/compatibility.md`. The doctor command source lives in the kbexplorer **CLI** repo (out of scope here, per the task note); this PR is the template-side half of that contract.
- README links to CHANGELOG + compatibility.

## Verification
- `npm install` PASS
- `npm run build` PASS (tsc + vite build)
- `npm test` (vitest) PASS — **621 tests across 47 files passed**
- `npm run lint` PRE-EXISTING FAIL — 6 errors in `src/App.tsx`, `src/components/NodeVisual.tsx`, `src/components/SearchPalette.tsx` (ref-access-during-render, set-state-in-effect, react-refresh export, missing `jsx-a11y/no-static-element-interactions` rule). None of those files are touched by this PR (docs + version metadata only), so the failures are baseline on `main` and out of scope.

> Build note: this environment hit the known npm optional-deps bug (missing `@rolldown/binding-win32-x64-msvc`); installing that platform binding lets `vite build` succeed. Not a repo change.

## Maintainer action post-merge (NOT done by this PR)
Cutting/pushing the tag + GitHub Release is a maintainer action. After this merges to `main`:

```bash
git checkout main && git pull
git tag -a v0.2.0 -m "v0.2.0 — release pinning, CHANGELOG, compatibility matrix"
git push origin v0.2.0
gh release create v0.2.0 --repo anokye-labs/kbexplorer-template --title "v0.2.0" --notes-file <(sed -n '/^## \[0.2.0\]/,/^## \[0.1.0\]/p' CHANGELOG.md)
```

CLI-side `init --ref vX.Y.Z` resolution is out of scope (different repo).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
