### PR TITLE
F7.3 incremental graph-store parity guard

### DIFF
--- a/src/engine/loader.ts
+++ b/src/engine/loader.ts
@@ -108,13 +108,13 @@ export async function loadKnowledgeBase(
       import('./store/store-orchestrator'),
     ]);
     const store = await SQLiteGraphStore.create();
-    const key = await buildProviderResultCacheKey(source, config, data);
     const graph = await orchestrateWithProviderResultStore(
       registry,
       config,
       { readme: data.readme },
       store,
-      key,
+      (providerId, previousContentHash) =>
+        buildProviderResultCacheKey(source, config, data, providerId, previousContentHash),
     );
     return { graph, config };
   }

--- a/src/engine/store/__tests__/fingerprint.test.ts
+++ b/src/engine/store/__tests__/fingerprint.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_CONFIG, type KBConfig } from '../../../types';
+import type { RepoData, RepoSource } from '../../sources/repo-data';
+import { buildProviderResultCacheKey } from '../fingerprint';
+
+const source: RepoSource = {
+  id: 'manifest',
+  name: 'Manifest',
+  possibleAffordances: ['read'],
+  async retrieve() { return []; },
+  async get() { return undefined; },
+  async getRepoData() { return data; },
+};
+
+const config: KBConfig = {
+  ...DEFAULT_CONFIG,
+  source: { ...DEFAULT_CONFIG.source, owner: 'anokye-labs', repo: 'kbexplorer-template', branch: 'main' },
+};
+
+const data: RepoData = {
+  repo: 'kbexplorer-template',
+  tree: [{ path: 'README.md', mode: '100644', type: 'blob', sha: 'a', size: 1, url: 'https://example.test/tree/readme' }],
+  authoredContent: { 'content/a.md': '# A' },
+  nodemapRaw: null,
+  nodemapFiles: {},
+  nodemapDirs: {},
+  listFiles: async () => [],
+  issues: [{
+    number: 1,
+    title: 'Issue',
+    body: 'Body',
+    state: 'open',
+    labels: [],
+    assignees: [],
+    html_url: 'https://example.test/1',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  }],
+  pullRequests: [],
+  commits: [],
+  branches: [],
+  repoMetadata: null,
+  releases: [],
+  structuralFiles: {},
+  structuredNodeMapRaw: null,
+  contentModel: null,
+  readme: '# Readme',
+};
+
+describe('graph store fingerprints', () => {
+  it('is stable for unchanged provider inputs', async () => {
+    const first = await buildProviderResultCacheKey(source, config, data, 'files');
+    const second = await buildProviderResultCacheKey(source, config, data, 'files');
+
+    expect(second).toEqual(first);
+  });
+
+  it('scopes source changes to the provider data slice', async () => {
+    const changedTree = {
+      ...data,
+      tree: [{ path: 'README.md', mode: '100644', type: 'blob' as const, sha: 'b', size: 1, url: 'https://example.test/tree/readme' }],
+    };
+
+    const filesBefore = await buildProviderResultCacheKey(source, config, data, 'files');
+    const filesAfter = await buildProviderResultCacheKey(source, config, changedTree, 'files');
+    const workBefore = await buildProviderResultCacheKey(source, config, data, 'work');
+    const workAfter = await buildProviderResultCacheKey(source, config, changedTree, 'work');
+
+    expect(filesAfter.contentHash.digest).not.toBe(filesBefore.contentHash.digest);
+    expect(workAfter.contentHash.digest).toBe(workBefore.contentHash.digest);
+  });
+
+  it('invalidates provider and config fingerprints independently', async () => {
+    const changedIssue = {
+      ...data,
+      issues: [{ ...data.issues[0], title: 'Changed issue' }],
+    };
+    const changedConfig = {
+      ...config,
+      people: { minActiveItems: 2 },
+    } satisfies KBConfig;
+
+    const workBefore = await buildProviderResultCacheKey(source, config, data, 'work');
+    const workAfter = await buildProviderResultCacheKey(source, config, changedIssue, 'work');
+    const filesBefore = await buildProviderResultCacheKey(source, config, data, 'files');
+    const filesAfterConfig = await buildProviderResultCacheKey(source, changedConfig, data, 'files');
+
+    expect(workAfter.contentHash.digest).not.toBe(workBefore.contentHash.digest);
+    expect(filesAfterConfig.contentHash.digest).not.toBe(filesBefore.contentHash.digest);
+    expect(workBefore.providerId).toBe('work');
+    expect(filesBefore.providerId).toBe('files');
+  });
+});

--- a/src/engine/store/__tests__/store-orchestrator.test.ts
+++ b/src/engine/store/__tests__/store-orchestrator.test.ts
@@ -38,26 +38,26 @@ function node(id: string): KBNode {
 }
 
 class MemoryGraphStore implements GraphStore<ProviderResult> {
-  entry?: GraphStoreEntry<ProviderResult>;
+  entries = new Map<string, GraphStoreEntry<ProviderResult>>();
   putCount = 0;
 
-  async get(): Promise<GraphStoreEntry<ProviderResult> | undefined> {
-    return this.entry;
+  async get(key: GraphStoreCacheKey): Promise<GraphStoreEntry<ProviderResult> | undefined> {
+    return this.entries.get(`${key.providerId}:${key.contentHash.digest}`);
   }
 
   async put(entry: GraphStoreWrite<ProviderResult>): Promise<void> {
     this.putCount++;
-    this.entry = {
+    this.entries.set(`${entry.key.providerId}:${entry.key.contentHash.digest}`, {
       ...entry,
       createdAt: entry.createdAt ?? 'created',
       updatedAt: entry.updatedAt ?? 'updated',
-    };
+    });
   }
 
   async delete(): Promise<boolean> {
-    const existed = this.entry !== undefined;
-    this.entry = undefined;
-    return existed;
+    const count = this.entries.size;
+    this.entries.clear();
+    return count > 0;
   }
 
   async invalidate(_match: GraphStoreInvalidation): Promise<number> {
@@ -66,14 +66,28 @@ class MemoryGraphStore implements GraphStore<ProviderResult> {
 }
 
 class CountingProvider implements GraphProvider {
-  id = 'counting';
+  id: string;
   name = 'Counting';
   calls = 0;
+  value: string;
+
+  constructor(id = 'counting', value = 'from-provider') {
+    this.id = id;
+    this.value = value;
+  }
 
   async resolve(): Promise<ProviderResult> {
     this.calls++;
-    return { nodes: [node('from-provider')], edges: [] };
+    return { nodes: [node(this.value)], edges: [] };
   }
+}
+
+function keyFor(providerId: string, digest = providerId): GraphStoreCacheKey {
+  return {
+    ...key,
+    providerId,
+    contentHash: { algorithm: 'sha256', digest, encoding: 'hex' },
+  };
 }
 
 describe('orchestrateWithProviderResultStore', () => {
@@ -82,12 +96,18 @@ describe('orchestrateWithProviderResultStore', () => {
     const registry = new ProviderRegistry();
     registry.register(provider);
     const store = new MemoryGraphStore();
-    store.entry = {
-      key,
+    store.entries.set('counting:counting', {
+      key: keyFor('counting'),
       value: { nodes: [node('from-cache')], edges: [] },
-    };
+    });
 
-    const graph = await orchestrateWithProviderResultStore(registry, config, { readme: null }, store, key);
+    const graph = await orchestrateWithProviderResultStore(
+      registry,
+      config,
+      { readme: null },
+      store,
+      async providerId => keyFor(providerId),
+    );
 
     expect(provider.calls).toBe(0);
     expect(graph.nodes.map(n => n.id)).toEqual(['from-cache']);
@@ -100,23 +120,68 @@ describe('orchestrateWithProviderResultStore', () => {
     registry.register(provider);
     const store = new MemoryGraphStore();
 
-    const graph = await orchestrateWithProviderResultStore(registry, config, { readme: null }, store, key);
+    const graph = await orchestrateWithProviderResultStore(
+      registry,
+      config,
+      { readme: null },
+      store,
+      async providerId => keyFor(providerId),
+    );
 
     expect(provider.calls).toBe(1);
     expect(store.putCount).toBe(1);
-    expect(store.entry?.value.nodes.map(n => n.id)).toEqual(['from-provider']);
+    expect(store.entries.get('counting:counting')?.value.nodes.map(n => n.id)).toEqual(['from-provider']);
     expect(graph.nodes.map(n => n.id)).toEqual(['from-provider']);
+  });
+
+  it('reuses unchanged provider prefixes and recomputes from the first changed provider onward', async () => {
+    const providers = [
+      new CountingProvider('files', 'from-files'),
+      new CountingProvider('work', 'from-work-v2'),
+      new CountingProvider('person', 'from-person-v2'),
+    ];
+    const registry = new ProviderRegistry();
+    for (const provider of providers) registry.register(provider);
+    const store = new MemoryGraphStore();
+    store.entries.set('files:files', {
+      key: keyFor('files'),
+      value: { nodes: [node('from-files')], edges: [] },
+    });
+    store.entries.set('work:work-v1', {
+      key: keyFor('work', 'work-v1'),
+      value: { nodes: [node('from-files'), node('from-work-v1')], edges: [] },
+    });
+
+    const graph = await orchestrateWithProviderResultStore(
+      registry,
+      config,
+      { readme: null },
+      store,
+      async (providerId) => keyFor(providerId, providerId === 'work' ? 'work-v2' : providerId),
+    );
+
+    expect(providers.map(p => p.calls)).toEqual([0, 1, 1]);
+    expect(graph.nodes.map(n => n.id)).toEqual(['from-files', 'from-work-v2', 'from-person-v2']);
+    expect(store.entries.has('work:work-v2')).toBe(true);
+    expect(store.entries.has('person:person')).toBe(true);
   });
 
   it('surfaces malformed cached provider results', async () => {
     const registry = new ProviderRegistry();
+    registry.register(new CountingProvider());
     const store = new MemoryGraphStore();
-    store.entry = {
-      key,
+    store.entries.set('counting:counting', {
+      key: keyFor('counting'),
       value: { nodes: undefined, edges: [] } as unknown as ProviderResult,
-    };
+    });
 
-    await expect(orchestrateWithProviderResultStore(registry, config, { readme: null }, store, key))
+    await expect(orchestrateWithProviderResultStore(
+      registry,
+      config,
+      { readme: null },
+      store,
+      async providerId => keyFor(providerId),
+    ))
       .rejects.toThrow('Invalid cached graph store entry');
   });
 });

--- a/src/engine/store/__tests__/store-orchestrator.test.ts
+++ b/src/engine/store/__tests__/store-orchestrator.test.ts
@@ -54,14 +54,25 @@ class MemoryGraphStore implements GraphStore<ProviderResult> {
     });
   }
 
-  async delete(): Promise<boolean> {
-    const count = this.entries.size;
-    this.entries.clear();
-    return count > 0;
+  async delete(key: GraphStoreCacheKey): Promise<boolean> {
+    return this.entries.delete(`${key.providerId}:${key.contentHash.digest}`);
   }
 
-  async invalidate(_match: GraphStoreInvalidation): Promise<number> {
-    return await this.delete() ? 1 : 0;
+  async invalidate(match: GraphStoreInvalidation): Promise<number> {
+    let deleted = 0;
+    for (const [cacheKey, entry] of this.entries) {
+      if (
+        (!match.scope || match.scope === entry.key.scope) &&
+        (!match.providerId || match.providerId === entry.key.providerId) &&
+        (!match.sourceId || match.sourceId === entry.key.sourceId) &&
+        (!match.variant || match.variant === entry.key.variant) &&
+        (!match.contentHash || match.contentHash.digest === entry.key.contentHash.digest)
+      ) {
+        this.entries.delete(cacheKey);
+        deleted++;
+      }
+    }
+    return deleted;
   }
 }
 

--- a/src/engine/store/fingerprint.ts
+++ b/src/engine/store/fingerprint.ts
@@ -12,17 +12,21 @@ export function buildProviderResultCacheKey(
   source: RepoSource,
   config: KBConfig,
   data: RepoData,
+  providerId: string = GRAPH_STORE_PROVIDER_ID,
+  previousContentHash?: ContentHash,
 ): Promise<GraphStoreCacheKey> {
   return contentHashFor({
     apiVersion: GRAPH_STORE_API_VERSION,
     cacheKeyVersion: GRAPH_STORE_CACHE_KEY_VERSION,
     derivationVersion: GRAPH_STORE_DERIVATION_VERSION,
     sourceId: source.id,
+    providerId,
+    previousContentHash,
     config,
-    data: stableRepoData(data),
+    data: stableProviderData(data, providerId),
   }).then(contentHash => ({
     scope: 'provider-result',
-    providerId: GRAPH_STORE_PROVIDER_ID,
+    providerId,
     sourceId: sourceIdFor(source, config),
     contentHash,
     variant: [
@@ -31,6 +35,16 @@ export function buildProviderResultCacheKey(
       GRAPH_STORE_DERIVATION_VERSION,
     ].join(':'),
   }));
+}
+
+export function hashProviderResultPrefix(providerId: string, nodes: unknown): Promise<ContentHash> {
+  return contentHashFor({
+    apiVersion: GRAPH_STORE_API_VERSION,
+    cacheKeyVersion: GRAPH_STORE_CACHE_KEY_VERSION,
+    derivationVersion: GRAPH_STORE_DERIVATION_VERSION,
+    providerId,
+    nodes,
+  });
 }
 
 export function sourceIdFor(source: RepoSource, config: KBConfig): string {
@@ -44,7 +58,7 @@ export function sourceIdFor(source: RepoSource, config: KBConfig): string {
   ].join(':');
 }
 
-async function contentHashFor(value: unknown): Promise<ContentHash> {
+export async function contentHashFor(value: unknown): Promise<ContentHash> {
   const crypto = globalThis.crypto?.subtle;
   if (!crypto) {
     throw new Error('Graph store hashing requires Web Crypto SubtleCrypto support.');
@@ -98,6 +112,78 @@ function stableRepoData(data: RepoData): unknown {
     contentModel: data.contentModel,
     readme: data.readme,
   };
+}
+
+function stableProviderData(data: RepoData, providerId: string): unknown {
+  switch (providerId) {
+    case 'files':
+      return {
+        repo: data.repo,
+        tree: data.tree.map(item => ({
+          path: item.path,
+          mode: item.mode,
+          type: item.type,
+          sha: item.sha,
+          size: item.size,
+        })),
+      };
+    case 'authored':
+      return {
+        authoredContent: data.authoredContent,
+        nodemapRaw: data.nodemapRaw,
+        nodemapFiles: data.nodemapFiles,
+        nodemapDirs: data.nodemapDirs,
+      };
+    case 'work':
+      return {
+        issues: data.issues.map(issue => ({
+          number: issue.number,
+          title: issue.title,
+          body: issue.body,
+          state: issue.state,
+          labels: issue.labels,
+          assignees: issue.assignees,
+          user: issue.user,
+          html_url: issue.html_url,
+          created_at: issue.created_at,
+          updated_at: issue.updated_at,
+        })),
+        pullRequests: data.pullRequests,
+        commits: data.commits,
+        branches: data.branches,
+        repoMetadata: data.repoMetadata,
+        releases: data.releases,
+      };
+    case 'content-model':
+      return {
+        contentModel: data.contentModel,
+      };
+    case 'person':
+      return {
+        issues: data.issues.map(issue => ({
+          number: issue.number,
+          title: issue.title,
+          state: issue.state,
+          assignees: issue.assignees,
+          user: issue.user,
+        })),
+        pullRequests: data.pullRequests.map(pr => ({
+          number: pr.number,
+          title: pr.title,
+          state: pr.state,
+          html_url: pr.html_url,
+          user: pr.user,
+          assignees: pr.assignees,
+        })),
+      };
+    case 'structural':
+      return {
+        structuralFiles: data.structuralFiles,
+        structuredNodeMapRaw: data.structuredNodeMapRaw,
+      };
+    default:
+      return stableRepoData(data);
+  }
 }
 
 export function stableStringify(value: unknown): string {

--- a/src/engine/store/store-orchestrator.ts
+++ b/src/engine/store/store-orchestrator.ts
@@ -79,6 +79,9 @@ function dependencyFor(
 }
 
 function cloneProviderResult(value: ProviderResult): ProviderResult {
+  if (typeof structuredClone === 'function') {
+    return structuredClone(value);
+  }
   return JSON.parse(JSON.stringify(value)) as ProviderResult;
 }
 

--- a/src/engine/store/store-orchestrator.ts
+++ b/src/engine/store/store-orchestrator.ts
@@ -1,10 +1,7 @@
-import type { KBConfig, KBGraph, KBNode, GraphStore } from '../../types';
+import type { KBConfig, KBGraph, KBNode, GraphStore, GraphStoreEntry } from '../../types';
 import { extractClusters } from '../parser';
 import { buildGraph } from '../graph';
 import type { ProviderRegistry, ProviderResult } from '../providers';
-import {
-  collectProviderNodes,
-} from '../orchestrator';
 import {
   applyTransforms,
   DEFAULT_TRANSFORMS,
@@ -16,40 +13,73 @@ import {
   GRAPH_STORE_API_VERSION,
   GRAPH_STORE_CACHE_KEY_VERSION,
 } from '../../types';
-import { GRAPH_STORE_DERIVATION_VERSION } from './fingerprint';
+import {
+  GRAPH_STORE_DERIVATION_VERSION,
+  hashProviderResultPrefix,
+} from './fingerprint';
+
+export type ProviderCacheKeyBuilder = (
+  providerId: string,
+  previousContentHash: GraphStoreCacheKey['contentHash'] | undefined,
+) => Promise<GraphStoreCacheKey>;
 
 export async function orchestrateWithProviderResultStore(
   registry: ProviderRegistry,
   config: KBConfig,
   ctx: TransformContext,
   store: GraphStore<ProviderResult>,
-  key: GraphStoreCacheKey,
+  buildCacheKey: ProviderCacheKeyBuilder,
   transforms: readonly GraphTransform[] = DEFAULT_TRANSFORMS,
 ): Promise<KBGraph> {
-  const cached = await store.get(key);
-  if (cached) {
-    const nodes = validateProviderResult(cached.value, 'cached graph store entry').nodes;
-    return buildGraph(nodes, extractClusters(nodes, config));
+  const providers = registry.getExecutionOrder();
+  let allNodes: KBNode[] = [];
+  let previousContentHash: GraphStoreCacheKey['contentHash'] | undefined;
+
+  for (const provider of providers) {
+    const key = await buildCacheKey(provider.id, previousContentHash);
+    const cached = await store.get(key);
+    if (cached) {
+      allNodes = cloneProviderResult(
+        validateProviderResult(cached.value, `cached graph store entry for ${provider.id}`),
+      ).nodes;
+      previousContentHash = await hashProviderResultPrefix(provider.id, allNodes);
+      continue;
+    }
+
+    const result = await provider.resolve(config, allNodes);
+    allNodes.push(...result.nodes);
+    const value: ProviderResult = cloneProviderResult({ nodes: allNodes, edges: [] });
+    await store.put({
+      key,
+      value,
+      dependencies: [dependencyFor(key, previousContentHash)],
+      metadata: {
+        graphStoreApiVersion: GRAPH_STORE_API_VERSION,
+        graphStoreCacheKeyVersion: GRAPH_STORE_CACHE_KEY_VERSION,
+        graphStoreDerivationVersion: GRAPH_STORE_DERIVATION_VERSION,
+        providerId: provider.id,
+      },
+    });
+    previousContentHash = await hashProviderResultPrefix(provider.id, allNodes);
   }
 
-  const allNodes = await collectProviderNodes(registry, config);
   const transformed = applyTransforms(allNodes, ctx, transforms);
-  const value: ProviderResult = { nodes: transformed, edges: [] };
-  await store.put({
-    key,
-    value,
-    dependencies: [{
-      href: key.sourceId ?? key.providerId,
-      contentHash: key.contentHash,
-      sourceId: key.sourceId,
-    }],
-    metadata: {
-      graphStoreApiVersion: GRAPH_STORE_API_VERSION,
-      graphStoreCacheKeyVersion: GRAPH_STORE_CACHE_KEY_VERSION,
-      graphStoreDerivationVersion: GRAPH_STORE_DERIVATION_VERSION,
-    },
-  });
   return buildGraph(transformed, extractClusters(transformed, config));
+}
+
+function dependencyFor(
+  key: GraphStoreCacheKey,
+  previousContentHash: GraphStoreCacheKey['contentHash'] | undefined,
+): NonNullable<GraphStoreEntry<ProviderResult>['dependencies']>[number] {
+  return {
+    href: previousContentHash ? `${key.sourceId ?? key.providerId}#previous` : key.sourceId ?? key.providerId,
+    contentHash: previousContentHash ?? key.contentHash,
+    sourceId: key.sourceId,
+  };
+}
+
+function cloneProviderResult(value: ProviderResult): ProviderResult {
+  return JSON.parse(JSON.stringify(value)) as ProviderResult;
 }
 
 function validateProviderResult(value: ProviderResult, label: string): ProviderResult {

--- a/tests/golden/graph-store-parity.test.ts
+++ b/tests/golden/graph-store-parity.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import type {
+  GraphStore,
+  GraphStoreCacheKey,
+  GraphStoreEntry,
+  GraphStoreInvalidation,
+  GraphStoreWrite,
+  ProviderResult,
+} from '../../src/types';
+import {
+  buildConfigFromManifest,
+  buildKnowledgeBaseFromManifest,
+  type RepoManifest,
+} from '../../src/engine/local-loader';
+import { registerProviders } from '../../src/engine/loader';
+import { ManifestSource } from '../../src/engine/sources/manifest-source';
+import { formatGraphStoreCacheKey } from '../../src/types';
+import { buildProviderResultCacheKey } from '../../src/engine/store/fingerprint';
+import { orchestrateWithProviderResultStore } from '../../src/engine/store/store-orchestrator';
+import { ProviderRegistry } from '../../src/engine/providers';
+import { serializeGraph } from './serialize';
+import { installWikipediaFetchMock } from './wikipedia-mock';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const MANIFEST = join(here, 'fixtures', 'manifest.json');
+
+function loadManifestFixture(): RepoManifest {
+  return JSON.parse(readFileSync(MANIFEST, 'utf8')) as RepoManifest;
+}
+
+class MemoryGraphStore implements GraphStore<ProviderResult> {
+  entries = new Map<string, GraphStoreEntry<ProviderResult>>();
+  getCount = 0;
+  putCount = 0;
+
+  async get(key: GraphStoreCacheKey): Promise<GraphStoreEntry<ProviderResult> | undefined> {
+    this.getCount++;
+    return this.entries.get(formatGraphStoreCacheKey(key));
+  }
+
+  async put(entry: GraphStoreWrite<ProviderResult>): Promise<void> {
+    this.putCount++;
+    this.entries.set(formatGraphStoreCacheKey(entry.key), {
+      ...entry,
+      createdAt: entry.createdAt ?? 'created',
+      updatedAt: entry.updatedAt ?? 'updated',
+    });
+  }
+
+  async delete(key: GraphStoreCacheKey): Promise<boolean> {
+    return this.entries.delete(formatGraphStoreCacheKey(key));
+  }
+
+  async invalidate(_match: GraphStoreInvalidation): Promise<number> {
+    const count = this.entries.size;
+    this.entries.clear();
+    return count;
+  }
+}
+
+async function buildLocalGraphWithStore(store: MemoryGraphStore) {
+  const manifest = loadManifestFixture();
+  const config = buildConfigFromManifest(manifest);
+  const source = new ManifestSource(manifest, config);
+  const data = await source.getRepoData();
+  const registry = new ProviderRegistry();
+  registerProviders(registry, data);
+  const graph = await orchestrateWithProviderResultStore(
+    registry,
+    config,
+    { readme: data.readme },
+    store,
+    (providerId, previousContentHash) =>
+      buildProviderResultCacheKey(source, config, data, providerId, previousContentHash),
+  );
+  return { graph, config };
+}
+
+describe('golden: graph-store parity', () => {
+  beforeEach(() => {
+    installWikipediaFetchMock();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('matches the default-off local graph byte-for-byte and reuses cache on no-change reload', async () => {
+    const manifest = loadManifestFixture();
+    const config = buildConfigFromManifest(manifest);
+    const baseline = await buildKnowledgeBaseFromManifest(manifest, config);
+    const store = new MemoryGraphStore();
+
+    const first = await buildLocalGraphWithStore(store);
+    const writesAfterFirst = store.putCount;
+    const second = await buildLocalGraphWithStore(store);
+
+    expect(serializeGraph(first.graph)).toBe(serializeGraph(baseline.graph));
+    expect(serializeGraph(second.graph)).toBe(serializeGraph(baseline.graph));
+    expect(writesAfterFirst).toBeGreaterThan(0);
+    expect(store.putCount).toBe(writesAfterFirst);
+  });
+});


### PR DESCRIPTION
## Summary
- Cache graph-store provider prefixes instead of one whole-pipeline result so no-change SQLite reloads reuse provider entries and source/provider/config hash changes invalidate only the affected provider prefix and downstream prefixes.
- Add provider-slice fingerprint coverage for source/provider/config invalidation.
- Add a golden parity guard proving the store-backed local graph serializes byte-for-byte identically to the default-off local graph and reuses cache on reload.

Part of #338

## Validation
- npx vitest run --config vitest.config.ts src/engine/store tests/golden/graph-store-parity.test.ts --reporter=dot
- npm run test -- --reporter=dot
- npm run lint (passes with existing warnings)
- npm run build
- VITE_KB_LOCAL=true VITE_KB_GRAPH_STORE=sqlite npm run build
- npx playwright test smoke --project=chromium --reporter=line
- One-off Playwright SQLite opt-in load/reload check against preview
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anokye-labs/kbexplorer-template/pull/392" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->