### PR TITLE
feat(graph): reports-to org tree layout (#279)

### DIFF
--- a/src/components/HUD.tsx
+++ b/src/components/HUD.tsx
@@ -39,12 +39,13 @@ import {
   MoreHorizontalRegular,
 } from '@fluentui/react-icons';
 import type { KBGraph, KBConfig, KBNode } from '../types';
-import { getEdgeStyle, getEdgeLegendKey, BUILT_IN_VIEWS, filterGraphToView, collapseGraphClusters, trimGraphToLimits } from '../types';
-import type { TrimResult } from '../types';
+import { getEdgeStyle, getEdgeLegendKey, BUILT_IN_VIEWS, getView, filterGraphToView, collapseGraphClusters, trimGraphToLimits } from '../types';
+import type { TrimResult, GraphLayoutMode } from '../types';
 import type { ThemeMode } from '../hooks/useTheme';
 import { NodeVisual, FLUENT_ICONS, isFluentIconName } from './NodeVisual';
 import { resolveImageUrl } from '../api';
 import { createGraphNetwork, computeGraphPositions } from '../engine/createGraphNetwork';
+import { countReportsToParticipants } from '../engine/reports-to-layout';
 import { ICON_NODE_SHAPE } from '../engine/nodeRenderer';
 
 export type DockPosition = 'bottom' | 'left' | 'right' | 'top';
@@ -493,12 +494,29 @@ export function HUD({ graph, config, currentNodeId, theme, isDark, availableThem
     });
   }, []);
 
+  // Layout strategy requested by the active view (org tree vs force constellation).
+  const viewLayout: GraphLayoutMode = getView(activeView)?.layout ?? 'force';
+
   // Filter graph: view → cluster collapse → trim to limits
   const trimResult = React.useMemo<TrimResult>(() => {
-    let g = filterGraphToView(graph, activeView);
+    const viewGraph = filterGraphToView(graph, activeView);
+    // Org tree: the resolver already scoped + capped the graph to the reporting
+    // hierarchy. Skip cluster-collapse and degree-trim (which assume a force
+    // constellation with a hub) so the whole tree renders. Report how many of
+    // the org's people are shown so the "showing N of M" note stays honest.
+    if (viewLayout === 'reports-to') {
+      const total = countReportsToParticipants(graph);
+      return {
+        graph: viewGraph,
+        trimmed: viewGraph.nodes.length < total,
+        totalNodes: total,
+        totalEdges: viewGraph.edges.length,
+      };
+    }
+    let g = viewGraph;
     if (collapsedClusters.size > 0) g = collapseGraphClusters(g, collapsedClusters);
     return trimGraphToLimits(g, currentNodeId, detailLevel, Infinity);
-  }, [graph, activeView, collapsedClusters, currentNodeId, detailLevel]);
+  }, [graph, activeView, viewLayout, collapsedClusters, currentNodeId, detailLevel]);
 
   const filteredGraph = trimResult.graph;
 
@@ -668,6 +686,7 @@ export function HUD({ graph, config, currentNodeId, theme, isDark, availableThem
       fitOnStabilize: !currentNodeId || filteredGraph.nodes.length < 60,
       emphasizeNodeId: currentNodeId,
       interactive: true,
+      layout: viewLayout,
       auditSlot: 'map-overlay',
     });
     network.once('stabilized', () => {
@@ -678,6 +697,11 @@ export function HUD({ graph, config, currentNodeId, theme, isDark, availableThem
       network.moveTo({ scale: Math.max(scale, 0.3) });
       setOverlayZoom(Math.round(network.getScale() * 100));
     });
+    // Org tree has physics disabled, so `stabilized` never fires — sync the
+    // zoom indicator on the next frame instead.
+    if (viewLayout === 'reports-to' && typeof requestAnimationFrame === 'function') {
+      requestAnimationFrame(() => setOverlayZoom(Math.round(network.getScale() * 100)));
+    }
     network.on('zoom', () => {
       setOverlayZoom(Math.round(network.getScale() * 100));
     });
@@ -686,7 +710,7 @@ export function HUD({ graph, config, currentNodeId, theme, isDark, availableThem
 
     return () => { network.destroy(); overlayNetworkRef.current = null; overlayEmphasisRef.current = null; };
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mapExpanded, filteredGraph, config]);
+  }, [mapExpanded, filteredGraph, config, viewLayout]);
 
   // Sidebar live graph (left/right dock)
   const isVertical = dock === 'left' || dock === 'right';
@@ -718,11 +742,16 @@ export function HUD({ graph, config, currentNodeId, theme, isDark, availableThem
         nodeSizeRange: [28, 44],
         nodeSizeStep: 3,
         labelMaxLength: 18,
+        layout: viewLayout,
         auditSlot: 'hud-sidebar',
       });
       network.once('stabilized', () => {
         setSidebarZoom(Math.round(network.getScale() * 100));
       });
+      // Org tree has physics disabled → sync the zoom indicator next frame.
+      if (viewLayout === 'reports-to' && typeof requestAnimationFrame === 'function') {
+        requestAnimationFrame(() => setSidebarZoom(Math.round(network.getScale() * 100)));
+      }
       network.on('zoom', () => {
         setSidebarZoom(Math.round(network.getScale() * 100));
       });
@@ -741,7 +770,7 @@ export function HUD({ graph, config, currentNodeId, theme, isDark, availableThem
       }
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isVertical, collapsed, filteredGraph, isDark]);
+  }, [isVertical, collapsed, filteredGraph, isDark, viewLayout]);
 
   // Update selection + focus + neighborhood emphasis when currentNodeId changes (no rebuild)
   useEffect(() => {

--- a/src/engine/__tests__/reports-to-layout.test.ts
+++ b/src/engine/__tests__/reports-to-layout.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect } from 'vitest';
+import type { KBGraph, KBNode, KBEdge } from '../../types';
+import { BUILT_IN_VIEWS, getView, filterGraphToView } from '../../types';
+import {
+  REPORTS_TO_RELATION,
+  isPersonNode,
+  selectReportsToEdges,
+  hasReportsToTree,
+  countReportsToParticipants,
+  computeReportsToLevels,
+  projectReportsToTree,
+  DEFAULT_MAX_TREE_NODES,
+} from '../reports-to-layout';
+
+// ── Helpers ────────────────────────────────────────────────
+
+function person(id: string, overrides: Partial<KBNode> = {}): KBNode {
+  return {
+    id,
+    title: id,
+    cluster: 'org',
+    content: '',
+    rawContent: '',
+    connections: [],
+    entityType: 'person',
+    source: { type: 'structured', entityType: 'person' },
+    ...overrides,
+  };
+}
+
+/** reports-to edge: report (from) → manager (to). */
+function reportsTo(report: string, manager: string): KBEdge {
+  return {
+    from: report,
+    to: manager,
+    type: 'related',
+    relation: REPORTS_TO_RELATION,
+    description: 'Reports to',
+    source: 'inferred',
+    weight: 1,
+  };
+}
+
+function graphOf(nodes: KBNode[], edges: KBEdge[]): KBGraph {
+  return { nodes, edges, clusters: [{ id: 'org', name: 'Org', color: '#a371f7' }], related: {} };
+}
+
+// ── isPersonNode ───────────────────────────────────────────
+
+describe('isPersonNode', () => {
+  it('matches entityType person and source.type person', () => {
+    expect(isPersonNode(person('a'))).toBe(true);
+    expect(isPersonNode({ ...person('b'), entityType: undefined, source: { type: 'person', login: 'b', linked: false } })).toBe(true);
+  });
+  it('rejects non-person nodes', () => {
+    expect(isPersonNode({ ...person('c'), entityType: 'team', source: { type: 'structured', entityType: 'team' } })).toBe(false);
+  });
+});
+
+// ── selectReportsToEdges / hasReportsToTree / count ─────────
+
+describe('reports-to edge selection', () => {
+  it('selects only reports-to edges', () => {
+    const g = graphOf(
+      [person('a'), person('b')],
+      [reportsTo('a', 'b'), { from: 'a', to: 'b', type: 'related', relation: 'staffs', description: '', source: 'inferred', weight: 1 }],
+    );
+    expect(selectReportsToEdges(g)).toHaveLength(1);
+    expect(hasReportsToTree(g)).toBe(true);
+    expect(countReportsToParticipants(g)).toBe(2);
+  });
+
+  it('ignores reports-to edges to/from non-person nodes', () => {
+    const team = { ...person('t'), entityType: 'team', source: { type: 'structured' as const, entityType: 'team' } };
+    const g = graphOf([person('a'), team], [reportsTo('a', 't')]);
+    expect(hasReportsToTree(g)).toBe(false);
+    expect(countReportsToParticipants(g)).toBe(0);
+  });
+
+  it('reports no tree on an empty/person-less graph', () => {
+    expect(hasReportsToTree(graphOf([], []))).toBe(false);
+  });
+});
+
+// ── computeReportsToLevels ─────────────────────────────────
+
+describe('computeReportsToLevels', () => {
+  it('levels a simple chain (manager above report)', () => {
+    // ceo <- vp <- eng   (eng reports to vp reports to ceo)
+    const g = graphOf(
+      [person('ceo'), person('vp'), person('eng')],
+      [reportsTo('vp', 'ceo'), reportsTo('eng', 'vp')],
+    );
+    const levels = computeReportsToLevels(g);
+    expect(levels.get('ceo')).toBe(0);
+    expect(levels.get('vp')).toBe(1);
+    expect(levels.get('eng')).toBe(2);
+  });
+
+  it('places all direct reports at the same level (wide fan-out)', () => {
+    const reports = ['r1', 'r2', 'r3', 'r4'];
+    const g = graphOf(
+      [person('boss'), ...reports.map(r => person(r))],
+      reports.map(r => reportsTo(r, 'boss')),
+    );
+    const levels = computeReportsToLevels(g);
+    expect(levels.get('boss')).toBe(0);
+    for (const r of reports) expect(levels.get(r)).toBe(1);
+  });
+
+  it('supports multiple independent roots', () => {
+    const g = graphOf(
+      [person('a'), person('a1'), person('b'), person('b1')],
+      [reportsTo('a1', 'a'), reportsTo('b1', 'b')],
+    );
+    const levels = computeReportsToLevels(g);
+    expect(levels.get('a')).toBe(0);
+    expect(levels.get('b')).toBe(0);
+    expect(levels.get('a1')).toBe(1);
+    expect(levels.get('b1')).toBe(1);
+  });
+
+  it('uses the shortest depth when a person has multiple managers', () => {
+    // x reports to both ceo (lvl0) and vp (lvl1) → x should be lvl1 (min)
+    const g = graphOf(
+      [person('ceo'), person('vp'), person('x')],
+      [reportsTo('vp', 'ceo'), reportsTo('x', 'ceo'), reportsTo('x', 'vp')],
+    );
+    const levels = computeReportsToLevels(g);
+    expect(levels.get('x')).toBe(1);
+  });
+
+  it('is cycle-safe: every participant gets a finite level', () => {
+    // a -> b -> c -> a  (mutual reporting cycle, malformed data)
+    const g = graphOf(
+      [person('a'), person('b'), person('c')],
+      [reportsTo('a', 'b'), reportsTo('b', 'c'), reportsTo('c', 'a')],
+    );
+    const levels = computeReportsToLevels(g);
+    expect(levels.size).toBe(3);
+    for (const id of ['a', 'b', 'c']) {
+      expect(Number.isFinite(levels.get(id))).toBe(true);
+    }
+  });
+
+  it('omits people not in any reporting edge', () => {
+    const g = graphOf(
+      [person('boss'), person('rep'), person('lonely')],
+      [reportsTo('rep', 'boss')],
+    );
+    const levels = computeReportsToLevels(g);
+    expect(levels.has('lonely')).toBe(false);
+  });
+
+  it('scales to a hundreds-person org quickly', () => {
+    // branching 4, depth 4 → 1+4+16+64+256 = 341 people
+    const nodes: KBNode[] = [];
+    const edges: KBEdge[] = [];
+    let counter = 0;
+    const root = person(`p${counter++}`);
+    nodes.push(root);
+    let frontier = [root.id];
+    for (let level = 1; level <= 4; level++) {
+      const next: string[] = [];
+      for (const mgr of frontier) {
+        for (let b = 0; b < 4; b++) {
+          const id = `p${counter++}`;
+          nodes.push(person(id));
+          edges.push(reportsTo(id, mgr));
+          next.push(id);
+        }
+      }
+      frontier = next;
+    }
+    expect(nodes.length).toBe(341);
+    const start = Date.now();
+    const levels = computeReportsToLevels(graphOf(nodes, edges));
+    expect(Date.now() - start).toBeLessThan(200);
+    expect(levels.size).toBe(341);
+    expect(levels.get('p0')).toBe(0);
+    expect(Math.max(...levels.values())).toBe(4);
+  });
+});
+
+// ── projectReportsToTree ───────────────────────────────────
+
+describe('projectReportsToTree', () => {
+  it('keeps only tree participants and reports-to edges', () => {
+    const team = { ...person('t'), entityType: 'team', source: { type: 'structured' as const, entityType: 'team' } };
+    const g = graphOf(
+      [person('boss'), person('rep'), person('lonely'), team],
+      [
+        reportsTo('rep', 'boss'),
+        { from: 'rep', to: 't', type: 'related', relation: 'staffs', description: '', source: 'inferred', weight: 1 },
+      ],
+    );
+    const tree = projectReportsToTree(g);
+    expect(tree.nodes.map(n => n.id).sort()).toEqual(['boss', 'rep']);
+    expect(tree.edges).toHaveLength(1);
+    expect(tree.edges[0].relation).toBe(REPORTS_TO_RELATION);
+  });
+
+  it('returns an empty graph when there is no reporting tree', () => {
+    const tree = projectReportsToTree(graphOf([person('a')], []));
+    expect(tree.nodes).toHaveLength(0);
+    expect(tree.edges).toHaveLength(0);
+  });
+
+  it('rebuilds related restricted to kept nodes', () => {
+    const g: KBGraph = {
+      ...graphOf([person('boss'), person('rep')], [reportsTo('rep', 'boss')]),
+      related: { rep: ['boss', 'ghost'], boss: ['rep'] },
+    };
+    const tree = projectReportsToTree(g);
+    expect(tree.related['rep']).toEqual(['boss']);
+    expect(tree.related['boss']).toEqual(['rep']);
+  });
+
+  it('truncates to the cap breadth-first while staying rooted', () => {
+    // root + 10 reports = 11 nodes; cap at 5 keeps root + first 4 reports
+    const reports = Array.from({ length: 10 }, (_, i) => `r${i}`);
+    const g = graphOf(
+      [person('root'), ...reports.map(r => person(r))],
+      reports.map(r => reportsTo(r, 'root')),
+    );
+    const tree = projectReportsToTree(g, 5);
+    expect(tree.nodes.length).toBe(5);
+    expect(tree.nodes.some(n => n.id === 'root')).toBe(true);
+  });
+
+  it('exposes a sane default cap', () => {
+    expect(DEFAULT_MAX_TREE_NODES).toBeGreaterThanOrEqual(100);
+  });
+});
+
+// ── org built-in view wiring ───────────────────────────────
+
+describe('org built-in view', () => {
+  it('registers an org view that requests the reports-to layout', () => {
+    const org = getView('org');
+    expect(org).toBeDefined();
+    expect(org!.layout).toBe('reports-to');
+    expect(BUILT_IN_VIEWS.some(v => v.id === 'org')).toBe(true);
+  });
+
+  it('resolves to the reporting tree projection', () => {
+    const g = graphOf(
+      [person('boss'), person('rep')],
+      [reportsTo('rep', 'boss')],
+    );
+    const resolved = filterGraphToView(g, 'org');
+    expect(resolved.nodes.map(n => n.id).sort()).toEqual(['boss', 'rep']);
+  });
+
+  it('other views keep the default (force) layout', () => {
+    expect(getView('all')?.layout).toBeUndefined();
+    expect(getView('work')?.layout).toBeUndefined();
+  });
+});

--- a/src/engine/__tests__/reports-to-layout.test.ts
+++ b/src/engine/__tests__/reports-to-layout.test.ts
@@ -152,8 +152,10 @@ describe('computeReportsToLevels', () => {
     expect(levels.has('lonely')).toBe(false);
   });
 
-  it('scales to a hundreds-person org quickly', () => {
-    // branching 4, depth 4 → 1+4+16+64+256 = 341 people
+  it('scales to a hundreds-person org with correct levels', () => {
+    // branching 4, depth 4 → 1+4+16+64+256 = 341 people. Asserts correctness
+    // on a large input (size + depth) deterministically — no wall-clock timing,
+    // which is flaky across CI machines.
     const nodes: KBNode[] = [];
     const edges: KBEdge[] = [];
     let counter = 0;
@@ -173,12 +175,12 @@ describe('computeReportsToLevels', () => {
       frontier = next;
     }
     expect(nodes.length).toBe(341);
-    const start = Date.now();
     const levels = computeReportsToLevels(graphOf(nodes, edges));
-    expect(Date.now() - start).toBeLessThan(200);
     expect(levels.size).toBe(341);
     expect(levels.get('p0')).toBe(0);
     expect(Math.max(...levels.values())).toBe(4);
+    // Every person is leveled exactly once (single sweep, no orphans left over).
+    expect(new Set(levels.keys()).size).toBe(341);
   });
 });
 

--- a/src/engine/createGraphNetwork.ts
+++ b/src/engine/createGraphNetwork.ts
@@ -6,7 +6,8 @@ import { Network } from 'vis-network/standalone';
 import { DataSet } from 'vis-data';
 import { createNodeRenderer } from './nodeRenderer';
 import { getNodeDegrees } from './graph';
-import type { KBGraph } from '../types';
+import { computeReportsToLevels } from './reports-to-layout';
+import type { KBGraph, GraphLayoutMode } from '../types';
 import { getEdgeStyle } from '../types';
 
 export interface GraphNetworkOptions {
@@ -25,6 +26,12 @@ export interface GraphNetworkOptions {
   emphasizeNodeId?: string | null;
   /** Enable drag-to-pan and scroll-to-zoom (default: false) */
   interactive?: boolean;
+  /**
+   * Layout strategy. `'force'` (default) is the force-directed constellation;
+   * `'reports-to'` renders a hierarchical org tree where managers sit above
+   * their reports, levels computed from the `reports-to` relation (#279).
+   */
+  layout?: GraphLayoutMode;
   /**
    * Slot label for the audit hook (`window.__kbeNetworks[slot]`). Used by
    * `scripts/audit-visual.mjs` and devtools to find the live network. If
@@ -130,8 +137,13 @@ export function createGraphNetwork(options: GraphNetworkOptions): GraphNetworkRe
     labelMaxLength = 25,
     emphasizeNodeId,
     interactive = false,
+    layout = 'force',
     auditSlot,
   } = options;
+
+  const hierarchical = layout === 'reports-to';
+  // Per-node tree depth for the hierarchical org layout. Empty in force mode.
+  const reportsToLevels = hierarchical ? computeReportsToLevels(graph) : null;
 
   // Adaptive node sizing — large graphs need smaller nodes so the labels stay
   // proportional and the canvas doesn't turn into a sea of overlapping bubbles.
@@ -175,7 +187,7 @@ export function createGraphNetwork(options: GraphNetworkOptions): GraphNetworkRe
     const sizeRange: [number, number] = faded
       ? [nodeSizeRange[0] * fadedSizeScale, nodeSizeRange[1] * fadedSizeScale]
       : nodeSizeRange;
-    return buildVisNode(n, {
+    const visNode = buildVisNode(n, {
       degrees, clusterColorMap, isDark, keyNodeIds,
       nodeSizeRange: sizeRange, nodeSizeStep, labelMaxLength,
       flagDisconnected: true,
@@ -186,6 +198,9 @@ export function createGraphNetwork(options: GraphNetworkOptions): GraphNetworkRe
       // because the global label threshold (degree ≥ 2) hides them.
       labelDegreeThreshold: effectiveEmphasis && emphasizedIds.has(n.id) ? 0 : undefined,
     });
+    // Hierarchical org layout positions nodes by their reporting depth.
+    if (reportsToLevels) visNode.level = reportsToLevels.get(n.id) ?? 0;
+    return visNode;
   });
 
   // Slightly brighter faded edge tone — the previous rgba(80,80,80,0.08) made
@@ -206,10 +221,14 @@ export function createGraphNetwork(options: GraphNetworkOptions): GraphNetworkRe
     const faded = effectiveEmphasis && !emphasizedIds.has(e.from) && !emphasizedIds.has(e.to);
     const nearFaded = effectiveEmphasis && !(emphasizedIds.has(e.from) && emphasizedIds.has(e.to));
     const springBase = e.source === 'inferred' ? inferredSpringLength : baseSpringLength;
+    // In the hierarchical org tree, render edges manager→report (parent→child)
+    // so vis-network routes them downward. Semantic KBEdge direction
+    // (report→manager) is unchanged; this only affects the drawn vis edge.
+    const reverseForTree = hierarchical && e.relation === 'reports-to';
     return {
       id: `e${i}`,
-      from: e.from,
-      to: e.to,
+      from: reverseForTree ? e.to : e.from,
+      to: reverseForTree ? e.from : e.to,
       title: `${style.label}: ${e.description}`,
       color: {
         color: faded ? EDGE_FADED_COLOR : nearFaded ? 'rgba(80,80,80,0.25)' : style.color,
@@ -349,6 +368,45 @@ export function createGraphNetwork(options: GraphNetworkOptions): GraphNetworkRe
     network.setOptions({ physics: { enabled: false } });
   };
 
+  // Physics + layout differ by mode. Force mode uses forceAtlas2 stabilization;
+  // the org tree uses vis-network's hierarchical layout with physics disabled —
+  // deterministic and fast even for a hundreds-person org (#279).
+  const physicsOptions = hierarchical
+    ? { enabled: false }
+    : {
+        solver: 'forceAtlas2Based',
+        forceAtlas2Based: {
+          gravitationalConstant: -120,
+          // Higher centralGravity keeps the whole graph — including lightly-
+          // connected (orphan) nodes — pulled toward the centre, preventing
+          // them from drifting into a noisy ring at the periphery (#252).
+          centralGravity: 0.06,
+          springLength: 180,
+          springConstant: 0.05,
+          damping: 0.6,
+        },
+        stabilization: { enabled: true, iterations: 500, updateInterval: 100 },
+      };
+
+  const layoutOptions = hierarchical
+    ? {
+        // Explicit per-node `level` drives placement; we do NOT use
+        // sortMethod:'directed' (our edges are report→manager, which would
+        // invert the tree). Levels are authoritative.
+        hierarchical: {
+          enabled: true,
+          direction: 'UD',
+          levelSeparation: 160,
+          nodeSpacing: 130,
+          treeSpacing: 220,
+          blockShifting: true,
+          edgeMinimization: true,
+          parentCentralization: true,
+          shakeTowards: 'roots',
+        },
+      }
+    : undefined;
+
   const network = new Network(container, { nodes, edges }, {
     nodes: {
       scaling: {
@@ -360,20 +418,8 @@ export function createGraphNetwork(options: GraphNetworkOptions): GraphNetworkRe
       },
       font: { vadjust: 45, size: 13 },
     },
-    physics: {
-      solver: 'forceAtlas2Based',
-      forceAtlas2Based: {
-        gravitationalConstant: -120,
-        // Higher centralGravity keeps the whole graph — including lightly-
-        // connected (orphan) nodes — pulled toward the centre, preventing
-        // them from drifting into a noisy ring at the periphery (#252).
-        centralGravity: 0.06,
-        springLength: 180,
-        springConstant: 0.05,
-        damping: 0.6,
-      },
-      stabilization: { enabled: true, iterations: 500, updateInterval: 100 },
-    },
+    ...(layoutOptions ? { layout: layoutOptions } : {}),
+    physics: physicsOptions,
     interaction: {
       hover: true,
       tooltipDelay: 200,
@@ -384,7 +430,7 @@ export function createGraphNetwork(options: GraphNetworkOptions): GraphNetworkRe
       zoomSpeed: 0.3,
     },
     edges: {
-      smooth: { enabled: true, type: 'continuous', roundness: 0.5 },
+      smooth: { enabled: true, type: hierarchical ? 'cubicBezier' : 'continuous', roundness: 0.5 },
     },
   });
 
@@ -401,7 +447,14 @@ export function createGraphNetwork(options: GraphNetworkOptions): GraphNetworkRe
     network.setOptions({ physics: { enabled: false } });
   });
 
-  network.once('stabilized', () => {
+  // Finalize once: kill physics, compute pan bounds, wire bounded pan/zoom and
+  // the initial fit/focus. Idempotent so it can be driven from `stabilized`
+  // (force layout) or from rAF/afterDrawing (hierarchical layout, where physics
+  // is disabled and `stabilized` never fires).
+  let finalized = false;
+  const finalizeLayout = () => {
+    if (finalized) return;
+    finalized = true;
     // Kill physics immediately — no more drifting
     network.setOptions({ physics: { enabled: false } });
 
@@ -508,7 +561,20 @@ export function createGraphNetwork(options: GraphNetworkOptions): GraphNetworkRe
         });
       }
     }
-  });
+  };
+
+  // Drive finalization. Force layout finalizes on `stabilized`; the org tree
+  // (physics off) finalizes on the next frame, with `afterDrawing` as a
+  // belt-and-suspenders fallback. `finalizeLayout` is idempotent.
+  network.once('stabilized', finalizeLayout);
+  if (hierarchical) {
+    if (typeof requestAnimationFrame === 'function') {
+      requestAnimationFrame(finalizeLayout);
+    } else {
+      setTimeout(finalizeLayout, 0);
+    }
+    network.once('afterDrawing', finalizeLayout);
+  }
 
   if (auditSlot) {
     registerNetworkForAudit(network, container, auditSlot);

--- a/src/engine/createGraphNetwork.ts
+++ b/src/engine/createGraphNetwork.ts
@@ -158,6 +158,9 @@ export function createGraphNetwork(options: GraphNetworkOptions): GraphNetworkRe
         ? [34, 52]
         : [44, 64];
   const nodeSizeRange = options.nodeSizeRange ?? adaptiveDefault;
+  // Largest node diameter — the base unit for hierarchical-tree spacing so the
+  // org tree scales with the same sizing primitive as the constellation.
+  const maxNodeSize = nodeSizeRange[1];
 
   const degrees = getNodeDegrees(graph);
   const clusterColorMap = new Map(graph.clusters.map(c => [c.id, c.color]));
@@ -393,12 +396,19 @@ export function createGraphNetwork(options: GraphNetworkOptions): GraphNetworkRe
         // Explicit per-node `level` drives placement; we do NOT use
         // sortMethod:'directed' (our edges are report→manager, which would
         // invert the tree). Levels are authoritative.
+        //
+        // Spacing is derived from the node-size primitive (`nodeSizeRange`)
+        // rather than hard-coded pixels, so the tree breathes proportionally
+        // as nodes scale down for larger orgs — consistent with the project's
+        // no-fixed-pixels sizing convention. Multiples are relative to the
+        // largest node diameter (vertical gap between ranks > sibling gap;
+        // sub-tree gap widest to keep branches legible).
         hierarchical: {
           enabled: true,
           direction: 'UD',
-          levelSeparation: 160,
-          nodeSpacing: 130,
-          treeSpacing: 220,
+          levelSeparation: Math.round(maxNodeSize * 3.6),
+          nodeSpacing: Math.round(maxNodeSize * 3),
+          treeSpacing: Math.round(maxNodeSize * 5),
           blockShifting: true,
           edgeMinimization: true,
           parentCentralization: true,
@@ -451,9 +461,17 @@ export function createGraphNetwork(options: GraphNetworkOptions): GraphNetworkRe
   // the initial fit/focus. Idempotent so it can be driven from `stabilized`
   // (force layout) or from rAF/afterDrawing (hierarchical layout, where physics
   // is disabled and `stabilized` never fires).
+  //
+  // For the hierarchical path the finalize callback is deferred (rAF/timeout),
+  // so a fast unmount + `network.destroy()` could otherwise fire it against a
+  // destroyed network. We track a `disposed` flag and cancel any pending handle
+  // when destroy() is called.
+  let disposed = false;
+  let rafHandle: number | null = null;
+  let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
   let finalized = false;
   const finalizeLayout = () => {
-    if (finalized) return;
+    if (finalized || disposed) return;
     finalized = true;
     // Kill physics immediately — no more drifting
     network.setOptions({ physics: { enabled: false } });
@@ -565,16 +583,33 @@ export function createGraphNetwork(options: GraphNetworkOptions): GraphNetworkRe
 
   // Drive finalization. Force layout finalizes on `stabilized`; the org tree
   // (physics off) finalizes on the next frame, with `afterDrawing` as a
-  // belt-and-suspenders fallback. `finalizeLayout` is idempotent.
+  // belt-and-suspenders fallback. `finalizeLayout` is idempotent and bails if
+  // the network has already been disposed.
   network.once('stabilized', finalizeLayout);
   if (hierarchical) {
     if (typeof requestAnimationFrame === 'function') {
-      requestAnimationFrame(finalizeLayout);
+      rafHandle = requestAnimationFrame(() => { rafHandle = null; finalizeLayout(); });
     } else {
-      setTimeout(finalizeLayout, 0);
+      timeoutHandle = setTimeout(() => { timeoutHandle = null; finalizeLayout(); }, 0);
     }
     network.once('afterDrawing', finalizeLayout);
   }
+
+  // Wrap destroy so deferred finalize callbacks can't run on a torn-down
+  // network. Callers keep using `network.destroy()` exactly as before.
+  const originalDestroy = network.destroy.bind(network);
+  network.destroy = () => {
+    disposed = true;
+    if (rafHandle !== null && typeof cancelAnimationFrame === 'function') {
+      cancelAnimationFrame(rafHandle);
+      rafHandle = null;
+    }
+    if (timeoutHandle !== null) {
+      clearTimeout(timeoutHandle);
+      timeoutHandle = null;
+    }
+    originalDestroy();
+  };
 
   if (auditSlot) {
     registerNetworkForAudit(network, container, auditSlot);

--- a/src/engine/demo-entities.ts
+++ b/src/engine/demo-entities.ts
@@ -81,7 +81,13 @@ export function registerDemoEntityTypes(): void {
   registerViewer('squad', SquadView);
 }
 
-/** Whether the large synthetic-org demo seam is enabled for this session. */
+/**
+ * Whether the large synthetic-org demo seam is enabled for this session.
+ *
+ * Query-param only (`?demo=bigorg`) — deliberately NOT backed by localStorage.
+ * The persisted `kbe-*` keys are part of this repo's settings contract; this is
+ * a throwaway scale-testing seam, so it stays ephemeral and leaves no trace.
+ */
 export function isBigOrgDemoEnabled(): boolean {
   try {
     if (typeof window !== 'undefined') {
@@ -93,11 +99,9 @@ export function isBigOrgDemoEnabled(): boolean {
         const hp = new URLSearchParams(hash.slice(qIndex + 1));
         if (hp.get('demo') === 'bigorg') return true;
       }
-      const flag = window.localStorage?.getItem('kbe-demo-bigorg');
-      if (flag === '1' || flag === 'true') return true;
     }
   } catch {
-    /* access to window/localStorage may be denied; treat as disabled */
+    /* access to window may be denied; treat as disabled */
   }
   return false;
 }

--- a/src/engine/demo-entities.ts
+++ b/src/engine/demo-entities.ts
@@ -81,6 +81,109 @@ export function registerDemoEntityTypes(): void {
   registerViewer('squad', SquadView);
 }
 
+/** Whether the large synthetic-org demo seam is enabled for this session. */
+export function isBigOrgDemoEnabled(): boolean {
+  try {
+    if (typeof window !== 'undefined') {
+      const params = new URLSearchParams(window.location.search);
+      if (params.get('demo') === 'bigorg') return true;
+      const hash = window.location.hash;
+      const qIndex = hash.indexOf('?');
+      if (qIndex >= 0) {
+        const hp = new URLSearchParams(hash.slice(qIndex + 1));
+        if (hp.get('demo') === 'bigorg') return true;
+      }
+      const flag = window.localStorage?.getItem('kbe-demo-bigorg');
+      if (flag === '1' || flag === 'true') return true;
+    }
+  } catch {
+    /* access to window/localStorage may be denied; treat as disabled */
+  }
+  return false;
+}
+
+/**
+ * Build a deep/wide synthetic org of `person` nodes wired by `reports-to`
+ * (report → manager) edges — a single rooted tree. Used to validate the
+ * hierarchical org-tree layout (#279) at a hundreds-person scale without
+ * committing hundreds of YAML files.
+ */
+export function generateOrgTree(
+  branching = 4,
+  depth = 4,
+): { nodes: KBNode[]; edges: KBEdge[] } {
+  const nodes: KBNode[] = [];
+  const edges: KBEdge[] = [];
+  let counter = 0;
+
+  const makePerson = (level: number): KBNode => {
+    const idx = counter++;
+    const id = `org-p${idx}`;
+    const role = level === 0 ? 'Chief Executive' : level === 1 ? 'VP' : level === 2 ? 'Director' : 'Engineer';
+    return entityNode(
+      id,
+      `${role} ${idx}`,
+      'person',
+      { name: `${role} ${idx}`, role, email: `p${idx}@example.com`, level },
+      'Person',
+    );
+  };
+
+  const root = makePerson(0);
+  nodes.push(root);
+
+  let frontier = [root];
+  for (let level = 1; level <= depth; level++) {
+    const next: KBNode[] = [];
+    for (const manager of frontier) {
+      for (let b = 0; b < branching; b++) {
+        const report = makePerson(level);
+        nodes.push(report);
+        next.push(report);
+        // reports-to edge: report (from) → manager (to)
+        edges.push(relationEdge(report.id, manager.id, 'reports-to', `${report.title} reports to ${manager.title}`));
+      }
+    }
+    frontier = next;
+  }
+
+  return { nodes, edges };
+}
+
+/**
+ * Return a new graph with a large synthetic org tree appended (off by default).
+ * Idempotent: skips injection if the org tree is already present.
+ */
+export function injectBigOrg(graph: KBGraph): KBGraph {
+  registerDemoEntityTypes();
+
+  if (graph.nodes.some(n => n.id === 'org-p0')) return graph;
+
+  const { nodes: orgNodes, edges: orgEdges } = generateOrgTree();
+
+  // Anchor the root to an existing hub so the subgraph is reachable in non-org
+  // views (the org view itself only needs the reports-to edges).
+  const hub =
+    graph.nodes.find(n => n.id === 'readme') ??
+    graph.nodes.find(n => n.id === 'home') ??
+    graph.nodes.find(n => n.id === 'overview') ??
+    graph.nodes[0];
+  if (hub) {
+    orgEdges.push(relationEdge(hub.id, 'org-p0', 'structural', `${hub.title} → Org`));
+  }
+
+  const clusters = graph.clusters.some(c => c.id === DEMO_CLUSTER.id)
+    ? graph.clusters
+    : [...graph.clusters, DEMO_CLUSTER];
+
+  return {
+    nodes: [...graph.nodes, ...orgNodes],
+    edges: [...graph.edges, ...orgEdges],
+    clusters,
+    related: graph.related,
+  };
+}
+
 function entityNode(
   id: string,
   title: string,

--- a/src/engine/reports-to-layout.ts
+++ b/src/engine/reports-to-layout.ts
@@ -1,0 +1,202 @@
+/**
+ * Reports-to tree layout (#279).
+ *
+ * Pure, SSR-safe helpers that project the knowledge graph down to the
+ * `reports-to` reporting hierarchy and compute a per-node tree *level* for a
+ * vis-network hierarchical layout. No DOM / vis-network imports here so the
+ * logic stays unit-testable and safe to run during SSR.
+ *
+ * Edge convention (content-model/schema/edges.yaml `person-manager`):
+ *   reports-to edge.from = the report (subordinate, has a `manager`)
+ *   reports-to edge.to   = the manager (the parent in the tree)
+ * So a manager sits one level ABOVE their reports. Level 0 = top of the org.
+ *
+ * The level map and projection scale to a hundreds-person org in O(V + E):
+ * a single breadth-first sweep from the roots assigns shortest-path depth,
+ * which is also the natural level for a (mostly) tree-shaped reporting graph.
+ */
+import type { KBGraph, KBNode, KBEdge } from '../types';
+
+/** The relation taxonomy key for a reporting edge. */
+export const REPORTS_TO_RELATION = 'reports-to';
+
+/**
+ * Default upper bound on nodes rendered in the org tree. Protects the live
+ * vis-network from pathological inputs; when exceeded the tree is truncated
+ * breadth-first from the roots so the kept subtree stays connected. HUD shows a
+ * "showing N of M" note when this kicks in.
+ */
+export const DEFAULT_MAX_TREE_NODES = 600;
+
+/** Whether a node represents a person (descriptor or work-derived). */
+export function isPersonNode(node: KBNode): boolean {
+  return node.entityType === 'person' || node.source?.type === 'person';
+}
+
+/** All `reports-to` edges in the graph (unfiltered by node type). */
+export function selectReportsToEdges(graph: KBGraph): KBEdge[] {
+  return graph.edges.filter(e => e.relation === REPORTS_TO_RELATION);
+}
+
+/** Reports-to edges whose endpoints are both person nodes in this graph. */
+function personReportsToEdges(graph: KBGraph): KBEdge[] {
+  const personIds = new Set(graph.nodes.filter(isPersonNode).map(n => n.id));
+  return selectReportsToEdges(graph).filter(
+    e => personIds.has(e.from) && personIds.has(e.to),
+  );
+}
+
+/** Whether the graph contains a meaningful person→person reporting tree. */
+export function hasReportsToTree(graph: KBGraph): boolean {
+  return personReportsToEdges(graph).length > 0;
+}
+
+/** Number of distinct people participating in the reporting tree. */
+export function countReportsToParticipants(graph: KBGraph): number {
+  const ids = new Set<string>();
+  for (const e of personReportsToEdges(graph)) {
+    ids.add(e.from);
+    ids.add(e.to);
+  }
+  return ids.size;
+}
+
+interface TreeShape {
+  /** parent id → sorted child ids (parent = manager, child = report). */
+  children: Map<string, string[]>;
+  /** Every person that appears in a reporting edge. */
+  participants: Set<string>;
+  /** Roots (people with no manager), deterministically sorted. */
+  roots: string[];
+}
+
+/** Build the manager→reports adjacency from person reports-to edges. */
+function buildTreeShape(edges: KBEdge[]): TreeShape {
+  const children = new Map<string, string[]>();
+  const participants = new Set<string>();
+  const hasManager = new Set<string>();
+
+  for (const e of edges) {
+    const child = e.from; // report
+    const parent = e.to; // manager
+    participants.add(child);
+    participants.add(parent);
+    hasManager.add(child);
+    let kids = children.get(parent);
+    if (!kids) {
+      kids = [];
+      children.set(parent, kids);
+    }
+    kids.push(child);
+  }
+
+  // Deterministic ordering so layouts are stable across runs.
+  for (const kids of children.values()) kids.sort();
+  const roots = [...participants].filter(id => !hasManager.has(id)).sort();
+
+  return { children, participants, roots };
+}
+
+/**
+ * Compute a tree level for each person in the reporting hierarchy.
+ *
+ * Level 0 = roots (people with no manager). A report is one level below its
+ * manager. Cycle-safe (a node is leveled at most once); any person left
+ * unreached by the root sweep — only possible inside a reporting cycle — is
+ * promoted to a fresh root so the whole org still renders. Non-person nodes and
+ * non-reporting edges are ignored.
+ */
+export function computeReportsToLevels(graph: KBGraph): Map<string, number> {
+  const edges = personReportsToEdges(graph);
+  const { children, participants, roots } = buildTreeShape(edges);
+  const level = new Map<string, number>();
+
+  // BFS from every root simultaneously → shortest-path depth = tree level.
+  const sweep = (start: string) => {
+    const queue: string[] = [start];
+    let head = 0;
+    while (head < queue.length) {
+      const cur = queue[head++];
+      const d = level.get(cur)!;
+      for (const child of children.get(cur) ?? []) {
+        if (!level.has(child)) {
+          level.set(child, d + 1);
+          queue.push(child);
+        }
+      }
+    }
+  };
+
+  for (const r of roots) {
+    if (!level.has(r)) {
+      level.set(r, 0);
+      sweep(r);
+    }
+  }
+
+  // Cycle remnants: any participant not yet leveled becomes its own root.
+  for (const p of [...participants].sort()) {
+    if (!level.has(p)) {
+      level.set(p, 0);
+      sweep(p);
+    }
+  }
+
+  return level;
+}
+
+/** Breadth-first set of node ids to keep when the tree exceeds the cap. */
+function truncateToCap(shape: TreeShape, cap: number): Set<string> {
+  const keep = new Set<string>();
+  const queue = [...shape.roots];
+  let head = 0;
+  // Seed: if there are no roots (pure cycle), start from sorted participants.
+  if (queue.length === 0) queue.push(...[...shape.participants].sort());
+  while (head < queue.length && keep.size < cap) {
+    const cur = queue[head++];
+    if (keep.has(cur)) continue;
+    keep.add(cur);
+    for (const child of shape.children.get(cur) ?? []) {
+      if (!keep.has(child)) queue.push(child);
+    }
+  }
+  return keep;
+}
+
+/**
+ * Project the graph down to the reporting tree: only person nodes that take
+ * part in a `reports-to` relationship and the reporting edges between them.
+ *
+ * Returns an empty graph (no nodes) when there is no reporting tree, so the
+ * org view honestly shows nothing rather than the whole constellation. When the
+ * tree exceeds `maxNodes` it is truncated breadth-first from the roots so the
+ * kept subtree stays connected and rooted.
+ */
+export function projectReportsToTree(
+  graph: KBGraph,
+  maxNodes: number = DEFAULT_MAX_TREE_NODES,
+): KBGraph {
+  const edges = personReportsToEdges(graph);
+  if (edges.length === 0) {
+    return { nodes: [], edges: [], clusters: graph.clusters, related: {} };
+  }
+
+  const shape = buildTreeShape(edges);
+  const keep =
+    shape.participants.size > maxNodes
+      ? truncateToCap(shape, maxNodes)
+      : shape.participants;
+
+  const nodes = graph.nodes.filter(n => keep.has(n.id));
+  const keptEdges = edges.filter(e => keep.has(e.from) && keep.has(e.to));
+
+  // Rebuild `related` restricted to kept nodes so downstream UI never points at
+  // a node that was projected out.
+  const related: Record<string, string[]> = {};
+  for (const n of nodes) {
+    const prior = graph.related[n.id];
+    if (prior) related[n.id] = prior.filter(id => keep.has(id));
+  }
+
+  return { nodes, edges: keptEdges, clusters: graph.clusters, related };
+}

--- a/src/hooks/useKnowledgeBase.ts
+++ b/src/hooks/useKnowledgeBase.ts
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import type { KBGraph, KBConfig, SourceConfig } from '../types';
 import { detectLocalMode, loadLocalKnowledgeBase } from '../engine/local-loader';
 import { loadRemoteKnowledgeBase } from '../engine/remote-loader';
-import { isDemoEntitiesEnabled, injectDemoEntities } from '../engine/demo-entities';
+import { isDemoEntitiesEnabled, injectDemoEntities, isBigOrgDemoEnabled, injectBigOrg } from '../engine/demo-entities';
 
 export type LoadingState =
   | { status: 'loading' }
@@ -34,7 +34,7 @@ export function useKnowledgeBase(sourceOverride?: SourceConfig): LoadingState {
                 error: 'No content found in local manifest. Run `npm run prebuild` to regenerate.',
               });
             } else {
-              const finalGraph = isDemoEntitiesEnabled() ? injectDemoEntities(graph) : graph;
+              const finalGraph = applyDemoSeams(graph);
               exposeAuditGraph(finalGraph, config, 'local');
               setState({ status: 'ready', graph: finalGraph, config });
             }
@@ -51,7 +51,7 @@ export function useKnowledgeBase(sourceOverride?: SourceConfig): LoadingState {
               error: 'No content loaded. The GitHub API may be rate-limited — try again in a minute, or check your network.',
             });
           } else {
-            const finalGraph = isDemoEntitiesEnabled() ? injectDemoEntities(graph) : graph;
+            const finalGraph = applyDemoSeams(graph);
             exposeAuditGraph(finalGraph, config, 'remote');
             setState({ status: 'ready', graph: finalGraph, config });
           }
@@ -71,6 +71,18 @@ export function useKnowledgeBase(sourceOverride?: SourceConfig): LoadingState {
   }, [sourceOverride]);
 
   return state;
+}
+
+/**
+ * Apply optional demo seams (off by default) to the loaded graph: small
+ * entity demo (`?demo=entities`) and the large synthetic org tree
+ * (`?demo=bigorg`, for exercising the reports-to layout at scale — #279).
+ */
+function applyDemoSeams(graph: KBGraph): KBGraph {
+  let g = graph;
+  if (isDemoEntitiesEnabled()) g = injectDemoEntities(g);
+  if (isBigOrgDemoEnabled()) g = injectBigOrg(g);
+  return g;
 }
 
 /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,7 @@
 /** Core data types for the kbexplorer knowledge graph. */
 
 import { resolveNodeLayer } from '../engine/node-types/registry';
+import { projectReportsToTree } from '../engine/reports-to-layout';
 
 /**
  * How a node's content should be rendered.
@@ -461,12 +462,21 @@ function filterByPredicate(graph: KBGraph, predicate: (n: KBNode) => boolean): K
 
 // ── Graph Views ────────────────────────────────────────────
 
+/** Layout strategy a view requests for the live graph canvas. */
+export type GraphLayoutMode = 'force' | 'reports-to'
+
 /** A named view projection over the graph */
 export interface GraphView {
   id: string
   name: string
   icon: string
   color: string
+  /**
+   * Layout strategy for this view's graph. Defaults to the force-directed
+   * constellation when omitted. `'reports-to'` renders a hierarchical org tree
+   * keyed on the reporting relation (#279).
+   */
+  layout?: GraphLayoutMode
   /** Resolve this view — custom logic, not just a filter */
   resolve: (graph: KBGraph) => KBGraph
 }
@@ -530,6 +540,16 @@ export const BUILT_IN_VIEWS: GraphView[] = [
       const visibleIds = new Set([...externalIds, ...neighborIds])
       return filterByPredicate(graph, n => visibleIds.has(n.id))
     },
+  },
+  {
+    id: 'org',
+    name: 'Org',
+    icon: 'Organization',
+    // Matches the `reports-to` relation colour so the org tree reads as a
+    // first-class projection of the reporting hierarchy (#279).
+    color: '#a371f7',
+    layout: 'reports-to',
+    resolve: (graph) => projectReportsToTree(graph),
   },
 ]
 


### PR DESCRIPTION
## Summary

Implements **Task C2 (#279)** — a hierarchical **reports-to tree layout** for the person graph that scales to a hundreds-person org. Additive and SSR-safe; the existing force layout is unchanged.

Selecting the new **Org** view projects the graph down to the reporting hierarchy and renders it as a top-down tree (managers above their reports), keyed on the `person-manager → reports-to` FK edge already defined in `content-model/schema/edges.yaml`.

## What changed
- **`src/engine/reports-to-layout.ts`** (new, pure, SSR-safe): `computeReportsToLevels` (BFS from roots, cycle-safe, multi-root, shortest-depth for multi-manager, O(V+E)), `projectReportsToTree` (person→person reporting subgraph + cap with breadth-first truncation), plus `selectReportsToEdges` / `hasReportsToTree` / `countReportsToParticipants` helpers.
- **`src/types/index.ts`**: `GraphView` gains an optional `layout` mode; new built-in **`org`** view requesting `reports-to`.
- **`src/engine/createGraphNetwork.ts`**: new `layout` option. In `reports-to` mode it assigns explicit vis-network `level`s, enables the hierarchical layout (UD), **disables physics** (deterministic + fast at scale), and reverses the *drawn* vis edges so managers sit above reports (semantic `KBEdge` direction is untouched). Viewport bounds / pan / zoom finalization refactored into an idempotent `finalizeLayout` driven by `requestAnimationFrame` + `afterDrawing` (the physics-off tree never fires `stabilized`).
- **`src/components/HUD.tsx`**: wires the active view's layout into the sidebar + overlay graphs; bypasses cluster-collapse and degree-trim for the org tree so the whole hierarchy renders, with an honest "showing N of M" count.
- **`src/engine/demo-entities.ts` / `useKnowledgeBase.ts`**: `?demo=bigorg` seam injects a deep/wide synthetic org (341 people) for scale validation.

## Design notes
Reviewed with a design critique before implementing. Key decisions: rely on **explicit `level` values** (not `sortMethod:'directed'`, which would invert the tree since edges are report→manager); **reverse only the rendered vis edges** for correct downward routing; **idempotent finalization** independent of physics lifecycle; deterministic ordering and cycle-safety for malformed org data.

## Verification
- `npm install`, `npm run build`, `vitest` (**641 tests pass**, incl. 20 new). `npm run lint` clean on all changed files (pre-existing repo lint debt in untouched `NodeVisual.tsx` / `SearchPalette.tsx` only).
- Playwright on `?demo=bigorg` + Org view: **341 person nodes**, **5 distinct tree levels**, root at top (UD), navigable via pan/zoom.

Closes #279
