### PR TITLE
fix(dtu): static stub manifest (no gh) written before vite for gitea e2e

### DIFF
--- a/playwright.gitea.config.ts
+++ b/playwright.gitea.config.ts
@@ -45,7 +45,20 @@ export default defineConfig({
     },
     {
       // Real app (dev server) in remote/repo-aware mode, pointed at the adapter.
-      command: `node ./node_modules/vite/bin/vite.js --port ${APP_PORT} --strictPort`,
+      //
+      // `ensure-manifest-stub.mjs` writes a minimal stub
+      // src/generated/repo-manifest.json (only if absent) so Vite's
+      // import-analysis can resolve the static import of it in
+      // src/engine/local-loader.ts. A bare `vite` dev server never runs
+      // `prebuild`, so in a fresh CI checkout that gitignored file is missing and
+      // the server 500s on import resolution — the app never boots and every
+      // gitea spec fails. Chaining the stub ahead of `vite` (rather than writing
+      // it in globalSetup, which Playwright starts concurrently with the
+      // webServers) is race-free: the file exists before Vite's first transform.
+      // The stub does NOT run generate-manifest.js and makes NO GitHub/`gh`
+      // calls; the app runs in REMOTE mode (no VITE_KB_LOCAL) and never reads the
+      // manifest at runtime — it exists solely to satisfy the resolver.
+      command: `node twins/gitea/ensure-manifest-stub.mjs && node ./node_modules/vite/bin/vite.js --port ${APP_PORT} --strictPort`,
       url: `http://localhost:${APP_PORT}`,
       reuseExistingServer: !process.env.CI,
       timeout: 60000,

--- a/twins/gitea/ensure-manifest-stub.mjs
+++ b/twins/gitea/ensure-manifest-stub.mjs
@@ -1,0 +1,51 @@
+/**
+ * Ensure a minimal STUB `src/generated/repo-manifest.json` exists so Vite's
+ * import-analysis can resolve the static `import('../generated/repo-manifest.json')`
+ * in src/engine/local-loader.ts.
+ *
+ * Run from the Vite webServer command in playwright.gitea.config.ts BEFORE the
+ * dev server starts, so the module resolves on Vite's very first transform. This
+ * placement is race-free: Playwright starts webServers concurrently with (in CI,
+ * before) globalSetup, so writing the file in globalSetup leaves a transient
+ * pre-transform error; chaining it ahead of `vite` in the webServer command
+ * guarantees the file exists before Vite ever runs.
+ *
+ * L3 runs the app in REMOTE mode (the config sets VITE_GH_API_BASE and does NOT
+ * set VITE_KB_LOCAL), so the app sources everything from the live Gitea twin and
+ * NEVER reads this manifest at runtime — the file only needs to EXIST as valid
+ * JSON. A static stub (rather than running scripts/generate-manifest.js) keeps
+ * the harness fully offline and deterministic: no `gh`/GitHub calls, so no extra
+ * network/CLI failure mode on the nightly lane.
+ *
+ * Idempotent: if the file already exists it is left untouched, so a real
+ * local-mode manifest (e.g. from `prebuild`, for a dev running
+ * `npm run test:e2e:gitea`) is never clobbered. The path is gitignored
+ * (src/generated/.gitignore), so it never enters the seed's `git add -A` snapshot.
+ */
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const manifestPath = resolve(repoRoot, 'src', 'generated', 'repo-manifest.json');
+
+if (existsSync(manifestPath)) {
+  console.log('[manifest-stub] src/generated/repo-manifest.json already present, leaving as-is');
+} else {
+  mkdirSync(dirname(manifestPath), { recursive: true });
+  // Minimal valid RepoManifest — only the REQUIRED (non-optional) fields of the
+  // interface in src/engine/local-loader.ts. Contents are irrelevant in remote
+  // mode; this exists solely so the static import resolves.
+  const stub = {
+    generatedAt: '',
+    configRaw: null,
+    authoredContent: {},
+    tree: [],
+    readme: null,
+    issues: [],
+    pullRequests: [],
+    commits: [],
+  };
+  writeFileSync(manifestPath, `${JSON.stringify(stub, null, 2)}\n`, 'utf-8');
+  console.log('[manifest-stub] wrote src/generated/repo-manifest.json');
+}

--- a/twins/gitea/global-setup.ts
+++ b/twins/gitea/global-setup.ts
@@ -1,13 +1,11 @@
 import { execFileSync } from 'node:child_process';
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
-import { resolve, dirname } from 'node:path';
+import { resolve } from 'node:path';
 
 /**
- * Playwright globalSetup for the Gitea DTU: bring up Podman+Gitea, seed the
- * baseline universe, then ensure a stub manifest exists — all before any spec
- * runs. The harness steps are idempotent, so a warm environment reconciles
- * quickly. Runs the harness scripts as child processes so their logging and
- * error handling are reused verbatim.
+ * Playwright globalSetup for the Gitea DTU: bring up Podman+Gitea and seed the
+ * baseline universe before any spec runs. Both steps are idempotent, so a warm
+ * environment reconciles quickly. Runs the harness scripts as child processes so
+ * their logging and error handling are reused verbatim.
  */
 export default async function globalSetup() {
   const root = process.cwd();
@@ -20,49 +18,4 @@ export default async function globalSetup() {
   };
   run('bootstrap.mjs');
   run('seed.mjs');
-  ensureStubManifest(root);
-}
-
-/**
- * Write a minimal STUB `src/generated/repo-manifest.json` so Vite's
- * import-analysis can resolve the static `import('../generated/repo-manifest.json')`
- * in src/engine/local-loader.ts.
- *
- * Why this is needed: playwright.gitea.config.ts serves the app with a bare
- * `vite` dev server (no `prebuild` step). That import is resolved by Vite at
- * transform time regardless of mode; the file is gitignored and normally only
- * produced by scripts/generate-manifest.js, so in a fresh CI checkout it is
- * absent and the dev server 500s on import resolution — the app never boots and
- * every gitea spec fails.
- *
- * Why a STUB (not running generate-manifest.js): L3 runs the app in REMOTE mode
- * (the config sets VITE_GH_API_BASE and does NOT set VITE_KB_LOCAL), so the app
- * sources everything from the live Gitea twin and NEVER reads this manifest at
- * runtime. The file only needs to EXIST as valid JSON to satisfy the resolver,
- * so a stub keeps the harness fully offline (no GitHub/`gh` calls).
- *
- * Idempotent: written only when absent, so a real local-mode manifest (e.g. from
- * `prebuild`) is never clobbered. The path is gitignored (src/generated/.gitignore),
- * so it never enters the seed's `git add -A` snapshot — writing it after seed is
- * belt-and-suspenders on top of that.
- */
-function ensureStubManifest(root: string) {
-  const manifestPath = resolve(root, 'src', 'generated', 'repo-manifest.json');
-  if (existsSync(manifestPath)) return;
-  mkdirSync(dirname(manifestPath), { recursive: true });
-  // Minimal RepoManifest — only the required (non-optional) fields of the
-  // interface in src/engine/local-loader.ts. Contents are irrelevant in remote
-  // mode; this exists solely so the static import resolves.
-  const stub = {
-    configRaw: null,
-    authoredContent: {},
-    tree: [],
-    readme: null,
-    issues: [],
-    pullRequests: [],
-    commits: [],
-    generatedAt: '',
-  };
-  writeFileSync(manifestPath, `${JSON.stringify(stub, null, 2)}\n`, 'utf-8');
-  console.log(`[dtu:setup] wrote stub repo-manifest.json → ${manifestPath}`);
 }


### PR DESCRIPTION
## What

Follow-up to #399 (which fixed the L3 app-boot 500). This refines the mechanism per Epic-orchestrator guidance: a **static stub** written **before Vite starts**, with no `gh`/GitHub calls.

#399 wrote the stub from `twins/gitea/global-setup.ts`. Two issues with that:

1. **Racy placement → transient error.** Playwright starts the webServers *concurrently with* (in CI, *before*) `globalSetup`, so Vite pre-transforms `src/engine/local-loader.ts` and logs a transient `Failed to resolve import "../generated/repo-manifest.json"` before the stub lands. Specs still pass (Vite self-heals once the file exists), but the error string remains in the dev-server log (a grep false-positive for anyone scanning the nightly lane).
2. An earlier iteration ran `scripts/generate-manifest.js`, which shells out to **`gh`** on every L3 boot — it degrades to empty without `GH_TOKEN`, but adds a network/CLI failure mode to a lane we want reliably green.

## Fix

- New committed, dependency-free script **`twins/gitea/ensure-manifest-stub.mjs`**: writes a minimal `src/generated/repo-manifest.json` (only the required `RepoManifest` fields, empty), **idempotently** (skips when the file already exists, so a real local-mode manifest from `prebuild` is never clobbered). One log line either way.
- **`playwright.gitea.config.ts`**: the Vite webServer command is now `node twins/gitea/ensure-manifest-stub.mjs && node ./node_modules/vite/bin/vite.js …`. Chaining the stub ahead of `vite` is **race-free** — the file exists before Vite's first transform, so the transient error is gone entirely.
- **Reverts** the now-redundant stub-write from `twins/gitea/global-setup.ts` (back to bootstrap + seed only).

Properties: **offline/deterministic** (static stub, no `gh`); L3 stays **REMOTE mode** (no `VITE_KB_LOCAL`), so the manifest is never read at runtime — it exists solely to satisfy Vite's import-analysis resolver. No `/* @vite-ignore */`. Gitignored, so it never enters the seed's `git add -A` snapshot.

## Verification

- `node --check twins/gitea/ensure-manifest-stub.mjs` clean; script write-path + idempotent path both exercised; `vite.transformRequest('/src/engine/local-loader.ts')` → resolves with the stub present.
- `npm test` → **740 pass**; `npm run lint` → **0 errors** (3 pre-existing warnings).
- CI: `dtu-gitea.yml` dispatched against this branch — confirms seed green, **no** `Failed to resolve import` / `Pre-transform error` in the dev-server log, and e2e/gitea specs run (10 passed / 2 skipped — the 2 skips are the documented remote content-model gap, cf #265).

Refs #394
