### PR TITLE
fix(dtu): L3 gitea e2e app boot 500s — generate repo-manifest before dev server

### DIFF
--- a/twins/gitea/global-setup.ts
+++ b/twins/gitea/global-setup.ts
@@ -2,20 +2,36 @@ import { execFileSync } from 'node:child_process';
 import { resolve } from 'node:path';
 
 /**
- * Playwright globalSetup for the Gitea DTU: bring up Podman+Gitea and seed the
- * baseline universe before any spec runs. Both steps are idempotent, so a warm
- * environment reconciles quickly. Runs the harness scripts as child processes so
- * their logging and error handling are reused verbatim.
+ * Playwright globalSetup for the Gitea DTU: generate the local-mode manifest
+ * module, then bring up Podman+Gitea and seed the baseline universe before any
+ * spec runs. All steps are idempotent, so a warm environment reconciles quickly.
+ * Runs the harness scripts as child processes so their logging and error
+ * handling are reused verbatim.
  */
 export default async function globalSetup() {
   const root = process.cwd();
-  const run = (script: string) => {
-    console.log(`\n[dtu:setup] node ${script}`);
-    execFileSync(process.execPath, [resolve(root, 'twins', 'gitea', script)], {
+  const run = (label: string, ...segments: string[]) => {
+    console.log(`\n[dtu:setup] node ${label}`);
+    execFileSync(process.execPath, [resolve(root, ...segments)], {
       stdio: 'inherit',
       env: process.env,
     });
   };
-  run('bootstrap.mjs');
-  run('seed.mjs');
+
+  // Generate src/generated/repo-manifest.json BEFORE the webServers start.
+  // playwright.gitea.config.ts serves a bare `vite` dev server (no `prebuild`
+  // step), and src/engine/local-loader.ts statically imports
+  // `../generated/repo-manifest.json`, which Vite's import-analysis resolves at
+  // transform time. That file is gitignored and is produced only by
+  // scripts/generate-manifest.js (normally via the `prebuild` npm script before
+  // `vite build`). In a fresh CI checkout it is therefore absent, so the dev
+  // server 500s on import resolution and the app never boots — failing every
+  // gitea spec. Generating it here satisfies Vite's resolver. The app stays in
+  // REMOTE mode (no VITE_KB_LOCAL), so the manifest is never consumed at runtime;
+  // its sole purpose is to make the static import resolvable. The output is
+  // gitignored, so it does not affect seed.mjs's `git add -A` snapshot.
+  run('scripts/generate-manifest.js', 'scripts', 'generate-manifest.js');
+
+  run('twins/gitea/bootstrap.mjs', 'twins', 'gitea', 'bootstrap.mjs');
+  run('twins/gitea/seed.mjs', 'twins', 'gitea', 'seed.mjs');
 }


### PR DESCRIPTION
## What

The L3 live-Gitea e2e lane (`dtu-gitea.yml` → `playwright.gitea.config.ts`) reaches app bring-up after the seed fix (#396), but the bare Vite dev server **500s** and the app never boots, so every `e2e/gitea` spec fails.

`playwright.gitea.config.ts` serves the app with a **bare** `vite` dev server in **remote mode** (`VITE_GH_API_BASE` set, `VITE_KB_LOCAL` not set). `src/engine/local-loader.ts` statically imports `../generated/repo-manifest.json`, which Vite's import-analysis resolves at **transform time** regardless of mode. That file is gitignored and produced only by `scripts/generate-manifest.js` (normally via the `prebuild` npm script before `vite build`). A bare dev server never runs `prebuild`, so in a fresh CI checkout the file is **absent**:

```
Failed to resolve import "../generated/repo-manifest.json" from "src/engine/local-loader.ts". Does the file exist?
```

L2 (static twin) is unaffected — it serves `vite preview` of a production build where the manifest is generated + bundled. This L3 break was masked until now by the pre-existing seed 404 (#395, fixed in #396).

## Fix

Run `node scripts/generate-manifest.js` from `twins/gitea/global-setup.ts`. Playwright runs `globalSetup` **before** the webServers start, so the manifest module exists before the dev server transforms `local-loader.ts`. Applies to CI and local `npm run test:e2e:gitea`.

- The app **stays in REMOTE mode** (no `VITE_KB_LOCAL`), so it still sources data from the live Gitea twin and the mutate → refresh assertions stay meaningful. The manifest exists only to satisfy Vite's import resolver; it is never consumed at runtime in remote mode.
- No `/* @vite-ignore */` — that would break L2/production local-mode bundling, where the manifest must be bundled + consumed.
- `generate-manifest.js` is offline-tolerant and its output is gitignored, so it always writes a valid manifest and does not affect seed.mjs's `git add -A` snapshot.

## Verification

- Reproduced + fixed locally via Vite's programmatic `transformRequest('/src/engine/local-loader.ts')`: manifest **absent** → `Failed to resolve import … repo-manifest.json`; manifest **present** → transform OK.
- `npm test` → **740 pass**; `npm run lint` → **0 errors** (3 pre-existing warnings).
- CI: dispatched `dtu-gitea.yml` against this branch to confirm seed stays green, the Vite 500 is gone, and the e2e/gitea specs run end-to-end.

## Stacking

This branch is **stacked on #396** (the DTU Gitea seed fix). The seed commit shows in this diff until #396 merges, then auto-cleans. This PR touches only `twins/gitea/global-setup.ts`.

Closes #397
Refs #394