### PR TITLE
feat(person): navigable manager/team links in PersonView (#278)

### DIFF
--- a/src/views/viewers/PersonView.tsx
+++ b/src/views/viewers/PersonView.tsx
@@ -1,6 +1,7 @@
 import type { ViewerProps } from './GenericStructuredView';
+import type { KBNode } from '../../types';
 import { EntityHeader } from './spine-shared';
-import { nativeTypeOf } from './spine-data';
+import { nativeTypeOf, resolveRef } from './spine-data';
 
 /** Render a simple key/value row when the value is present. */
 function Row({ label, children }: { label: string; children: React.ReactNode }) {
@@ -27,6 +28,17 @@ function NodeLink({ to, label }: { to: string; label: string }) {
       {label}
     </a>
   );
+}
+
+/**
+ * Render a foreign-key field value (e.g. a person's `manager` or `team`) as a
+ * navigable graph link when it resolves to a node id via the node's JSON-LD
+ * context, falling back to plain text when it cannot be resolved (e.g. a
+ * work-derived person node that carries no context). SSR-safe.
+ */
+function RefLink({ node, kind, value }: { node: KBNode; kind: string; value: string }) {
+  const to = resolveRef(node, kind, value);
+  return to ? <NodeLink to={to} label={value} /> : <>{value}</>;
 }
 
 /**
@@ -73,8 +85,8 @@ export function PersonView({ node }: ViewerProps) {
           {(alias ?? login) && (
             <Row label="GitHub"><code className="kb-structured-code">@{alias ?? login}</code></Row>
           )}
-          {team && <Row label="Team">{team}</Row>}
-          {manager && <Row label="Reports to">{manager}</Row>}
+          {team && <Row label="Team"><RefLink node={node} kind="team" value={team} /></Row>}
+          {manager && <Row label="Reports to"><RefLink node={node} kind="person" value={manager} /></Row>}
           {email && (
             <Row label="Email">
               <a className="kb-structured-link" href={`mailto:${email}`}>{email}</a>

--- a/src/views/viewers/__tests__/spine-viewers.test.ts
+++ b/src/views/viewers/__tests__/spine-viewers.test.ts
@@ -11,6 +11,7 @@ import { MissionView } from '../MissionView';
 import { PriorityView } from '../PriorityView';
 import { CycleView } from '../CycleView';
 import { OrgView } from '../OrgView';
+import { PersonView } from '../PersonView';
 
 function makeNode(entityType: string, data: Record<string, unknown>): KBNode {
   const id = `kg://test/${entityType}`;
@@ -121,5 +122,52 @@ describe('spine viewers — registration + resolution (#164, #165)', () => {
       }
       expect(typeof resolved).toBe('function');
     }
+  });
+});
+
+describe('PersonView — navigable reporting-line links (C1 / #278)', () => {
+  const LD_CONTEXT = {
+    '@base': 'kg://xbox.com/',
+    person: 'kg://xbox.com/people/',
+    team: 'kg://xbox.com/teams/',
+  };
+
+  /** A content-model person descriptor node carrying the JSON-LD @context. */
+  function personNode(data: Record<string, unknown>): KBNode {
+    const id = 'kg://xbox.com/people/ben';
+    return {
+      ...makeNode('person', data),
+      id,
+      identity: id,
+      jsonld: { '@id': id, '@type': 'person', '@context': LD_CONTEXT },
+    };
+  }
+
+  it('renders the manager (Reports to) value as a link to the person node', () => {
+    const html = render(PersonView, personNode({ name: 'Ben Carter', manager: 'ada' }));
+    expect(html).toContain('Reports to');
+    expect(html).toContain('data-node-id="kg://xbox.com/people/ada"');
+    expect(html).toContain('href="#/node/kg%3A%2F%2Fxbox.com%2Fpeople%2Fada"');
+  });
+
+  it('renders the team value as a link to the team node', () => {
+    const html = render(PersonView, personNode({ name: 'Ben Carter', team: 'graph-platform' }));
+    expect(html).toContain('data-node-id="kg://xbox.com/teams/graph-platform"');
+    expect(html).toContain('href="#/node/kg%3A%2F%2Fxbox.com%2Fteams%2Fgraph-platform"');
+  });
+
+  it('expands a CURIE manager reference via the context prefix', () => {
+    const html = render(PersonView, personNode({ name: 'Ben Carter', manager: 'person:ada' }));
+    expect(html).toContain('data-node-id="kg://xbox.com/people/ada"');
+  });
+
+  it('falls back to plain text when the node carries no @context (work-derived person)', () => {
+    const node = makeNode('person', { name: '@octocat', manager: 'ada', team: 'graph-platform' });
+    node.jsonld = { '@id': node.id, '@type': 'person' }; // no @context
+    const html = render(PersonView, node);
+    expect(html).toContain('Reports to');
+    expect(html).toContain('ada');
+    expect(html).toContain('graph-platform');
+    expect(html).not.toContain('data-node-id');
   });
 });

--- a/src/views/viewers/spine-data.ts
+++ b/src/views/viewers/spine-data.ts
@@ -17,6 +17,67 @@ export function arrayField(d: Record<string, unknown>, key: string): unknown[] {
 }
 
 /**
+ * Read the JSON-LD `@context` prefix → URN-base map from a node's envelope.
+ *
+ * The content-model builder emits an object-shaped `@context` (CURIE prefix →
+ * base, plus `@base`). A string/array context (or none) carries no inline
+ * prefixes, so this returns `{}`. Each base value may be a bare string or a
+ * `{ "@id": "…" }` object — both shapes are read, mirroring how the schema
+ * reader parses the context itself.
+ */
+export function ldContextOf(node: Pick<KBNode, 'jsonld'>): Record<string, string> {
+  const ctx = node.jsonld?.['@context'];
+  if (!ctx || typeof ctx !== 'string' && (typeof ctx !== 'object' || Array.isArray(ctx))) {
+    return {};
+  }
+  if (typeof ctx === 'string') return {};
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(ctx as Record<string, unknown>)) {
+    if (typeof v === 'string') out[k] = v;
+    else if (v && typeof v === 'object') {
+      const iri = (v as Record<string, unknown>)['@id'];
+      if (typeof iri === 'string') out[k] = iri;
+    }
+  }
+  return out;
+}
+
+/**
+ * Resolve a foreign-key reference (e.g. a person `manager` id, or a `team` id)
+ * to the canonical graph node id (URN) it points at — the same way the
+ * content-model builder mints node ids — so a viewer can render it as a
+ * navigable `#/node/<id>` link.
+ *
+ * The URN base is read from the source node's own JSON-LD `@context` (never
+ * hardcoded), keeping this pure and SSR-safe. Returns `null` when the reference
+ * cannot be resolved (no context base for `kind`, e.g. a work-derived person
+ * node) so callers can fall back to plain text rather than emit a broken link.
+ *
+ * Accepted reference shapes:
+ *  - already-expanded URN (`kg://…`)            → returned verbatim
+ *  - CURIE (`person:ada`) whose prefix is known → `<base><local>`
+ *  - bare id (`ada`)                            → `<base[kind]><id>`
+ */
+export function resolveRef(
+  node: Pick<KBNode, 'jsonld'>,
+  kind: string,
+  ref: string,
+): string | null {
+  const value = ref.trim();
+  if (!value) return null;
+  if (value.includes('://')) return value; // already a full URN
+  const ctx = ldContextOf(node);
+  const colon = value.indexOf(':');
+  if (colon > 0) {
+    const prefix = value.slice(0, colon);
+    const base = ctx[prefix];
+    if (typeof base === 'string') return `${base}${value.slice(colon + 1)}`;
+  }
+  const base = ctx[kind];
+  return typeof base === 'string' ? `${base}${value}` : null;
+}
+
+/**
  * The repo's native vocabulary term when this node was canonicalized from a
  * cross-repo alias (#153). Surfaced on the JSON-LD envelope as `nativeType` by
  * the content-model builder; `undefined` when the declared `@type` was already


### PR DESCRIPTION
Closes #278

## What

Task C1 (Feature #274, Epic #273). `PersonView` rendered the **manager** (`Reports to`) and **team** field values as plain text. This makes them navigable graph links, reusing the existing `NodeLink` anchor (`#/node/<encoded id>`, with `data-node-id`).

## How

- New pure helpers in `spine-data.ts`:
  - `ldContextOf(node)` — reads the JSON-LD `@context` prefix -> URN-base map from the node's own envelope.
  - `resolveRef(node, kind, ref)` — resolves a foreign-key ref (person `manager` id, `team` id, CURIE, or already-expanded URN) to the canonical node id the same way the content-model builder mints node ids, reading the URN base from the node's context (never hardcoded). Returns `null` when unresolvable.
- `PersonView` gains a small `RefLink` component: renders `NodeLink` when `resolveRef` succeeds, else falls back to plain text (e.g. work-derived person nodes with no `@context`).
- SSR-safe, className-styled (no pixel sizing).

## Tests

Extended `src/views/viewers/__tests__/spine-viewers.test.ts` with a `PersonView` block asserting manager id, team id, CURIE expansion, and the plain-text fallback (encoded href + data-node-id).

## Verification

`npm install`, `npm run build`, vitest (625 passed) all green. `npm run lint` is clean for the changed files (the 6 pre-existing repo lint errors are unrelated).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
