### PR TITLE
fix(dtu): L3 gitea e2e app boot 500s — stub repo-manifest so the dev server boots

### DIFF
--- a/twins/gitea/global-setup.ts
+++ b/twins/gitea/global-setup.ts
@@ -1,11 +1,13 @@
 import { execFileSync } from 'node:child_process';
-import { resolve } from 'node:path';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
 
 /**
- * Playwright globalSetup for the Gitea DTU: bring up Podman+Gitea and seed the
- * baseline universe before any spec runs. Both steps are idempotent, so a warm
- * environment reconciles quickly. Runs the harness scripts as child processes so
- * their logging and error handling are reused verbatim.
+ * Playwright globalSetup for the Gitea DTU: bring up Podman+Gitea, seed the
+ * baseline universe, then ensure a stub manifest exists — all before any spec
+ * runs. The harness steps are idempotent, so a warm environment reconciles
+ * quickly. Runs the harness scripts as child processes so their logging and
+ * error handling are reused verbatim.
  */
 export default async function globalSetup() {
   const root = process.cwd();
@@ -18,4 +20,49 @@ export default async function globalSetup() {
   };
   run('bootstrap.mjs');
   run('seed.mjs');
+  ensureStubManifest(root);
+}
+
+/**
+ * Write a minimal STUB `src/generated/repo-manifest.json` so Vite's
+ * import-analysis can resolve the static `import('../generated/repo-manifest.json')`
+ * in src/engine/local-loader.ts.
+ *
+ * Why this is needed: playwright.gitea.config.ts serves the app with a bare
+ * `vite` dev server (no `prebuild` step). That import is resolved by Vite at
+ * transform time regardless of mode; the file is gitignored and normally only
+ * produced by scripts/generate-manifest.js, so in a fresh CI checkout it is
+ * absent and the dev server 500s on import resolution — the app never boots and
+ * every gitea spec fails.
+ *
+ * Why a STUB (not running generate-manifest.js): L3 runs the app in REMOTE mode
+ * (the config sets VITE_GH_API_BASE and does NOT set VITE_KB_LOCAL), so the app
+ * sources everything from the live Gitea twin and NEVER reads this manifest at
+ * runtime. The file only needs to EXIST as valid JSON to satisfy the resolver,
+ * so a stub keeps the harness fully offline (no GitHub/`gh` calls).
+ *
+ * Idempotent: written only when absent, so a real local-mode manifest (e.g. from
+ * `prebuild`) is never clobbered. The path is gitignored (src/generated/.gitignore),
+ * so it never enters the seed's `git add -A` snapshot — writing it after seed is
+ * belt-and-suspenders on top of that.
+ */
+function ensureStubManifest(root: string) {
+  const manifestPath = resolve(root, 'src', 'generated', 'repo-manifest.json');
+  if (existsSync(manifestPath)) return;
+  mkdirSync(dirname(manifestPath), { recursive: true });
+  // Minimal RepoManifest — only the required (non-optional) fields of the
+  // interface in src/engine/local-loader.ts. Contents are irrelevant in remote
+  // mode; this exists solely so the static import resolves.
+  const stub = {
+    configRaw: null,
+    authoredContent: {},
+    tree: [],
+    readme: null,
+    issues: [],
+    pullRequests: [],
+    commits: [],
+    generatedAt: '',
+  };
+  writeFileSync(manifestPath, `${JSON.stringify(stub, null, 2)}\n`, 'utf-8');
+  console.log(`[dtu:setup] wrote stub repo-manifest.json → ${manifestPath}`);
 }


### PR DESCRIPTION
## What

The L3 live-Gitea e2e lane (`dtu-gitea.yml` → `playwright.gitea.config.ts`) reaches app bring-up after the seed fix (#396), but the bare Vite dev server **500s** and the app never boots, so every `e2e/gitea` spec fails.

`playwright.gitea.config.ts` serves the app with a **bare** `vite` dev server in **remote mode** (`VITE_GH_API_BASE` set, `VITE_KB_LOCAL` not set). `src/engine/local-loader.ts` statically imports `../generated/repo-manifest.json`, which Vite's import-analysis resolves at **transform time** regardless of mode. That file is gitignored and produced only by `scripts/generate-manifest.js` (normally via the `prebuild` npm script before `vite build`). A bare dev server never runs `prebuild`, so in a fresh CI checkout the file is **absent**:

```
Failed to resolve import "../generated/repo-manifest.json" from "src/engine/local-loader.ts". Does the file exist?
```

L2 (static twin) is unaffected — it serves `vite preview` of a production build where the manifest is generated + bundled. This L3 break was masked until now by the pre-existing seed 404 (#395, fixed in #396).

## Fix

`twins/gitea/global-setup.ts` now writes a minimal **stub** `src/generated/repo-manifest.json` (only the required `RepoManifest` fields, all empty) after bootstrap + seed, **idempotently** (only when the file is absent).

- **Why a stub, not `generate-manifest.js`:** L3 runs the app in **REMOTE mode**, so it sources everything from the live Gitea twin and **never reads the manifest at runtime**. The file only needs to *exist as valid JSON* so Vite's resolver doesn't 500. A stub keeps the harness fully **offline** — no GitHub/`gh` calls (running the live generator would hit GitHub, which L3 doesn't want).
- **Idempotent / non-clobbering:** written only when absent, so a real local-mode manifest (e.g. from `prebuild`) is never overwritten.
- **Snapshot-safe:** the path is gitignored (`src/generated/.gitignore`), so it never enters seed.mjs's `git add -A` snapshot; writing it after seed is belt-and-suspenders on top of that.
- No `/* @vite-ignore */` (would break L2/production local-mode bundling); no change to app code, `local-loader.ts`, or other configs — the change is contained to the gitea harness.

## Verification

- Locally: writing the stub then `vite.transformRequest('/src/engine/local-loader.ts')` → resolves OK (without it → `Failed to resolve import …`). `npm run lint` → 0 errors (3 pre-existing warnings). `playwright … --list` → 12 tests in 4 files.
- CI: `dtu-gitea.yml` dispatched against this branch to confirm seed stays green, the app boots, and the e2e/gitea specs run end-to-end.

## Stacking

This branch is **stacked on #396** (the DTU Gitea seed fix); the seed files show in this diff until #396 merges, then auto-clean. This PR's own change is a single file: `twins/gitea/global-setup.ts`.

Closes #397
Refs #394