### PR TITLE
fix(dtu): seed Gitea repo non-empty so listPulls 404 stops blocking seed

### DIFF
--- a/twins/gitea/gitea-client.mjs
+++ b/twins/gitea/gitea-client.mjs
@@ -52,8 +52,17 @@ export async function ensureOrg(owner) {
   return { created: res.ok };
 }
 
-/** Create the repo under the org if missing (idempotent). No auto-init: seed pushes a snapshot. */
-export async function ensureRepo(owner, repo, { autoInit = false } = {}) {
+/**
+ * Create the repo under the org if missing (idempotent).
+ *
+ * Born non-empty via `auto_init` (an in-process initial commit, NOT a push hook):
+ * Gitea enables the Pull Requests unit only when `CanEnablePulls()` is true
+ * (`!IsMirror && !IsEmpty`), so an *empty* repo makes `GET /pulls` 404 with the
+ * generic API NotFound (`/api/swagger`) body. The seed's `snapshotPushMain` then
+ * force-pushes the working-tree snapshot over that initial commit, so `main`
+ * still mirrors the real repo while the repo is never empty.
+ */
+export async function ensureRepo(owner, repo, { autoInit = true } = {}) {
   const get = await gitea('GET', `/repos/${owner}/${repo}`);
   if (get.ok) return { created: false };
   const res = await gitea('POST', `/orgs/${owner}/repos`, {

--- a/twins/gitea/seed.mjs
+++ b/twins/gitea/seed.mjs
@@ -51,11 +51,42 @@ function snapshotPushMain(owner, repo) {
   log(`force-pushing snapshot ${commit.slice(0, 8)} → ${owner}/${repo}@main`);
   git(['push', '--force', remote, `${commit}:refs/heads/main`], env);
   if (existsSync(indexFile)) rmSync(indexFile);
-  // Make sure main is the default branch even on a repo created without auto-init.
+  // The repo is created with auto_init (born non-empty); this force-push just
+  // replaces that initial commit so `main` mirrors the working tree.
 }
 
 async function setDefaultBranch(owner, repo, branch) {
   await gitea('PATCH', `/repos/${owner}/${repo}`, { default_branch: branch }).catch(() => {});
+}
+
+/**
+ * Gate any pull-request operation on the repo being genuinely pull-ready.
+ *
+ * Gitea's `/repos/{owner}/{repo}/pulls` route is guarded by `mustAllowPulls`,
+ * which 404s (with the generic API NotFound `/api/swagger` body) whenever
+ * `CanEnablePulls()` is false — i.e. while the repo is still flagged empty. We
+ * create the repo with auto_init so it is non-empty from birth, but also poll
+ * the repo metadata here so a still-empty repo (e.g. a warm twin from before
+ * this fix) fails loudly with an actionable message instead of a cryptic 404.
+ */
+async function waitForRepoReady(owner, repo, branch, { timeoutMs = 20000 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  let detail = 'no response from Gitea';
+  while (Date.now() < deadline) {
+    const meta = await gitea('GET', `/repos/${owner}/${repo}`);
+    if (meta.ok && meta.json && meta.json.empty === false) {
+      const head = await gitea('GET', `/repos/${owner}/${repo}/branches/${encodeURIComponent(branch)}`);
+      if (head.ok) return;
+      detail = `default branch "${branch}" not resolvable yet (${head.status})`;
+    } else {
+      detail = meta.ok ? 'repo still reports empty (is_empty=true)' : `repo metadata ${meta.status}`;
+    }
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  throw new Error(
+    `repo ${owner}/${repo} is not pull-ready (${detail}); ` +
+    'Gitea disables the pulls route on empty repos. Try `npm run dtu:reset`.',
+  );
 }
 
 const BASELINE_ISSUES = [
@@ -103,9 +134,12 @@ async function main() {
   log(`seeding ${owner}/${repo}@${branch}`);
 
   await ensureOrg(owner);
-  await ensureRepo(owner, repo, { autoInit: false });
+  await ensureRepo(owner, repo, { autoInit: true });
   snapshotPushMain(owner, repo);
   await setDefaultBranch(owner, repo, branch);
+  // Block until Gitea reports the repo non-empty with `branch` resolvable, so the
+  // pulls route is enabled before seedSourceEditPr/listPulls touch it.
+  await waitForRepoReady(owner, repo, branch);
 
   let created = 0;
   for (const spec of BASELINE_ISSUES) {

--- a/twins/gitea/seed.mjs
+++ b/twins/gitea/seed.mjs
@@ -73,13 +73,22 @@ async function waitForRepoReady(owner, repo, branch, { timeoutMs = 20000 } = {})
   const deadline = Date.now() + timeoutMs;
   let detail = 'no response from Gitea';
   while (Date.now() < deadline) {
-    const meta = await gitea('GET', `/repos/${owner}/${repo}`);
-    if (meta.ok && meta.json && meta.json.empty === false) {
-      const head = await gitea('GET', `/repos/${owner}/${repo}/branches/${encodeURIComponent(branch)}`);
-      if (head.ok) return;
-      detail = `default branch "${branch}" not resolvable yet (${head.status})`;
-    } else {
-      detail = meta.ok ? 'repo still reports empty (is_empty=true)' : `repo metadata ${meta.status}`;
+    try {
+      const meta = await gitea('GET', `/repos/${owner}/${repo}`);
+      if (meta.ok && meta.json && meta.json.empty === false) {
+        const head = await gitea('GET', `/repos/${owner}/${repo}/branches/${encodeURIComponent(branch)}`);
+        if (head.ok) return;
+        detail = `default branch "${branch}" not resolvable yet (${head.status})`;
+      } else {
+        detail = meta.ok ? 'repo still reports empty (is_empty=true)' : `repo metadata ${meta.status}`;
+      }
+    } catch (err) {
+      // Gitea can be briefly unreachable during bring-up; gitea()'s underlying
+      // fetch() throws on transient connection errors/timeouts. Swallow those and
+      // keep polling until the deadline rather than aborting the seed — that is
+      // the whole point of the readiness gate. A genuinely never-ready repo still
+      // fails loudly at the timeout below.
+      detail = `transient fetch error: ${err?.message ?? err}`;
     }
     await new Promise((r) => setTimeout(r, 500));
   }

--- a/twins/gitea/state.mjs
+++ b/twins/gitea/state.mjs
@@ -23,6 +23,10 @@ export const BIN_DIR = resolve(DTU_DIR, 'bin');
 export const HARNESS = {
   giteaApi: process.env.GITEA_API ?? 'http://localhost:3000',
   container: process.env.GITEA_CONTAINER ?? 'kbe-gitea',
+  // Pinned to the 1.24 minor so the harness tracks security/bugfix patches within
+  // a known-good major.minor without surprise behavior jumps across majors. The
+  // pulls/issues REST surface the harness uses is stable across 1.24.x. Override
+  // via GITEA_IMAGE to reproduce against a specific patch if drift is suspected.
   image: process.env.GITEA_IMAGE ?? 'docker.io/gitea/gitea:1.24',
   httpPort: Number(process.env.GITEA_HTTP_PORT ?? 3000),
   twinPort: Number(process.env.TWIN_PORT ?? 3456),


### PR DESCRIPTION
## What & why

`npm run dtu:seed` has fast-failed **100% of the time since ~2026-06-13**, taking down two nightly DTU lanes with a single root cause:

- **L3** live-Gitea e2e (`dtu-gitea.yml`)
- **L6** exploratory-agent stage (`explore-dtu.yml`)

Both die at the same call:

```
[seed] FAILED: listPulls failed: 404 ... /api/swagger
```

First failing call: `twins/gitea/seed.mjs` `seedSourceEditPr` → `listPulls` → `GET /repos/{owner}/{repo}/pulls`. Issue-seeding succeeds earlier in the same run, so the repo exists.

## Root cause

Gitea guards `/repos/{owner}/{repo}/pulls` with `mustAllowPulls`, which returns the **generic API NotFound** (body references `/api/swagger`) when `CanEnablePulls()` is false. `CanEnablePulls() = !IsMirror && !IsEmpty`.

The seed created the repo with `auto_init: false`, so it is born `is_empty = true`. `snapshotPushMain` force-pushes a working-tree snapshot to `main` to make it non-empty, but in the containerized CI Gitea the `is_empty` DB flag was **not reliably cleared** before `listPulls` ran → deterministic 404. Issues don't require a non-empty repo, which is why they succeed first.

## Fix (minimal, within `twins/gitea/`)

- **`ensureRepo` now creates the repo with `auto_init: true`** — born non-empty via Gitea's **in-process** repo init (independent of any push hook), so the Pull Requests unit is enabled from creation. `snapshotPushMain` still force-pushes the working-tree snapshot over the initial commit, so `main` mirrors the real repo exactly.
- **Added `waitForRepoReady`** in `seed.mjs`: after the push, poll until the repo reports `empty === false` **and** the default branch is resolvable before any pulls op. Turns a silent 404 into a clear, actionable error and absorbs any async settle.
- **Justified the pinned `gitea/gitea:1.24` image tag** with a comment in `state.mjs`.

No assertions weakened — the fix makes the repo genuinely pull-ready rather than masking the failure (holdout discipline).

## Verification

- `npm test` → **740 passed** (64 files), including `twins/gitea/__tests__/adapter.test.mjs`.
- `npm run lint` → **0 errors** (3 pre-existing warnings in unrelated files).
- Podman is unavailable in the authoring environment, so the live Gitea bring-up is verified in CI: dispatching `dtu-gitea.yml` and `explore-dtu.yml` and confirming both get **past `dtu:seed`**.

Closes #395
Refs #394 (P0 — Fix the Gitea seed `listPulls` 404; revives L3 + L6).