### PR TITLE
feat: add opt-in SQLite graph store

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "kbexplorer-template",
       "version": "0.2.0",
       "dependencies": {
-        "@anokye-labs/kbexplorer-core": "github:anokye-labs/kbexplorer-core#hoopsomuah-f7-1-graphstore-contract",
+        "@anokye-labs/kbexplorer-core": "github:anokye-labs/kbexplorer-core#8b78351d57ed9a927d4505ffda542eb97841d580",
         "@fluentui/react-components": "^9.74.2",
         "@fluentui/react-icons": "^2.0.323",
         "@octokit/rest": "^22.0.1",
@@ -16,10 +16,10 @@
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "react-router-dom": "^7.18.0",
+        "sql.js": "^1.14.1",
         "vis-data": "^8.0.4",
         "vis-network": "^10.1.0",
-        "yaml": "^2.9.0",
-        "sql.js": "^1.14.1"
+        "yaml": "^2.9.0"
       },
       "devDependencies": {
         "@anokye-labs/kbexplorer-example-quotes": "file:examples/quotes-provider",
@@ -28,6 +28,7 @@
         "@types/node": "^26.0.1",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
+        "@types/sql.js": "^1.4.11",
         "@vitejs/plugin-react": "^6.0.3",
         "eslint": "^10.2.0",
         "eslint-plugin-react-hooks": "^7.1.1",
@@ -38,8 +39,7 @@
         "typescript": "~6.0.2",
         "typescript-eslint": "^8.61.1",
         "vite": "^8.0.5",
-        "vitest": "^4.1.4",
-        "@types/sql.js": "^1.4.11"
+        "vitest": "^4.1.4"
       }
     },
     "examples/quotes-provider": {
@@ -56,7 +56,8 @@
     },
     "node_modules/@anokye-labs/kbexplorer-core": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/anokye-labs/kbexplorer-core.git#8ce15eadaa689c844ad8914e21430d089a3b3dc4",
+      "resolved": "git+ssh://git@github.com/anokye-labs/kbexplorer-core.git#8b78351d57ed9a927d4505ffda542eb97841d580",
+      "integrity": "sha512-2CrKw6eHZu4WBASBH+C10aQQmTHsLU8aHw6Ub53Z9PyRc1r7khOI1B+0EvUCJxMsJtH6B+p2dNnPq+p7PjeO3g==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -2732,6 +2733,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/emscripten": {
+      "version": "1.41.5",
+      "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.41.5.tgz",
+      "integrity": "sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
@@ -2786,6 +2794,17 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/sql.js": {
+      "version": "1.4.11",
+      "resolved": "https://registry.npmjs.org/@types/sql.js/-/sql.js-1.4.11.tgz",
+      "integrity": "sha512-QXIx38p2ZThJaK9vP5ZdqdlRe1FG9I8SmCZOS7FHfB/2qPAjZwkL7/vlfPg6N/oWHuuOaGg/P/IRwfP2W0kWVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/emscripten": "*",
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -4756,6 +4775,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/sql.js": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.14.1.tgz",
+      "integrity": "sha512-gcj8zBWU5cFsi9WUP+4bFNXAyF1iRpA3LLyS/DP5xlrNzGmPIizUeBggKa8DbDwdqaKwUcTEnChtd2grWo/x/A==",
+      "license": "MIT"
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -5295,30 +5320,6 @@
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
       }
-    },
-    "node_modules/@types/emscripten": {
-      "version": "1.41.5",
-      "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.41.5.tgz",
-      "integrity": "sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/sql.js": {
-      "version": "1.4.11",
-      "resolved": "https://registry.npmjs.org/@types/sql.js/-/sql.js-1.4.11.tgz",
-      "integrity": "sha512-QXIx38p2ZThJaK9vP5ZdqdlRe1FG9I8SmCZOS7FHfB/2qPAjZwkL7/vlfPg6N/oWHuuOaGg/P/IRwfP2W0kWVQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/emscripten": "*",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/sql.js": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.14.1.tgz",
-      "integrity": "sha512-gcj8zBWU5cFsi9WUP+4bFNXAyF1iRpA3LLyS/DP5xlrNzGmPIizUeBggKa8DbDwdqaKwUcTEnChtd2grWo/x/A==",
-      "license": "MIT"
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "kbexplorer-template",
       "version": "0.2.0",
       "dependencies": {
-        "@anokye-labs/kbexplorer-core": "github:anokye-labs/kbexplorer-core#8b78351d57ed9a927d4505ffda542eb97841d580",
+        "@anokye-labs/kbexplorer-core": "git+https://github.com/anokye-labs/kbexplorer-core.git#8b78351d57ed9a927d4505ffda542eb97841d580",
         "@fluentui/react-components": "^9.74.2",
         "@fluentui/react-icons": "^2.0.323",
         "@octokit/rest": "^22.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "kbexplorer-template",
       "version": "0.2.0",
       "dependencies": {
-        "@anokye-labs/kbexplorer-core": "git+https://github.com/anokye-labs/kbexplorer-core.git#e33fd6aeb3483c64a87b5d5ee1a847bb277f7fda",
+        "@anokye-labs/kbexplorer-core": "github:anokye-labs/kbexplorer-core#hoopsomuah-f7-1-graphstore-contract",
         "@fluentui/react-components": "^9.74.2",
         "@fluentui/react-icons": "^2.0.323",
         "@octokit/rest": "^22.0.1",
@@ -18,7 +18,8 @@
         "react-router-dom": "^7.18.0",
         "vis-data": "^8.0.4",
         "vis-network": "^10.1.0",
-        "yaml": "^2.9.0"
+        "yaml": "^2.9.0",
+        "sql.js": "^1.14.1"
       },
       "devDependencies": {
         "@anokye-labs/kbexplorer-example-quotes": "file:examples/quotes-provider",
@@ -37,7 +38,8 @@
         "typescript": "~6.0.2",
         "typescript-eslint": "^8.61.1",
         "vite": "^8.0.5",
-        "vitest": "^4.1.4"
+        "vitest": "^4.1.4",
+        "@types/sql.js": "^1.4.11"
       }
     },
     "examples/quotes-provider": {
@@ -54,8 +56,7 @@
     },
     "node_modules/@anokye-labs/kbexplorer-core": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/anokye-labs/kbexplorer-core.git#e33fd6aeb3483c64a87b5d5ee1a847bb277f7fda",
-      "integrity": "sha512-NXhgOaxDiNdj2LQl2wMXTzNaRegjbBOHUzDcNjjicbSWh50niukXyCxMI7lIru71hosdlWFU6jJk2Qcbr9XukQ==",
+      "resolved": "git+ssh://git@github.com/anokye-labs/kbexplorer-core.git#8ce15eadaa689c844ad8914e21430d089a3b3dc4",
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -5294,6 +5295,30 @@
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
       }
+    },
+    "node_modules/@types/emscripten": {
+      "version": "1.41.5",
+      "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.41.5.tgz",
+      "integrity": "sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/sql.js": {
+      "version": "1.4.11",
+      "resolved": "https://registry.npmjs.org/@types/sql.js/-/sql.js-1.4.11.tgz",
+      "integrity": "sha512-QXIx38p2ZThJaK9vP5ZdqdlRe1FG9I8SmCZOS7FHfB/2qPAjZwkL7/vlfPg6N/oWHuuOaGg/P/IRwfP2W0kWVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/emscripten": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/sql.js": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.14.1.tgz",
+      "integrity": "sha512-gcj8zBWU5cFsi9WUP+4bFNXAyF1iRpA3LLyS/DP5xlrNzGmPIizUeBggKa8DbDwdqaKwUcTEnChtd2grWo/x/A==",
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "explore:dtu": "node scripts/explore-dtu.mjs"
   },
   "dependencies": {
-    "@anokye-labs/kbexplorer-core": "github:anokye-labs/kbexplorer-core#8b78351d57ed9a927d4505ffda542eb97841d580",
+    "@anokye-labs/kbexplorer-core": "git+https://github.com/anokye-labs/kbexplorer-core.git#8b78351d57ed9a927d4505ffda542eb97841d580",
     "@fluentui/react-components": "^9.74.2",
     "@fluentui/react-icons": "^2.0.323",
     "@octokit/rest": "^22.0.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "explore:dtu": "node scripts/explore-dtu.mjs"
   },
   "dependencies": {
-    "@anokye-labs/kbexplorer-core": "github:anokye-labs/kbexplorer-core#hoopsomuah-f7-1-graphstore-contract",
+    "@anokye-labs/kbexplorer-core": "github:anokye-labs/kbexplorer-core#8b78351d57ed9a927d4505ffda542eb97841d580",
     "@fluentui/react-components": "^9.74.2",
     "@fluentui/react-icons": "^2.0.323",
     "@octokit/rest": "^22.0.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "explore:dtu": "node scripts/explore-dtu.mjs"
   },
   "dependencies": {
-    "@anokye-labs/kbexplorer-core": "git+https://github.com/anokye-labs/kbexplorer-core.git#e33fd6aeb3483c64a87b5d5ee1a847bb277f7fda",
+    "@anokye-labs/kbexplorer-core": "github:anokye-labs/kbexplorer-core#hoopsomuah-f7-1-graphstore-contract",
     "@fluentui/react-components": "^9.74.2",
     "@fluentui/react-icons": "^2.0.323",
     "@octokit/rest": "^22.0.1",
@@ -49,6 +49,7 @@
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "react-router-dom": "^7.18.0",
+    "sql.js": "^1.14.1",
     "vis-data": "^8.0.4",
     "vis-network": "^10.1.0",
     "yaml": "^2.9.0"
@@ -60,6 +61,7 @@
     "@types/node": "^26.0.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
+    "@types/sql.js": "^1.4.11",
     "@vitejs/plugin-react": "^6.0.3",
     "eslint": "^10.2.0",
     "eslint-plugin-react-hooks": "^7.1.1",

--- a/src/engine/loader.ts
+++ b/src/engine/loader.ts
@@ -19,6 +19,8 @@ import { StructuralProvider } from './providers/structural-provider';
 import { ContentModelProvider } from './providers/content-model-provider';
 import { orchestrateWithTransforms } from './orchestrator';
 import type { RepoSource, RepoData } from './sources/repo-data';
+import { resolveGraphStoreOptions } from './store/config';
+import { buildProviderResultCacheKey } from './store/fingerprint';
 
 /** Build + register the provider pipeline from a normalized {@link RepoData} bundle. */
 export function registerProviders(registry: ProviderRegistry, data: RepoData): void {
@@ -94,6 +96,27 @@ export async function loadKnowledgeBase(
     const { loadExternalProviders } = await import('./plugin-loader');
     const externals = await loadExternalProviders(config.providers);
     for (const p of externals) registry.register(p);
+  }
+
+  const storeOptions = resolveGraphStoreOptions();
+  if (storeOptions.mode === 'sqlite') {
+    const [
+      { SQLiteGraphStore },
+      { orchestrateWithProviderResultStore },
+    ] = await Promise.all([
+      import('./store/sqlite-graph-store'),
+      import('./store/store-orchestrator'),
+    ]);
+    const store = await SQLiteGraphStore.create();
+    const key = await buildProviderResultCacheKey(source, config, data);
+    const graph = await orchestrateWithProviderResultStore(
+      registry,
+      config,
+      { readme: data.readme },
+      store,
+      key,
+    );
+    return { graph, config };
   }
 
   const graph = await orchestrateWithTransforms(registry, config, { readme: data.readme });

--- a/src/engine/store/__tests__/config.test.ts
+++ b/src/engine/store/__tests__/config.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { resolveGraphStoreOptions, isGraphStoreEnabled } from '../config';
+
+describe('graph store config', () => {
+  it('defaults to disabled', () => {
+    expect(resolveGraphStoreOptions({})).toEqual({ mode: 'off' });
+    expect(isGraphStoreEnabled({})).toBe(false);
+  });
+
+  it('treats off-like values as disabled', () => {
+    for (const value of ['off', 'false', '0', '']) {
+      expect(resolveGraphStoreOptions({ VITE_KB_GRAPH_STORE: value })).toEqual({ mode: 'off' });
+    }
+  });
+
+  it('enables sqlite only when explicitly requested', () => {
+    expect(resolveGraphStoreOptions({ VITE_KB_GRAPH_STORE: 'sqlite' })).toEqual({ mode: 'sqlite' });
+    expect(isGraphStoreEnabled({ VITE_KB_GRAPH_STORE: 'sqlite' })).toBe(true);
+  });
+
+  it('rejects unsupported values clearly', () => {
+    expect(() => resolveGraphStoreOptions({ VITE_KB_GRAPH_STORE: 'indexeddb' }))
+      .toThrow('Unsupported VITE_KB_GRAPH_STORE value');
+  });
+});

--- a/src/engine/store/__tests__/sqlite-graph-store.test.ts
+++ b/src/engine/store/__tests__/sqlite-graph-store.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import type { GraphStoreCacheKey, ProviderResult } from '../../../types';
+import type { GraphStoreCacheKey } from '../../../types';
+import type { ProviderResult } from '../../providers';
 import { formatGraphStoreCacheKey } from '../../../types';
 import { MemorySqliteByteStore } from '../sqlite-runtime';
 import { SQLiteGraphStore } from '../sqlite-graph-store';

--- a/src/engine/store/__tests__/sqlite-graph-store.test.ts
+++ b/src/engine/store/__tests__/sqlite-graph-store.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import type { GraphStoreCacheKey, ProviderResult } from '../../../types';
+import { formatGraphStoreCacheKey } from '../../../types';
+import { MemorySqliteByteStore } from '../sqlite-runtime';
+import { SQLiteGraphStore } from '../sqlite-graph-store';
+
+const key: GraphStoreCacheKey = {
+  scope: 'provider-result',
+  providerId: 'provider-pipeline',
+  sourceId: 'github-api:anokye-labs/kbexplorer-template:main:',
+  variant: 'test',
+  contentHash: {
+    algorithm: 'sha256',
+    digest: 'abc123',
+    encoding: 'hex',
+  },
+};
+
+const value: ProviderResult = {
+  nodes: [{
+    id: 'a',
+    title: 'A',
+    cluster: 'default',
+    content: '',
+    rawContent: '',
+    connections: [],
+    source: { type: 'readme' },
+  }],
+  edges: [],
+};
+
+describe('SQLiteGraphStore', () => {
+  it('round-trips provider results and persists through the byte store', async () => {
+    const bytes = new MemorySqliteByteStore();
+    const first = await SQLiteGraphStore.create<ProviderResult>(bytes);
+
+    await first.put({ key, value, metadata: { test: true } });
+    expect((await first.get(key))?.value).toEqual(value);
+
+    const second = await SQLiteGraphStore.create<ProviderResult>(bytes);
+    const loaded = await second.get(key);
+    expect(loaded?.value).toEqual(value);
+    expect(loaded?.metadata).toEqual({ test: true });
+    expect(formatGraphStoreCacheKey(loaded!.key)).toBe(formatGraphStoreCacheKey(key));
+  });
+
+  it('deletes exact cache keys', async () => {
+    const store = await SQLiteGraphStore.create<ProviderResult>(new MemorySqliteByteStore());
+    await store.put({ key, value });
+
+    expect(await store.delete(key)).toBe(true);
+    expect(await store.get(key)).toBeUndefined();
+    expect(await store.delete(key)).toBe(false);
+  });
+
+  it('invalidates by scope, source, provider, variant, and dependency hash', async () => {
+    const store = await SQLiteGraphStore.create<ProviderResult>(new MemorySqliteByteStore());
+    await store.put({
+      key,
+      value,
+      dependencies: [{
+        href: 'git://kbexplorer-template/README.md',
+        sourceId: 'readme',
+        contentHash: { algorithm: 'sha256', digest: 'dep456', encoding: 'hex' },
+      }],
+    });
+
+    expect(await store.invalidate({
+      scope: 'provider-result',
+      providerId: 'provider-pipeline',
+      sourceId: 'readme',
+      variant: 'test',
+      contentHash: { algorithm: 'sha256', digest: 'dep456', encoding: 'hex' },
+    })).toBe(1);
+    expect(await store.get(key)).toBeUndefined();
+  });
+});

--- a/src/engine/store/__tests__/store-orchestrator.test.ts
+++ b/src/engine/store/__tests__/store-orchestrator.test.ts
@@ -7,9 +7,8 @@ import type {
   GraphStoreWrite,
   KBConfig,
   KBNode,
-  ProviderResult,
 } from '../../../types';
-import { ProviderRegistry, type GraphProvider } from '../../providers';
+import { ProviderRegistry, type GraphProvider, type ProviderResult } from '../../providers';
 import { orchestrateWithProviderResultStore } from '../store-orchestrator';
 
 const key: GraphStoreCacheKey = {

--- a/src/engine/store/__tests__/store-orchestrator.test.ts
+++ b/src/engine/store/__tests__/store-orchestrator.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  GraphStore,
+  GraphStoreCacheKey,
+  GraphStoreEntry,
+  GraphStoreInvalidation,
+  GraphStoreWrite,
+  KBConfig,
+  KBNode,
+  ProviderResult,
+} from '../../../types';
+import { ProviderRegistry, type GraphProvider } from '../../providers';
+import { orchestrateWithProviderResultStore } from '../store-orchestrator';
+
+const key: GraphStoreCacheKey = {
+  scope: 'provider-result',
+  providerId: 'provider-pipeline',
+  sourceId: 'test',
+  variant: 'test',
+  contentHash: { algorithm: 'sha256', digest: 'abc', encoding: 'hex' },
+};
+
+const config = {
+  clusters: {
+    default: { name: 'Default', color: '#ccc' },
+  },
+} as unknown as KBConfig;
+
+function node(id: string): KBNode {
+  return {
+    id,
+    title: id,
+    cluster: 'default',
+    content: '',
+    rawContent: '',
+    connections: [],
+    source: { type: 'readme' },
+  };
+}
+
+class MemoryGraphStore implements GraphStore<ProviderResult> {
+  entry?: GraphStoreEntry<ProviderResult>;
+  putCount = 0;
+
+  async get(): Promise<GraphStoreEntry<ProviderResult> | undefined> {
+    return this.entry;
+  }
+
+  async put(entry: GraphStoreWrite<ProviderResult>): Promise<void> {
+    this.putCount++;
+    this.entry = {
+      ...entry,
+      createdAt: entry.createdAt ?? 'created',
+      updatedAt: entry.updatedAt ?? 'updated',
+    };
+  }
+
+  async delete(): Promise<boolean> {
+    const existed = this.entry !== undefined;
+    this.entry = undefined;
+    return existed;
+  }
+
+  async invalidate(_match: GraphStoreInvalidation): Promise<number> {
+    return await this.delete() ? 1 : 0;
+  }
+}
+
+class CountingProvider implements GraphProvider {
+  id = 'counting';
+  name = 'Counting';
+  calls = 0;
+
+  async resolve(): Promise<ProviderResult> {
+    this.calls++;
+    return { nodes: [node('from-provider')], edges: [] };
+  }
+}
+
+describe('orchestrateWithProviderResultStore', () => {
+  it('returns cached provider results without running providers', async () => {
+    const provider = new CountingProvider();
+    const registry = new ProviderRegistry();
+    registry.register(provider);
+    const store = new MemoryGraphStore();
+    store.entry = {
+      key,
+      value: { nodes: [node('from-cache')], edges: [] },
+    };
+
+    const graph = await orchestrateWithProviderResultStore(registry, config, { readme: null }, store, key);
+
+    expect(provider.calls).toBe(0);
+    expect(graph.nodes.map(n => n.id)).toEqual(['from-cache']);
+    expect(store.putCount).toBe(0);
+  });
+
+  it('runs providers on miss and writes transformed provider results', async () => {
+    const provider = new CountingProvider();
+    const registry = new ProviderRegistry();
+    registry.register(provider);
+    const store = new MemoryGraphStore();
+
+    const graph = await orchestrateWithProviderResultStore(registry, config, { readme: null }, store, key);
+
+    expect(provider.calls).toBe(1);
+    expect(store.putCount).toBe(1);
+    expect(store.entry?.value.nodes.map(n => n.id)).toEqual(['from-provider']);
+    expect(graph.nodes.map(n => n.id)).toEqual(['from-provider']);
+  });
+
+  it('surfaces malformed cached provider results', async () => {
+    const registry = new ProviderRegistry();
+    const store = new MemoryGraphStore();
+    store.entry = {
+      key,
+      value: { nodes: undefined, edges: [] } as unknown as ProviderResult,
+    };
+
+    await expect(orchestrateWithProviderResultStore(registry, config, { readme: null }, store, key))
+      .rejects.toThrow('Invalid cached graph store entry');
+  });
+});

--- a/src/engine/store/config.ts
+++ b/src/engine/store/config.ts
@@ -1,0 +1,23 @@
+export type GraphStoreMode = 'off' | 'sqlite';
+
+export interface GraphStoreOptions {
+  mode: GraphStoreMode;
+}
+
+export function resolveGraphStoreOptions(
+  env: Record<string, string | boolean | undefined> = import.meta.env,
+): GraphStoreOptions {
+  const raw = env.VITE_KB_GRAPH_STORE;
+  const value = typeof raw === 'string' ? raw.trim().toLowerCase() : '';
+  if (!value || value === 'off' || value === 'false' || value === '0') {
+    return { mode: 'off' };
+  }
+  if (value === 'sqlite') return { mode: 'sqlite' };
+  throw new Error(`Unsupported VITE_KB_GRAPH_STORE value: ${String(raw)}`);
+}
+
+export function isGraphStoreEnabled(
+  env: Record<string, string | boolean | undefined> = import.meta.env,
+): boolean {
+  return resolveGraphStoreOptions(env).mode === 'sqlite';
+}

--- a/src/engine/store/fingerprint.ts
+++ b/src/engine/store/fingerprint.ts
@@ -1,0 +1,118 @@
+import type { KBConfig, ContentHash, GraphStoreCacheKey } from '../../types';
+import {
+  GRAPH_STORE_API_VERSION,
+  GRAPH_STORE_CACHE_KEY_VERSION,
+} from '../../types';
+import type { RepoData, RepoSource } from '../sources/repo-data';
+
+export const GRAPH_STORE_DERIVATION_VERSION = 'template-graph-derivation-v1';
+export const GRAPH_STORE_PROVIDER_ID = 'provider-pipeline';
+
+export function buildProviderResultCacheKey(
+  source: RepoSource,
+  config: KBConfig,
+  data: RepoData,
+): Promise<GraphStoreCacheKey> {
+  return contentHashFor({
+    apiVersion: GRAPH_STORE_API_VERSION,
+    cacheKeyVersion: GRAPH_STORE_CACHE_KEY_VERSION,
+    derivationVersion: GRAPH_STORE_DERIVATION_VERSION,
+    sourceId: source.id,
+    config,
+    data: stableRepoData(data),
+  }).then(contentHash => ({
+    scope: 'provider-result',
+    providerId: GRAPH_STORE_PROVIDER_ID,
+    sourceId: sourceIdFor(source, config),
+    contentHash,
+    variant: [
+      GRAPH_STORE_API_VERSION,
+      GRAPH_STORE_CACHE_KEY_VERSION,
+      GRAPH_STORE_DERIVATION_VERSION,
+    ].join(':'),
+  }));
+}
+
+export function sourceIdFor(source: RepoSource, config: KBConfig): string {
+  const sourceConfig = config.source;
+  return [
+    source.id,
+    sourceConfig.owner,
+    sourceConfig.repo,
+    sourceConfig.branch ?? 'main',
+    sourceConfig.path ?? '',
+  ].join(':');
+}
+
+async function contentHashFor(value: unknown): Promise<ContentHash> {
+  const crypto = globalThis.crypto?.subtle;
+  if (!crypto) {
+    throw new Error('Graph store hashing requires Web Crypto SubtleCrypto support.');
+  }
+  const bytes = new TextEncoder().encode(stableStringify(value));
+  const digest = await crypto.digest('SHA-256', bytes);
+  return {
+    algorithm: 'sha256',
+    digest: bytesToHex(new Uint8Array(digest)),
+    encoding: 'hex',
+  };
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return [...bytes].map(byte => byte.toString(16).padStart(2, '0')).join('');
+}
+
+function stableRepoData(data: RepoData): unknown {
+  return {
+    repo: data.repo,
+    tree: data.tree.map(item => ({
+      path: item.path,
+      mode: item.mode,
+      type: item.type,
+      sha: item.sha,
+      size: item.size,
+    })),
+    authoredContent: data.authoredContent,
+    nodemapRaw: data.nodemapRaw,
+    nodemapFiles: data.nodemapFiles,
+    nodemapDirs: data.nodemapDirs,
+    issues: data.issues.map(issue => ({
+      number: issue.number,
+      title: issue.title,
+      body: issue.body,
+      state: issue.state,
+      labels: issue.labels,
+      assignees: issue.assignees,
+      user: issue.user,
+      html_url: issue.html_url,
+      created_at: issue.created_at,
+      updated_at: issue.updated_at,
+    })),
+    pullRequests: data.pullRequests,
+    commits: data.commits,
+    branches: data.branches,
+    repoMetadata: data.repoMetadata,
+    releases: data.releases,
+    structuralFiles: data.structuralFiles,
+    structuredNodeMapRaw: data.structuredNodeMapRaw,
+    contentModel: data.contentModel,
+    readme: data.readme,
+  };
+}
+
+export function stableStringify(value: unknown): string {
+  return JSON.stringify(normalizeForJson(value));
+}
+
+function normalizeForJson(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(normalizeForJson);
+  if (!value || typeof value !== 'object') return value;
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(value).sort()) {
+    const item = (value as Record<string, unknown>)[key];
+    if (typeof item !== 'function' && item !== undefined) {
+      out[key] = normalizeForJson(item);
+    }
+  }
+  return out;
+}

--- a/src/engine/store/index.ts
+++ b/src/engine/store/index.ts
@@ -1,0 +1,17 @@
+export { resolveGraphStoreOptions, isGraphStoreEnabled, type GraphStoreMode, type GraphStoreOptions } from './config';
+export {
+  GRAPH_STORE_DERIVATION_VERSION,
+  GRAPH_STORE_PROVIDER_ID,
+  buildProviderResultCacheKey,
+  sourceIdFor,
+  stableStringify,
+} from './fingerprint';
+export { SQLiteGraphStore } from './sqlite-graph-store';
+export { orchestrateWithProviderResultStore } from './store-orchestrator';
+export {
+  IndexedDbSqliteByteStore,
+  MemorySqliteByteStore,
+  loadSqlJs,
+  openPersistedDatabase,
+  type SqliteByteStore,
+} from './sqlite-runtime';

--- a/src/engine/store/sqlite-graph-store.ts
+++ b/src/engine/store/sqlite-graph-store.ts
@@ -1,0 +1,245 @@
+import type { Database, ParamsObject } from 'sql.js';
+import type {
+  GraphStore,
+  GraphStoreCacheKey,
+  GraphStoreEntry,
+  GraphStoreInvalidation,
+  GraphStoreWrite,
+  ProviderResult,
+} from '../../types';
+import {
+  GRAPH_STORE_API_VERSION,
+  GRAPH_STORE_CACHE_KEY_VERSION,
+  formatContentHash,
+  formatGraphStoreCacheKey,
+} from '../../types';
+import {
+  GRAPH_STORE_DERIVATION_VERSION,
+} from './fingerprint';
+import {
+  openPersistedDatabase,
+  type SqliteByteStore,
+} from './sqlite-runtime';
+
+const SQLITE_SCHEMA_VERSION = 'sqlite-graph-store-v1';
+
+interface EntryRow {
+  cache_key: string;
+  key_json: string;
+  value_json: string;
+  dependencies_json: string;
+  metadata_json: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export class SQLiteGraphStore<Value = ProviderResult> implements GraphStore<Value> {
+  private readonly db: Database;
+  private readonly persist: () => Promise<void>;
+
+  private constructor(db: Database, persist: () => Promise<void>) {
+    this.db = db;
+    this.persist = persist;
+    this.migrate();
+  }
+
+  static async create<Value = ProviderResult>(
+    byteStore?: SqliteByteStore,
+  ): Promise<SQLiteGraphStore<Value>> {
+    const { db, persist } = await openPersistedDatabase(byteStore);
+    const store = new SQLiteGraphStore<Value>(db, persist);
+    await store.persist();
+    return store;
+  }
+
+  async get(key: GraphStoreCacheKey): Promise<GraphStoreEntry<Value> | undefined> {
+    const row = this.selectEntry(formatGraphStoreCacheKey(key));
+    if (!row) return undefined;
+    const entry = rowToEntry<Value>(row);
+    if (formatGraphStoreCacheKey(entry.key) !== formatGraphStoreCacheKey(key)) {
+      return undefined;
+    }
+    return entry;
+  }
+
+  async put(entry: GraphStoreWrite<Value>): Promise<void> {
+    const now = new Date().toISOString();
+    const createdAt = entry.createdAt ?? now;
+    const updatedAt = entry.updatedAt ?? now;
+    this.db.run(
+      `insert into entries (
+        cache_key, key_json, scope, provider_id, source_id, variant, content_hash,
+        value_json, dependencies_json, metadata_json, created_at, updated_at
+      ) values (
+        $cache_key, $key_json, $scope, $provider_id, $source_id, $variant, $content_hash,
+        $value_json, $dependencies_json, $metadata_json, $created_at, $updated_at
+      )
+      on conflict(cache_key) do update set
+        key_json = excluded.key_json,
+        scope = excluded.scope,
+        provider_id = excluded.provider_id,
+        source_id = excluded.source_id,
+        variant = excluded.variant,
+        content_hash = excluded.content_hash,
+        value_json = excluded.value_json,
+        dependencies_json = excluded.dependencies_json,
+        metadata_json = excluded.metadata_json,
+        updated_at = excluded.updated_at`,
+      {
+        $cache_key: formatGraphStoreCacheKey(entry.key),
+        $key_json: JSON.stringify(entry.key),
+        $scope: entry.key.scope,
+        $provider_id: entry.key.providerId,
+        $source_id: entry.key.sourceId ?? null,
+        $variant: entry.key.variant ?? null,
+        $content_hash: formatContentHash(entry.key.contentHash),
+        $value_json: JSON.stringify(entry.value),
+        $dependencies_json: JSON.stringify(entry.dependencies ?? []),
+        $metadata_json: JSON.stringify(entry.metadata ?? {}),
+        $created_at: createdAt,
+        $updated_at: updatedAt,
+      } satisfies ParamsObject,
+    );
+    await this.persist();
+  }
+
+  async delete(key: GraphStoreCacheKey): Promise<boolean> {
+    const cacheKey = formatGraphStoreCacheKey(key);
+    const before = this.countEntries();
+    this.db.run('delete from entries where cache_key = $cache_key', { $cache_key: cacheKey });
+    const deleted = this.countEntries() < before;
+    if (deleted) await this.persist();
+    return deleted;
+  }
+
+  async invalidate(match: GraphStoreInvalidation): Promise<number> {
+    const rows = this.selectEntries();
+    let deleted = 0;
+    for (const row of rows) {
+      const entry = rowToEntry<Value>(row);
+      if (matchesInvalidation(entry, match)) {
+        this.db.run('delete from entries where cache_key = $cache_key', { $cache_key: row.cache_key });
+        deleted++;
+      }
+    }
+    if (deleted > 0) await this.persist();
+    return deleted;
+  }
+
+  private migrate(): void {
+    this.db.run(`
+      create table if not exists metadata (
+        key text primary key,
+        value text not null
+      );
+      create table if not exists entries (
+        cache_key text primary key,
+        key_json text not null,
+        scope text not null,
+        provider_id text not null,
+        source_id text,
+        variant text,
+        content_hash text not null,
+        value_json text not null,
+        dependencies_json text not null,
+        metadata_json text not null,
+        created_at text not null,
+        updated_at text not null
+      );
+      create index if not exists idx_entries_scope on entries(scope);
+      create index if not exists idx_entries_provider on entries(provider_id);
+      create index if not exists idx_entries_source on entries(source_id);
+      create index if not exists idx_entries_variant on entries(variant);
+      create index if not exists idx_entries_content_hash on entries(content_hash);
+    `);
+    this.setMetadata('sqlite_schema_version', SQLITE_SCHEMA_VERSION);
+    this.setMetadata('graph_store_api_version', GRAPH_STORE_API_VERSION);
+    this.setMetadata('graph_store_cache_key_version', GRAPH_STORE_CACHE_KEY_VERSION);
+    this.setMetadata('graph_store_derivation_version', GRAPH_STORE_DERIVATION_VERSION);
+  }
+
+  private setMetadata(key: string, value: string): void {
+    this.db.run(
+      `insert into metadata (key, value) values ($key, $value)
+       on conflict(key) do update set value = excluded.value`,
+      { $key: key, $value: value },
+    );
+  }
+
+  private selectEntry(cacheKey: string): EntryRow | undefined {
+    const statement = this.db.prepare(
+      `select cache_key, key_json, value_json, dependencies_json, metadata_json, created_at, updated_at
+       from entries where cache_key = $cache_key limit 1`,
+    );
+    try {
+      statement.bind({ $cache_key: cacheKey });
+      if (!statement.step()) return undefined;
+      return statement.getAsObject() as unknown as EntryRow;
+    } finally {
+      statement.free();
+    }
+  }
+
+  private selectEntries(): EntryRow[] {
+    const statement = this.db.prepare(
+      'select cache_key, key_json, value_json, dependencies_json, metadata_json, created_at, updated_at from entries',
+    );
+    const rows: EntryRow[] = [];
+    try {
+      while (statement.step()) {
+        rows.push(statement.getAsObject() as unknown as EntryRow);
+      }
+      return rows;
+    } finally {
+      statement.free();
+    }
+  }
+
+  private countEntries(): number {
+    const statement = this.db.prepare('select count(*) as count from entries');
+    try {
+      if (!statement.step()) return 0;
+      const row = statement.getAsObject() as unknown as { count: number };
+      return row.count;
+    } finally {
+      statement.free();
+    }
+  }
+}
+
+function rowToEntry<Value>(row: EntryRow): GraphStoreEntry<Value> {
+  try {
+    return {
+      key: JSON.parse(row.key_json) as GraphStoreCacheKey,
+      value: JSON.parse(row.value_json) as Value,
+      dependencies: JSON.parse(row.dependencies_json) as GraphStoreEntry<Value>['dependencies'],
+      metadata: JSON.parse(row.metadata_json) as Record<string, unknown>,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    };
+  } catch (err) {
+    throw new Error(`Failed to deserialize graph store entry ${row.cache_key}: ${err instanceof Error ? err.message : String(err)}`, {
+      cause: err,
+    });
+  }
+}
+
+function matchesInvalidation<Value>(
+  entry: GraphStoreEntry<Value>,
+  match: GraphStoreInvalidation,
+): boolean {
+  if (match.scope && entry.key.scope !== match.scope) return false;
+  if (match.providerId && entry.key.providerId !== match.providerId) return false;
+  if (match.sourceId && entry.key.sourceId !== match.sourceId) {
+    const dependencyMatch = entry.dependencies?.some(dep => dep.sourceId === match.sourceId) ?? false;
+    if (!dependencyMatch) return false;
+  }
+  if (match.variant && entry.key.variant !== match.variant) return false;
+  if (match.contentHash) {
+    const hash = formatContentHash(match.contentHash);
+    const keyMatch = formatContentHash(entry.key.contentHash) === hash;
+    const dependencyMatch = entry.dependencies?.some(dep => formatContentHash(dep.contentHash) === hash) ?? false;
+    if (!keyMatch && !dependencyMatch) return false;
+  }
+  return true;
+}

--- a/src/engine/store/sqlite-graph-store.ts
+++ b/src/engine/store/sqlite-graph-store.ts
@@ -5,8 +5,8 @@ import type {
   GraphStoreEntry,
   GraphStoreInvalidation,
   GraphStoreWrite,
-  ProviderResult,
 } from '../../types';
+import type { ProviderResult } from '../providers';
 import {
   GRAPH_STORE_API_VERSION,
   GRAPH_STORE_CACHE_KEY_VERSION,
@@ -47,9 +47,7 @@ export class SQLiteGraphStore<Value = ProviderResult> implements GraphStore<Valu
     byteStore?: SqliteByteStore,
   ): Promise<SQLiteGraphStore<Value>> {
     const { db, persist } = await openPersistedDatabase(byteStore);
-    const store = new SQLiteGraphStore<Value>(db, persist);
-    await store.persist();
-    return store;
+    return new SQLiteGraphStore<Value>(db, persist);
   }
 
   async get(key: GraphStoreCacheKey): Promise<GraphStoreEntry<Value> | undefined> {

--- a/src/engine/store/sqlite-runtime.ts
+++ b/src/engine/store/sqlite-runtime.ts
@@ -1,0 +1,93 @@
+import initSqlJs from 'sql.js';
+import type { Database, SqlJsStatic } from 'sql.js';
+import wasmUrl from 'sql.js/dist/sql-wasm.wasm?url';
+
+export interface SqliteByteStore {
+  load(): Promise<Uint8Array | undefined>;
+  save(bytes: Uint8Array): Promise<void>;
+}
+
+const DB_NAME = 'kbexplorer-graph-store';
+const STORE_NAME = 'sqlite';
+const DB_KEY = 'graph-store.sqlite';
+
+let sqlModulePromise: Promise<SqlJsStatic> | undefined;
+
+export async function loadSqlJs(): Promise<SqlJsStatic> {
+  sqlModulePromise ??= initSqlJs({
+    locateFile: () => resolveSqlJsWasmPath(wasmUrl),
+  });
+  return sqlModulePromise;
+}
+
+export async function openPersistedDatabase(
+  byteStore: SqliteByteStore = new IndexedDbSqliteByteStore(),
+): Promise<{ db: Database; persist: () => Promise<void> }> {
+  const SQL = await loadSqlJs();
+  const bytes = await byteStore.load();
+  const db = bytes ? new SQL.Database(bytes) : new SQL.Database();
+  return {
+    db,
+    persist: async () => {
+      await byteStore.save(db.export());
+    },
+  };
+}
+
+export class MemorySqliteByteStore implements SqliteByteStore {
+  private bytes?: Uint8Array;
+
+  async load(): Promise<Uint8Array | undefined> {
+    return this.bytes ? new Uint8Array(this.bytes) : undefined;
+  }
+
+  async save(bytes: Uint8Array): Promise<void> {
+    this.bytes = new Uint8Array(bytes);
+  }
+}
+
+export class IndexedDbSqliteByteStore implements SqliteByteStore {
+  async load(): Promise<Uint8Array | undefined> {
+    const db = await openIndexedDb();
+    return requestToPromise<Uint8Array | undefined>(
+      db.transaction(STORE_NAME, 'readonly').objectStore(STORE_NAME).get(DB_KEY),
+    ).finally(() => db.close());
+  }
+
+  async save(bytes: Uint8Array): Promise<void> {
+    const db = await openIndexedDb();
+    await requestToPromise(
+      db.transaction(STORE_NAME, 'readwrite').objectStore(STORE_NAME).put(bytes, DB_KEY),
+    ).finally(() => db.close());
+  }
+}
+
+function openIndexedDb(): Promise<IDBDatabase> {
+  if (!globalThis.indexedDB) {
+    throw new Error('Graph store SQLite persistence requires IndexedDB support.');
+  }
+
+  return new Promise((resolve, reject) => {
+    const request = globalThis.indexedDB.open(DB_NAME, 1);
+    request.onupgradeneeded = () => {
+      request.result.createObjectStore(STORE_NAME);
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error ?? new Error('Failed to open graph store IndexedDB database.'));
+  });
+}
+
+function requestToPromise<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error ?? new Error('IndexedDB graph store request failed.'));
+  });
+}
+
+function resolveSqlJsWasmPath(url: string): string {
+  const maybeProcess = (globalThis as { process?: { cwd?: () => string } }).process;
+  if (url.startsWith('/node_modules/') && maybeProcess?.cwd) {
+    return `${maybeProcess.cwd()}${url}`;
+  }
+  return url;
+}

--- a/src/engine/store/store-orchestrator.ts
+++ b/src/engine/store/store-orchestrator.ts
@@ -1,7 +1,7 @@
-import type { KBConfig, KBGraph, KBNode, GraphStore, ProviderResult } from '../../types';
+import type { KBConfig, KBGraph, KBNode, GraphStore } from '../../types';
 import { extractClusters } from '../parser';
 import { buildGraph } from '../graph';
-import type { ProviderRegistry } from '../providers';
+import type { ProviderRegistry, ProviderResult } from '../providers';
 import {
   collectProviderNodes,
 } from '../orchestrator';

--- a/src/engine/store/store-orchestrator.ts
+++ b/src/engine/store/store-orchestrator.ts
@@ -1,0 +1,75 @@
+import type { KBConfig, KBGraph, KBNode, GraphStore, ProviderResult } from '../../types';
+import { extractClusters } from '../parser';
+import { buildGraph } from '../graph';
+import type { ProviderRegistry } from '../providers';
+import {
+  collectProviderNodes,
+} from '../orchestrator';
+import {
+  applyTransforms,
+  DEFAULT_TRANSFORMS,
+  type GraphTransform,
+  type TransformContext,
+} from '../transforms';
+import type { GraphStoreCacheKey } from '../../types';
+import {
+  GRAPH_STORE_API_VERSION,
+  GRAPH_STORE_CACHE_KEY_VERSION,
+} from '../../types';
+import { GRAPH_STORE_DERIVATION_VERSION } from './fingerprint';
+
+export async function orchestrateWithProviderResultStore(
+  registry: ProviderRegistry,
+  config: KBConfig,
+  ctx: TransformContext,
+  store: GraphStore<ProviderResult>,
+  key: GraphStoreCacheKey,
+  transforms: readonly GraphTransform[] = DEFAULT_TRANSFORMS,
+): Promise<KBGraph> {
+  const cached = await store.get(key);
+  if (cached) {
+    const nodes = validateProviderResult(cached.value, 'cached graph store entry').nodes;
+    return buildGraph(nodes, extractClusters(nodes, config));
+  }
+
+  const allNodes = await collectProviderNodes(registry, config);
+  const transformed = applyTransforms(allNodes, ctx, transforms);
+  const value: ProviderResult = { nodes: transformed, edges: [] };
+  await store.put({
+    key,
+    value,
+    dependencies: [{
+      href: key.sourceId ?? key.providerId,
+      contentHash: key.contentHash,
+      sourceId: key.sourceId,
+    }],
+    metadata: {
+      graphStoreApiVersion: GRAPH_STORE_API_VERSION,
+      graphStoreCacheKeyVersion: GRAPH_STORE_CACHE_KEY_VERSION,
+      graphStoreDerivationVersion: GRAPH_STORE_DERIVATION_VERSION,
+    },
+  });
+  return buildGraph(transformed, extractClusters(transformed, config));
+}
+
+function validateProviderResult(value: ProviderResult, label: string): ProviderResult {
+  if (!value || !Array.isArray(value.nodes) || !Array.isArray(value.edges)) {
+    throw new Error(`Invalid ${label}: expected ProviderResult with nodes and edges arrays.`);
+  }
+  for (const node of value.nodes) {
+    validateNode(node, label);
+  }
+  return value;
+}
+
+function validateNode(node: KBNode, label: string): void {
+  if (
+    !node ||
+    typeof node.id !== 'string' ||
+    typeof node.title !== 'string' ||
+    typeof node.cluster !== 'string' ||
+    !Array.isArray(node.connections)
+  ) {
+    throw new Error(`Invalid ${label}: malformed KBNode.`);
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -24,6 +24,21 @@ import {
   type SourceConfig,
   type Theme,
   type VisualMode,
+  GRAPH_STORE_API_VERSION,
+  GRAPH_STORE_CACHE_KEY_VERSION,
+  formatContentHash,
+  formatGraphStoreCacheKey,
+  type ContentHash,
+  type ContentHashAlgorithm,
+  type ContentHashEncoding,
+  type GraphStore,
+  type GraphStoreCacheKey,
+  type GraphStoreCacheScope,
+  type GraphStoreDependency,
+  type GraphStoreEntry,
+  type GraphStoreInvalidation,
+  type GraphStoreWrite,
+  type ProviderResult,
 } from '@anokye-labs/kbexplorer-core';
 
 /**
@@ -58,6 +73,21 @@ export {
   type SourceConfig,
   type Theme,
   type VisualMode,
+  GRAPH_STORE_API_VERSION,
+  GRAPH_STORE_CACHE_KEY_VERSION,
+  formatContentHash,
+  formatGraphStoreCacheKey,
+  type ContentHash,
+  type ContentHashAlgorithm,
+  type ContentHashEncoding,
+  type GraphStore,
+  type GraphStoreCacheKey,
+  type GraphStoreCacheScope,
+  type GraphStoreDependency,
+  type GraphStoreEntry,
+  type GraphStoreInvalidation,
+  type GraphStoreWrite,
+  type ProviderResult,
 };
 
 /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -38,7 +38,6 @@ import {
   type GraphStoreEntry,
   type GraphStoreInvalidation,
   type GraphStoreWrite,
-  type ProviderResult,
 } from '@anokye-labs/kbexplorer-core';
 
 /**
@@ -87,7 +86,6 @@ export {
   type GraphStoreEntry,
   type GraphStoreInvalidation,
   type GraphStoreWrite,
-  type ProviderResult,
 };
 
 /**


### PR DESCRIPTION
## Summary
- Implements F7.2 for the optional template-owned SQLite graph store.
- Adds `VITE_KB_GRAPH_STORE=sqlite` as the opt-in flag; default-off keeps the existing direct provider-to-engine path and does not initialize SQLite.
- Adds a `sql.js` + IndexedDB-backed `SQLiteGraphStore<Value = ProviderResult>` using the finalized core `GraphStore` API.
- Adds store-aware orchestration at the loader seam, provider-result fingerprint/cache-key derivation, serialization, metadata, invalidation, and focused tests.

Part of #338.

## Dependency note
Uses `@anokye-labs/kbexplorer-core` from merged main commit `8b78351d57ed9a927d4505ffda542eb97841d580`, which includes the graph-store contract from anokye-labs/kbexplorer-core#14. No published npm semver package was available for `@anokye-labs/kbexplorer-core`, so this PR uses the merged commit reference instead of the former feature branch.

## Validation
- Verified installed core exports: `GRAPH_STORE_API_VERSION`, `GraphStore<Value>`, `formatGraphStoreCacheKey`
- `npx tsc -b && npx vitest run --config vitest.config.ts src/engine/store/__tests__`
- `npm run test`
- `npm run lint` (passes with existing warnings only)
- `npm run build`
- Playwright default-off local SPA flow
- Playwright SQLite opt-in load/reload flow with IndexedDB persistence