### PR TITLE
Rich-Markdown rendering with block-renderer registry (#427)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ template ↔ kbexplorer CLI compatibility matrix and the pinning contract.
   - A **pre-built-SVG fallback contract**: any block that ships an `svg` renders it
     instead of a raw code dump, so a block never degrades to raw code when an SVG
     exists. This replaces the prior raw-code display in the prose diagram walk.
+    The provider-supplied SVG is **untrusted**, so it is rendered as an inert
+    `<img>` from a `data:image/svg+xml` URL (loaded in the browser's secure static
+    mode — no scripts, event handlers, external fetches, or `<foreignObject>` HTML
+    can execute), never parsed into the live DOM.
   - Consumes the provider shape `node.data.richMarkdown.blocks` (kbexplorer-cli#133).
   - A `?demo=richmd` seam injects a sample document so the view is viewable without
     a provider.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,27 @@ template ↔ kbexplorer CLI compatibility matrix and the pinning contract.
 
 ## [Unreleased]
 
-_Nothing yet._
+### Added
+- **Rich-Markdown rendering** (#427): a rich-Markdown document view that composes
+  frontmatter facts (in the structured view), prose, and inline embedded blocks.
+  - An open **block-renderer registry** (`src/views/rich-markdown/`), modeled on the
+    viewer registry, that maps a block `kind` to a renderer. The inline-Mermaid path
+    is reused as the one live renderer; `dot` / `ics` / `canvas` render from a
+    **pre-built SVG**.
+  - A **pre-built-SVG fallback contract**: any block that ships an `svg` renders it
+    instead of a raw code dump, so a block never degrades to raw code when an SVG
+    exists. This replaces the prior raw-code display in the prose diagram walk.
+  - Consumes the provider shape `node.data.richMarkdown.blocks` (kbexplorer-cli#133).
+  - A `?demo=richmd` seam injects a sample document so the view is viewable without
+    a provider.
+
+### Changed
+- Bumped `@anokye-labs/kbexplorer-core` to **`#v0.1.0`**.
+- `ProseContent` now upgrades non-Mermaid fenced blocks to their pre-built SVG when
+  the node carries rich-Markdown blocks; ordinary code fences and the live-Mermaid
+  path are unchanged.
+- `validateSourceContent` accepts the full `NodeSourceFile['format']` union
+  (incl. `'markdown'`) introduced by core v0.1.0.
 
 ## [0.2.0] - 2026-06-16
 

--- a/e2e/rich-markdown.spec.ts
+++ b/e2e/rich-markdown.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Rich-Markdown rendering (Wave 0b — #427).
+ *
+ * The sample document is injected client-side via the `?demo=richmd` seam, so
+ * this runs against the standard preview build + GitHub twin without any
+ * provider dependency. It asserts the acceptance criteria end-to-end in a
+ * single page load (one content fetch — friendlier to the twin's rate limit):
+ *  - frontmatter renders in the structured view;
+ *  - a live Mermaid block renders to SVG;
+ *  - the `dot` and `canvas` blocks render via the pre-built-SVG fallback;
+ *  - no SVG-backed block is left as a raw code dump.
+ */
+const DOC_URL = '/#/node/demo-richmd-doc?demo=richmd';
+
+test('rich-Markdown document renders frontmatter, live Mermaid and SVG-fallback blocks (#427)', async ({
+  page,
+}) => {
+  await page.goto(DOC_URL, { timeout: 60000 });
+
+  // 1. Frontmatter facts in the structured view.
+  const facts = page.getByTestId('richmd-frontmatter');
+  await expect(facts).toBeVisible({ timeout: 20000 });
+  await expect(facts.locator('.kb-structured-view')).toBeVisible();
+  await expect(facts).toContainText('Release Pipeline');
+  await expect(facts).toContainText('Team Atlas');
+
+  // 2. Live Mermaid block → SVG.
+  const mermaid = page.locator('.kb-diagram[data-diagram-language="mermaid"]').first();
+  await expect(mermaid).toBeVisible({ timeout: 20000 });
+  await expect(mermaid.locator('svg')).toBeVisible();
+
+  // 3. dot + canvas blocks render via the pre-built-SVG fallback.
+  for (const kind of ['dot', 'canvas']) {
+    const figure = page.locator(
+      `figure[data-block-renderer="svg-fallback"][data-diagram-language="${kind}"]`,
+    );
+    await expect(figure).toBeVisible({ timeout: 20000 });
+    await expect(figure.locator('svg')).toBeVisible();
+  }
+
+  // 4. No SVG-backed block is left as visible raw code (source tucked into a
+  //    collapsed <details>, replaced by the SVG figure).
+  for (const kind of ['dot', 'canvas', 'ics']) {
+    await expect(page.locator(`code.language-${kind}`)).toBeHidden();
+  }
+});

--- a/e2e/rich-markdown.spec.ts
+++ b/e2e/rich-markdown.spec.ts
@@ -31,13 +31,18 @@ test('rich-Markdown document renders frontmatter, live Mermaid and SVG-fallback 
   await expect(mermaid).toBeVisible({ timeout: 20000 });
   await expect(mermaid.locator('svg')).toBeVisible();
 
-  // 3. dot + canvas blocks render via the pre-built-SVG fallback.
+  // 3. dot + canvas blocks render via the pre-built-SVG fallback — as an inert
+  //    <img> data URL (untrusted SVG is never inlined into the live DOM).
   for (const kind of ['dot', 'canvas']) {
     const figure = page.locator(
       `figure[data-block-renderer="svg-fallback"][data-diagram-language="${kind}"]`,
     );
     await expect(figure).toBeVisible({ timeout: 20000 });
-    await expect(figure.locator('svg')).toBeVisible();
+    const img = figure.locator('img.kb-diagram-svg');
+    await expect(img).toBeVisible();
+    await expect(img).toHaveAttribute('src', /^data:image\/svg\+xml/);
+    // the SVG is loaded as an image, never parsed into the DOM
+    await expect(figure.locator('svg')).toHaveCount(0);
   }
 
   // 4. No SVG-backed block is left as visible raw code (source tucked into a

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "kbexplorer-template",
       "version": "0.2.0",
       "dependencies": {
-        "@anokye-labs/kbexplorer-core": "git+https://github.com/anokye-labs/kbexplorer-core.git#8b78351d57ed9a927d4505ffda542eb97841d580",
+        "@anokye-labs/kbexplorer-core": "github:anokye-labs/kbexplorer-core#v0.1.0",
         "@fluentui/react-components": "^9.74.2",
         "@fluentui/react-icons": "^2.0.323",
         "@octokit/rest": "^22.0.1",
@@ -56,9 +56,8 @@
       }
     },
     "node_modules/@anokye-labs/kbexplorer-core": {
-      "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/anokye-labs/kbexplorer-core.git#8b78351d57ed9a927d4505ffda542eb97841d580",
-      "integrity": "sha512-2CrKw6eHZu4WBASBH+C10aQQmTHsLU8aHw6Ub53Z9PyRc1r7khOI1B+0EvUCJxMsJtH6B+p2dNnPq+p7PjeO3g==",
+      "version": "0.1.0",
+      "resolved": "git+ssh://git@github.com/anokye-labs/kbexplorer-core.git#2ce200b95287fe1780befbc5180743928008b2c1",
       "license": "MIT",
       "engines": {
         "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "explore:dtu": "node scripts/explore-dtu.mjs"
   },
   "dependencies": {
-    "@anokye-labs/kbexplorer-core": "git+https://github.com/anokye-labs/kbexplorer-core.git#8b78351d57ed9a927d4505ffda542eb97841d580",
+    "@anokye-labs/kbexplorer-core": "github:anokye-labs/kbexplorer-core#v0.1.0",
     "@fluentui/react-components": "^9.74.2",
     "@fluentui/react-icons": "^2.0.323",
     "@octokit/rest": "^22.0.1",

--- a/src/engine/__tests__/demo-entities.test.ts
+++ b/src/engine/__tests__/demo-entities.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { isDemoEntitiesEnabled, injectDemoEntities } from '../demo-entities';
+import { isDemoEntitiesEnabled, injectDemoEntities, isRichMarkdownDemoEnabled, injectRichMarkdownDemo } from '../demo-entities';
 import { resetNodeTypeRegistry } from '../node-types';
 import { getEdgeStyle } from '../../types';
+import { getRichMarkdownDocument } from '../../views/rich-markdown/types';
 import type { KBGraph, KBNode } from '../../types';
 
 function makeNode(id: string, overrides: Partial<KBNode> = {}): KBNode {
@@ -109,6 +110,48 @@ describe('demo-entities seam', () => {
     const once = injectDemoEntities(baseGraph());
     const twice = injectDemoEntities(once);
     expect(twice.nodes.filter(n => n.id === 'demo-person-ben')).toHaveLength(1);
+    expect(twice.nodes).toHaveLength(once.nodes.length);
+  });
+});
+
+describe('rich-Markdown demo seam (#427)', () => {
+  it('is disabled by default (no window in node env)', () => {
+    expect(isRichMarkdownDemoEnabled()).toBe(false);
+  });
+
+  it('appends the sample rich-Markdown doc, anchored to the hub, without mutating the original', () => {
+    const graph = baseGraph();
+    const before = graph.nodes.length;
+    const result = injectRichMarkdownDemo(graph);
+
+    expect(graph.nodes).toHaveLength(before); // original untouched
+    expect(result.nodes).toHaveLength(before + 1);
+
+    const doc = result.nodes.find(n => n.id === 'demo-richmd-doc')!;
+    expect(doc.display).toBe('rich-markdown');
+    expect(result.edges.some(e => e.from === 'readme' && e.to === 'demo-richmd-doc')).toBe(true);
+    expect(result.clusters.filter(c => c.id === 'docs')).toHaveLength(1);
+  });
+
+  it('carries a valid rich-Markdown payload (mermaid + dot/ics/canvas blocks)', () => {
+    const result = injectRichMarkdownDemo(baseGraph());
+    const node = result.nodes.find(n => n.id === 'demo-richmd-doc')!;
+    const richMarkdown = getRichMarkdownDocument(node);
+    expect(richMarkdown).not.toBeNull();
+    expect(richMarkdown!.blocks.map(b => b.kind)).toEqual(['mermaid', 'dot', 'ics', 'canvas']);
+    // every non-mermaid block ships a pre-built SVG (so none degrades to raw code)
+    for (const b of richMarkdown!.blocks.filter(b => b.kind !== 'mermaid')) {
+      expect(typeof b.svg).toBe('string');
+    }
+    // content is rendered HTML carrying the fenced blocks the prose walk upgrades
+    expect(node.content).toContain('language-dot');
+    expect(node.content).toContain('language-canvas');
+  });
+
+  it('is idempotent (no duplicate demo doc)', () => {
+    const once = injectRichMarkdownDemo(baseGraph());
+    const twice = injectRichMarkdownDemo(once);
+    expect(twice.nodes.filter(n => n.id === 'demo-richmd-doc')).toHaveLength(1);
     expect(twice.nodes).toHaveLength(once.nodes.length);
   });
 });

--- a/src/engine/demo-entities.ts
+++ b/src/engine/demo-entities.ts
@@ -15,6 +15,7 @@ import { registerType } from './node-types';
 import { registerViewer } from '../views/viewers';
 import { PersonView } from '../views/viewers/PersonView';
 import { SquadView } from '../views/viewers/SquadView';
+import { buildSampleRichMarkdownNode } from '../views/rich-markdown/sample-document';
 
 const DEMO_CLUSTER: Cluster = { id: 'org', name: 'Organization', color: '#c0a3ff' };
 
@@ -215,6 +216,68 @@ function entityNode(
 
 function relationEdge(from: string, to: string, relation: string, description: string): KBEdge {
   return { from, to, type: 'related', relation, description, source: 'inferred', weight: 1 };
+}
+
+/** Cluster the rich-Markdown demo doc lands in. */
+const DOCS_DEMO_CLUSTER: Cluster = { id: 'docs', name: 'Documentation', color: '#D4A050' };
+
+/**
+ * Whether the rich-Markdown demo seam is enabled for this session.
+ *
+ * Query-param only (`?demo=richmd`, including the hash query) — deliberately NOT
+ * backed by localStorage, so it leaves no trace in the persisted `kbe-*`
+ * settings contract (and needs no CACHE_VERSION bump).
+ */
+export function isRichMarkdownDemoEnabled(): boolean {
+  try {
+    if (typeof window !== 'undefined') {
+      const params = new URLSearchParams(window.location.search);
+      if (params.get('demo') === 'richmd') return true;
+      const hash = window.location.hash;
+      const qIndex = hash.indexOf('?');
+      if (qIndex >= 0) {
+        const hp = new URLSearchParams(hash.slice(qIndex + 1));
+        if (hp.get('demo') === 'richmd') return true;
+      }
+    }
+  } catch {
+    /* access to window may be denied; treat as disabled */
+  }
+  return false;
+}
+
+/**
+ * Return a new graph with the sample rich-Markdown document appended (off by
+ * default). Idempotent: skips injection if the demo doc is already present. The
+ * doc is anchored to an existing hub so it is reachable in the graph.
+ */
+export function injectRichMarkdownDemo(graph: KBGraph): KBGraph {
+  const DEMO_ID = 'demo-richmd-doc';
+  if (graph.nodes.some(n => n.id === DEMO_ID)) return graph;
+
+  const node = buildSampleRichMarkdownNode(DEMO_ID);
+
+  const hub =
+    graph.nodes.find(n => n.id === 'readme') ??
+    graph.nodes.find(n => n.id === 'home') ??
+    graph.nodes.find(n => n.id === 'overview') ??
+    graph.nodes[0];
+
+  const newEdges: KBEdge[] = [];
+  if (hub) {
+    newEdges.push(relationEdge(hub.id, DEMO_ID, 'structural', `${hub.title} → ${node.title}`));
+  }
+
+  const clusters = graph.clusters.some(c => c.id === DOCS_DEMO_CLUSTER.id)
+    ? graph.clusters
+    : [...graph.clusters, DOCS_DEMO_CLUSTER];
+
+  return {
+    nodes: [...graph.nodes, node],
+    edges: [...graph.edges, ...newEdges],
+    clusters,
+    related: graph.related,
+  };
 }
 
 /**

--- a/src/engine/source-edit.ts
+++ b/src/engine/source-edit.ts
@@ -75,19 +75,26 @@ export function normalizeNewlines(text: string): string {
 /**
  * Validate that edited content parses as its declared format **before** any
  * handoff, so a user never opens a PR carrying invalid YAML/JSON. Empty content
- * is rejected (an entity file must contain a document).
+ * is rejected (an entity file must contain a document). `markdown` is accepted
+ * as always-valid (there is nothing to parse) — `canEditSource` currently only
+ * surfaces the editor for `yaml`/`json`, but accepting the full
+ * `NodeSourceFile['format']` union keeps this forward-compatible and total.
  */
-export function validateSourceContent(raw: string, format: 'yaml' | 'json'): ValidationResult {
+export function validateSourceContent(
+  raw: string,
+  format: NodeSourceFile['format'],
+): ValidationResult {
   if (raw.trim().length === 0) {
     return { ok: false, error: 'Source file is empty.' };
   }
   try {
     if (format === 'json') {
       JSON.parse(raw);
-    } else {
+    } else if (format === 'yaml') {
       // `yaml.parse` throws on malformed YAML; a valid scalar/null is allowed.
       yaml.parse(raw);
     }
+    // `markdown` (and any future text format): non-empty content is valid.
     return { ok: true };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/src/hooks/useKnowledgeBase.ts
+++ b/src/hooks/useKnowledgeBase.ts
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import type { KBGraph, KBConfig, SourceConfig } from '../types';
 import { detectLocalMode, loadLocalKnowledgeBase } from '../engine/local-loader';
 import { loadRemoteKnowledgeBase } from '../engine/remote-loader';
-import { isDemoEntitiesEnabled, injectDemoEntities, isBigOrgDemoEnabled, injectBigOrg } from '../engine/demo-entities';
+import { isDemoEntitiesEnabled, injectDemoEntities, isBigOrgDemoEnabled, injectBigOrg, isRichMarkdownDemoEnabled, injectRichMarkdownDemo } from '../engine/demo-entities';
 
 export type LoadingState =
   | { status: 'loading' }
@@ -75,13 +75,15 @@ export function useKnowledgeBase(sourceOverride?: SourceConfig): LoadingState {
 
 /**
  * Apply optional demo seams (off by default) to the loaded graph: small
- * entity demo (`?demo=entities`) and the large synthetic org tree
- * (`?demo=bigorg`, for exercising the reports-to layout at scale — #279).
+ * entity demo (`?demo=entities`), the large synthetic org tree
+ * (`?demo=bigorg`, for exercising the reports-to layout at scale — #279), and
+ * the rich-Markdown sample document (`?demo=richmd` — #427).
  */
 function applyDemoSeams(graph: KBGraph): KBGraph {
   let g = graph;
   if (isDemoEntitiesEnabled()) g = injectDemoEntities(g);
   if (isBigOrgDemoEnabled()) g = injectBigOrg(g);
+  if (isRichMarkdownDemoEnabled()) g = injectRichMarkdownDemo(g);
   return g;
 }
 

--- a/src/views/ReadingView.tsx
+++ b/src/views/ReadingView.tsx
@@ -31,6 +31,13 @@ import {
   getDiagramRenderPlan,
   isDiagramCodeLanguage,
 } from './diagram';
+import {
+  getRichMarkdownDocument,
+  planProseFence,
+  findBlockForFence,
+  RichMarkdownDocumentView,
+  type RichMarkdownBlock,
+} from './rich-markdown';
 
 interface ReadingViewProps {
   graph: KBGraph;
@@ -336,14 +343,77 @@ function wrapRenderedProseDiagram(pre: HTMLPreElement, svgElement: SVGSVGElement
   details.append(pre);
 }
 
+/**
+ * Parse a pre-built SVG string (the block fallback contract) into an importable
+ * SVG element. Mirrors {@link parseMermaidSvg} but additionally **strips any
+ * `<script>` elements** — provider SVG shares the content trust boundary, so we
+ * defensively remove active content before inserting it into the live document.
+ */
+function parsePrebuiltSvg(svg: string): SVGSVGElement {
+  const element = parseMermaidSvg(normalizeMermaidSvgForXml(svg));
+  for (const script of Array.from(element.querySelectorAll('script'))) {
+    script.remove();
+  }
+  return element;
+}
+
+/**
+ * Insert a pre-built-SVG block in place of its raw `<pre>` fence — the fallback
+ * that replaces the raw-code display for blocks with no live renderer. The raw
+ * source stays available, collapsed, in a `<details>` (matching the Mermaid UX),
+ * so "no block falls back to raw code when an SVG exists" while the source is
+ * never lost.
+ */
+function wrapPrebuiltSvgBlock(
+  pre: HTMLPreElement,
+  svgElement: SVGSVGElement,
+  opts: { kind: string; title?: string },
+) {
+  const figure = document.createElement('figure');
+  figure.className = 'kb-diagram kb-diagram--prose kb-richmd-block';
+  figure.dataset.diagramLanguage = opts.kind;
+  figure.dataset.blockRenderer = 'svg-fallback';
+
+  const canvas = document.createElement('div');
+  canvas.className = 'kb-diagram-canvas';
+  canvas.replaceChildren(svgElement);
+  figure.append(canvas);
+
+  if (opts.title) {
+    const caption = document.createElement('figcaption');
+    caption.className = 'kb-diagram-caption';
+    caption.textContent = opts.title;
+    figure.append(caption);
+  }
+
+  const details = document.createElement('details');
+  details.className = 'kb-diagram-source';
+  const summary = document.createElement('summary');
+  summary.textContent = 'Block source';
+  details.append(summary);
+
+  pre.before(figure);
+  figure.after(details);
+  details.append(pre);
+}
+
+/**
+ * Renders prose HTML and upgrades embedded fenced blocks in place. Mermaid keeps
+ * its existing live render; when the node carries rich-Markdown `blocks`, a
+ * non-Mermaid fence that matches a provider block renders via the block registry
+ * — a pre-built SVG when one exists (replacing the raw-code display), else a
+ * graceful warning over the retained source. Ordinary code fences are untouched.
+ */
 function ProseContent({
   html,
   isDark,
   style,
+  blocks,
 }: {
   html: string;
   isDark: boolean;
   style?: CSSProperties;
+  blocks?: readonly RichMarkdownBlock[];
 }) {
   const rootRef = useRef<HTMLDivElement>(null);
 
@@ -359,20 +429,43 @@ function ProseContent({
     void (async () => {
       for (const code of codeBlocks) {
         if (cancelled) return;
-        const language = diagramLanguageFromClassName(code.className);
-        if (!isDiagramCodeLanguage(language)) continue;
 
         const pre = code.parentElement;
         if (!(pre instanceof HTMLPreElement)) continue;
 
-        const plan = getDiagramRenderPlan(code.textContent ?? '', language);
-        if (plan.kind !== 'mermaid') {
-          pre.before(createDiagramMessage(plan.reason, 'warning'));
+        const language = diagramLanguageFromClassName(code.className);
+        const source = code.textContent ?? '';
+
+        // A fence is "in scope" when it matches a rich-Markdown block (any kind)
+        // or is a diagram-language fence. Ordinary code fences are left as-is.
+        const matchedBlock = blocks ? findBlockForFence(source, blocks, { language }) : undefined;
+        if (!matchedBlock && !isDiagramCodeLanguage(language)) continue;
+
+        const output = planProseFence(language, source, blocks, { isDark });
+
+        if (output.type === 'svg') {
+          try {
+            const svgElement = parsePrebuiltSvg(output.svg);
+            if (cancelled) return;
+            wrapPrebuiltSvgBlock(pre, svgElement, {
+              kind: matchedBlock?.kind ?? language ?? 'block',
+              title: output.title,
+            });
+          } catch (err) {
+            if (cancelled) return;
+            pre.before(createDiagramMessage(`Block render failed: ${diagramErrorMessage(err)}`, 'error'));
+          }
           continue;
         }
 
+        if (output.type === 'unsupported') {
+          pre.before(createDiagramMessage(output.reason, 'warning'));
+          continue;
+        }
+
+        // output.type === 'mermaid' — live render (the existing inline path).
         try {
-          const { svg, bindFunctions } = await renderMermaid(plan.source, isDark);
+          const { svg, bindFunctions } = await renderMermaid(output.source, isDark);
           const svgElement = parseMermaidSvg(svg);
           if (cancelled) return;
           wrapRenderedProseDiagram(pre, svgElement, bindFunctions);
@@ -386,7 +479,7 @@ function ProseContent({
     return () => {
       cancelled = true;
     };
-  }, [html, isDark]);
+  }, [html, isDark, blocks]);
 
   return (
     <div
@@ -531,6 +624,14 @@ function renderContent(node: KBNode, linkedHtml: string, isDark: boolean, graph?
       return <TableView content={node.rawContent} />;
     case 'diagram':
       return <DiagramView content={node.rawContent} isDark={isDark} />;
+    case 'rich-markdown': {
+      const doc = getRichMarkdownDocument(node);
+      return (
+        <RichMarkdownDocumentView frontmatter={doc?.frontmatter}>
+          <ProseContent html={linkedHtml} isDark={isDark} blocks={doc?.blocks} />
+        </RichMarkdownDocumentView>
+      );
+    }
     case 'homepage':
       return (
         <div>

--- a/src/views/ReadingView.tsx
+++ b/src/views/ReadingView.tsx
@@ -35,6 +35,7 @@ import {
   getRichMarkdownDocument,
   planProseFence,
   findBlockForFence,
+  svgToImageDataUri,
   RichMarkdownDocumentView,
   type RichMarkdownBlock,
 } from './rich-markdown';
@@ -344,29 +345,19 @@ function wrapRenderedProseDiagram(pre: HTMLPreElement, svgElement: SVGSVGElement
 }
 
 /**
- * Parse a pre-built SVG string (the block fallback contract) into an importable
- * SVG element. Mirrors {@link parseMermaidSvg} but additionally **strips any
- * `<script>` elements** — provider SVG shares the content trust boundary, so we
- * defensively remove active content before inserting it into the live document.
- */
-function parsePrebuiltSvg(svg: string): SVGSVGElement {
-  const element = parseMermaidSvg(normalizeMermaidSvgForXml(svg));
-  for (const script of Array.from(element.querySelectorAll('script'))) {
-    script.remove();
-  }
-  return element;
-}
-
-/**
  * Insert a pre-built-SVG block in place of its raw `<pre>` fence — the fallback
- * that replaces the raw-code display for blocks with no live renderer. The raw
- * source stays available, collapsed, in a `<details>` (matching the Mermaid UX),
- * so "no block falls back to raw code when an SVG exists" while the source is
- * never lost.
+ * that replaces the raw-code display for blocks with no live renderer.
+ *
+ * The provider-supplied `svg` is **untrusted**, so it is rendered as an inert
+ * `<img>` from a `data:image/svg+xml` URL (see {@link svgToImageDataUri}): the
+ * browser loads it in secure static mode, so no script, event handler, external
+ * reference, or `<foreignObject>` HTML can ever execute. It is never parsed into
+ * the live DOM. The raw source stays available, collapsed, in a `<details>`
+ * (matching the Mermaid UX), so the source is never lost.
  */
 function wrapPrebuiltSvgBlock(
   pre: HTMLPreElement,
-  svgElement: SVGSVGElement,
+  svg: string,
   opts: { kind: string; title?: string },
 ) {
   const figure = document.createElement('figure');
@@ -376,7 +367,13 @@ function wrapPrebuiltSvgBlock(
 
   const canvas = document.createElement('div');
   canvas.className = 'kb-diagram-canvas';
-  canvas.replaceChildren(svgElement);
+  const img = document.createElement('img');
+  img.className = 'kb-diagram-svg';
+  img.src = svgToImageDataUri(svg);
+  img.alt = opts.title ?? `${opts.kind} diagram`;
+  img.loading = 'lazy';
+  img.decoding = 'async';
+  canvas.append(img);
   figure.append(canvas);
 
   if (opts.title) {
@@ -444,17 +441,12 @@ function ProseContent({
         const output = planProseFence(language, source, blocks, { isDark });
 
         if (output.type === 'svg') {
-          try {
-            const svgElement = parsePrebuiltSvg(output.svg);
-            if (cancelled) return;
-            wrapPrebuiltSvgBlock(pre, svgElement, {
-              kind: matchedBlock?.kind ?? language ?? 'block',
-              title: output.title,
-            });
-          } catch (err) {
-            if (cancelled) return;
-            pre.before(createDiagramMessage(`Block render failed: ${diagramErrorMessage(err)}`, 'error'));
-          }
+          // Untrusted provider SVG → rendered as an inert <img> data URL, never
+          // parsed into the live DOM (see wrapPrebuiltSvgBlock / svgToImageDataUri).
+          wrapPrebuiltSvgBlock(pre, output.svg, {
+            kind: matchedBlock?.kind ?? language ?? 'block',
+            title: output.title,
+          });
           continue;
         }
 

--- a/src/views/rich-markdown/FrontmatterFacts.tsx
+++ b/src/views/rich-markdown/FrontmatterFacts.tsx
@@ -1,0 +1,37 @@
+import type { KBNode } from '../../types';
+import { GenericStructuredView } from '../viewers/GenericStructuredView';
+
+/**
+ * Frontmatter facts (Wave 0b — #427).
+ *
+ * Renders a rich-Markdown document's frontmatter as a **structured view** —
+ * reusing {@link GenericStructuredView}, the same key/value + nested-table
+ * renderer used for typed entity nodes — so frontmatter facts read consistently
+ * with the rest of the app. Renders nothing when there are no facts.
+ */
+export function FrontmatterFacts({
+  frontmatter,
+}: {
+  frontmatter?: Record<string, unknown>;
+}) {
+  if (!frontmatter || Object.keys(frontmatter).length === 0) return null;
+
+  // Synthesize a minimal node carrying only the frontmatter in its `data` bag,
+  // so GenericStructuredView renders exactly those facts (no JSON-LD header).
+  const factsNode: KBNode = {
+    id: 'frontmatter',
+    title: 'Frontmatter',
+    cluster: '',
+    content: '',
+    rawContent: '',
+    connections: [],
+    source: { type: 'derived', generator: 'rich-markdown' },
+    data: frontmatter,
+  };
+
+  return (
+    <section className="kb-richmd-frontmatter" data-testid="richmd-frontmatter">
+      <GenericStructuredView node={factsNode} />
+    </section>
+  );
+}

--- a/src/views/rich-markdown/RichMarkdownDocumentView.tsx
+++ b/src/views/rich-markdown/RichMarkdownDocumentView.tsx
@@ -1,0 +1,30 @@
+import type { ReactNode } from 'react';
+import { FrontmatterFacts } from './FrontmatterFacts';
+
+/**
+ * Rich-Markdown document view (Wave 0b — #427).
+ *
+ * Composes a rich-Markdown document from its three parts:
+ *  1. **frontmatter facts** — rendered in the structured view ({@link FrontmatterFacts});
+ *  2. **prose** — the document body, passed as children;
+ *  3. **embedded blocks** — rendered *inline within* the prose by the generalized
+ *     `ProseContent` (live Mermaid, pre-built-SVG fallback, or raw-code last resort).
+ *
+ * The prose is injected as children rather than imported so this view stays
+ * decoupled from `ReadingView` (which owns the inline-Mermaid/SVG prose walk) —
+ * no circular import, and the composition is trivially testable with a stub.
+ */
+export function RichMarkdownDocumentView({
+  frontmatter,
+  children,
+}: {
+  frontmatter?: Record<string, unknown>;
+  children: ReactNode;
+}) {
+  return (
+    <article className="kb-richmd" data-testid="richmd-document">
+      <FrontmatterFacts frontmatter={frontmatter} />
+      <div className="kb-richmd-body">{children}</div>
+    </article>
+  );
+}

--- a/src/views/rich-markdown/__tests__/document.test.ts
+++ b/src/views/rich-markdown/__tests__/document.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import type { KBNode } from '../../../types';
+import {
+  getRichMarkdownDocument,
+  isRichMarkdownNode,
+  hashBlockSource,
+  normalizeBlockSource,
+} from '../types';
+import { FrontmatterFacts } from '../FrontmatterFacts';
+import { RichMarkdownDocumentView } from '../RichMarkdownDocumentView';
+import { SAMPLE_FRONTMATTER, buildSampleRichMarkdownNode } from '../sample-document';
+
+function node(data?: Record<string, unknown>): KBNode {
+  return {
+    id: 'n',
+    title: 'n',
+    cluster: 'c',
+    content: '',
+    rawContent: '',
+    connections: [],
+    source: { type: 'derived', generator: 't' },
+    data,
+  };
+}
+
+describe('getRichMarkdownDocument (#427)', () => {
+  it('returns null for nodes without a rich-Markdown payload', () => {
+    expect(getRichMarkdownDocument(node())).toBeNull();
+    expect(getRichMarkdownDocument(node({ other: 1 }))).toBeNull();
+    expect(isRichMarkdownNode(node())).toBe(false);
+  });
+
+  it('reads frontmatter + blocks and skips malformed blocks', () => {
+    const doc = getRichMarkdownDocument(
+      node({
+        richMarkdown: {
+          frontmatter: { title: 'Doc' },
+          blocks: [
+            { kind: 'dot', source: 'digraph{}', svg: '<svg/>', hash: 'h', range: { start: 1, end: 9 } },
+            { kind: 'mermaid' }, // missing source → skipped
+            { source: 'x' }, // missing kind → skipped
+            'not-an-object', // skipped
+          ],
+        },
+      }),
+    );
+    expect(doc).not.toBeNull();
+    expect(doc!.frontmatter).toEqual({ title: 'Doc' });
+    expect(doc!.blocks).toHaveLength(1);
+    expect(doc!.blocks[0]).toMatchObject({ kind: 'dot', svg: '<svg/>', range: { start: 1, end: 9 } });
+  });
+
+  it('reads the sample node (4 blocks + frontmatter)', () => {
+    const doc = getRichMarkdownDocument(buildSampleRichMarkdownNode());
+    expect(doc).not.toBeNull();
+    expect(doc!.blocks.map((b) => b.kind)).toEqual(['mermaid', 'dot', 'ics', 'canvas']);
+    expect(doc!.frontmatter).toMatchObject({ title: 'Release Pipeline' });
+  });
+});
+
+describe('block source hashing (#427)', () => {
+  it('normalizes whitespace before hashing (stable identity)', () => {
+    expect(normalizeBlockSource('a  \r\nb  ')).toBe('a\nb');
+    expect(hashBlockSource('digraph{}')).toBe(hashBlockSource('digraph{}\n  '));
+    expect(hashBlockSource('a')).not.toBe(hashBlockSource('b'));
+    expect(hashBlockSource('x')).toMatch(/^fnv1a:[0-9a-f]{8}$/);
+  });
+});
+
+describe('FrontmatterFacts renders in the structured view (#427)', () => {
+  it('renders the frontmatter facts', () => {
+    const html = renderToStaticMarkup(createElement(FrontmatterFacts, { frontmatter: SAMPLE_FRONTMATTER }));
+    expect(html).toContain('kb-structured-view');
+    expect(html).toContain('Release Pipeline');
+    expect(html).toContain('Owner');
+    expect(html).toContain('Team Atlas');
+    expect(html).toContain('Tags');
+    expect(html).toContain('release');
+  });
+
+  it('renders nothing when there are no facts', () => {
+    expect(renderToStaticMarkup(createElement(FrontmatterFacts, {}))).toBe('');
+    expect(renderToStaticMarkup(createElement(FrontmatterFacts, { frontmatter: {} }))).toBe('');
+  });
+});
+
+describe('RichMarkdownDocumentView composes facts + prose (#427)', () => {
+  it('renders frontmatter facts and the prose body', () => {
+    const html = renderToStaticMarkup(
+      createElement(RichMarkdownDocumentView, {
+        frontmatter: SAMPLE_FRONTMATTER,
+        children: createElement('div', { className: 'kb-prose' }, 'PROSE-BODY'),
+      }),
+    );
+    expect(html).toContain('richmd-document');
+    expect(html).toContain('kb-richmd-body');
+    expect(html).toContain('PROSE-BODY');
+    // facts composed in
+    expect(html).toContain('Release Pipeline');
+    expect(html).toContain('richmd-frontmatter');
+  });
+});

--- a/src/views/rich-markdown/__tests__/plan.test.ts
+++ b/src/views/rich-markdown/__tests__/plan.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { planProseFence, findBlockForFence } from '../plan';
+import { hashBlockSource } from '../types';
+import type { RichMarkdownBlock } from '../types';
+import { buildSampleBlocks } from '../sample-document';
+
+const dotBlock: RichMarkdownBlock = {
+  kind: 'dot',
+  source: 'digraph G {\n  a -> b;\n}',
+  svg: '<svg id="dot"/>',
+  hash: hashBlockSource('digraph G {\n  a -> b;\n}'),
+};
+
+describe('findBlockForFence (#427)', () => {
+  it('matches by normalized source (whitespace-insensitive)', () => {
+    const found = findBlockForFence('digraph G {\n  a -> b;  \n}\n', [dotBlock]);
+    expect(found).toBe(dotBlock);
+  });
+
+  it('matches by hash when provided', () => {
+    const found = findBlockForFence('totally different text', [dotBlock], { hash: dotBlock.hash });
+    expect(found).toBe(dotBlock);
+  });
+
+  it('returns undefined when nothing matches and for empty block lists', () => {
+    expect(findBlockForFence('no match', [dotBlock])).toBeUndefined();
+    expect(findBlockForFence('x', [])).toBeUndefined();
+    expect(findBlockForFence('x', undefined)).toBeUndefined();
+  });
+});
+
+describe('planProseFence (#427)', () => {
+  it('keeps the live Mermaid path for explicit and inferred Mermaid fences', () => {
+    expect(planProseFence('mermaid', 'flowchart TD\nA-->B').type).toBe('mermaid');
+    // inferred — no language, but the source is recognisably Mermaid
+    expect(planProseFence(undefined, 'sequenceDiagram\n A->>B: hi').type).toBe('mermaid');
+  });
+
+  it('renders a matched non-Mermaid block via its pre-built SVG (not raw code)', () => {
+    const out = planProseFence('dot', dotBlock.source, [dotBlock]);
+    expect(out).toMatchObject({ type: 'svg', svg: '<svg id="dot"/>' });
+  });
+
+  it('falls back to unsupported only when there is no matching block and no live renderer', () => {
+    const out = planProseFence('plantuml', '@startuml\nA->B\n@enduml');
+    expect(out.type).toBe('unsupported');
+  });
+});
+
+describe('acceptance — sample document blocks (#427)', () => {
+  const blocks = buildSampleBlocks();
+
+  it('renders the Mermaid block live and every SVG-backed block via SVG fallback', () => {
+    const byKind = Object.fromEntries(
+      blocks.map((b) => [b.kind, planProseFence(b.kind, b.source, blocks)]),
+    );
+    expect(byKind.mermaid.type).toBe('mermaid');
+    expect(byKind.dot.type).toBe('svg');
+    expect(byKind.ics.type).toBe('svg');
+    expect(byKind.canvas.type).toBe('svg');
+  });
+
+  it('NO block falls back to raw code when an SVG exists', () => {
+    for (const b of blocks) {
+      const out = planProseFence(b.kind, b.source, blocks);
+      if (b.svg) {
+        expect(out.type).toBe('svg');
+      }
+      // Whether live (mermaid) or svg-backed, no sample block is ever raw code.
+      expect(out.type).not.toBe('unsupported');
+    }
+  });
+});

--- a/src/views/rich-markdown/__tests__/registry.test.ts
+++ b/src/views/rich-markdown/__tests__/registry.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  registerBlockRenderer,
+  hasBlockRenderer,
+  getBlockRenderer,
+  getRegisteredBlockKinds,
+  resetBlockRendererRegistry,
+  resolveBlockOutput,
+  svgFallbackOutput,
+} from '../registry';
+import {
+  registerBuiltinBlockRenderers,
+  ensureBuiltinBlockRenderers,
+  mermaidBlockRenderer,
+} from '../renderers';
+import type { RichMarkdownBlock } from '../types';
+
+function block(overrides: Partial<RichMarkdownBlock> & Pick<RichMarkdownBlock, 'kind'>): RichMarkdownBlock {
+  return { source: 'SRC', ...overrides };
+}
+
+afterEach(() => {
+  resetBlockRendererRegistry();
+});
+
+describe('block-renderer registry (#427)', () => {
+  it('registers, resolves, lists and resets renderers', () => {
+    expect(hasBlockRenderer('dot')).toBe(false);
+    const r = mermaidBlockRenderer;
+    registerBlockRenderer('dot', r);
+    expect(hasBlockRenderer('dot')).toBe(true);
+    expect(getBlockRenderer('dot')).toBe(r);
+    expect(getRegisteredBlockKinds()).toContain('dot');
+    resetBlockRendererRegistry();
+    expect(getRegisteredBlockKinds()).toHaveLength(0);
+  });
+
+  it('rejects empty / whitespace-only keys', () => {
+    registerBlockRenderer('   ', mermaidBlockRenderer);
+    registerBlockRenderer('', mermaidBlockRenderer);
+    expect(getRegisteredBlockKinds()).toHaveLength(0);
+  });
+
+  it('matches keys case-insensitively and last registration wins', () => {
+    const a = mermaidBlockRenderer;
+    const b = mermaidBlockRenderer.bind(null);
+    registerBlockRenderer('Canvas', a);
+    expect(getBlockRenderer('CANVAS')).toBe(a);
+    registerBlockRenderer('canvas', b);
+    expect(getBlockRenderer('canvas')).toBe(b);
+  });
+});
+
+describe('resolveBlockOutput precedence (#427)', () => {
+  it('uses a registered renderer when present', () => {
+    registerBlockRenderer('mermaid', mermaidBlockRenderer);
+    expect(resolveBlockOutput(block({ kind: 'mermaid', source: 'flowchart TD\nA-->B' }))).toEqual({
+      type: 'mermaid',
+      source: 'flowchart TD\nA-->B',
+      title: undefined,
+    });
+  });
+
+  it('falls back to the pre-built SVG for an unregistered kind (universal fallback)', () => {
+    const out = resolveBlockOutput(block({ kind: 'totally-unknown', svg: '<svg/>' }));
+    expect(out).toEqual({ type: 'svg', svg: '<svg/>', title: undefined });
+  });
+
+  it('reports unsupported only when there is neither a renderer nor an SVG', () => {
+    const out = resolveBlockOutput(block({ kind: 'totally-unknown' }));
+    expect(out.type).toBe('unsupported');
+  });
+
+  it('SVG always wins over a registered renderer that reports unsupported', () => {
+    // A renderer that perversely returns unsupported even though an SVG exists.
+    registerBlockRenderer('weird', () => ({
+      type: 'unsupported',
+      kind: 'weird',
+      source: 'SRC',
+      reason: 'nope',
+    }));
+    const out = resolveBlockOutput(block({ kind: 'weird', svg: '<svg id="x"/>' }));
+    expect(out).toEqual({ type: 'svg', svg: '<svg id="x"/>', title: undefined });
+  });
+
+  it('svgFallbackOutput ignores blank SVG strings', () => {
+    expect(svgFallbackOutput(block({ kind: 'k', svg: '   ' })).type).toBe('unsupported');
+  });
+});
+
+describe('built-in renderers (#427)', () => {
+  it('registers mermaid + dot/graphviz + ics + canvas', () => {
+    registerBuiltinBlockRenderers();
+    for (const kind of ['mermaid', 'dot', 'graphviz', 'ics', 'ical', 'icalendar', 'canvas']) {
+      expect(hasBlockRenderer(kind)).toBe(true);
+    }
+  });
+
+  it('renders mermaid live, dot/ics/canvas from a pre-built SVG', () => {
+    registerBuiltinBlockRenderers();
+    expect(resolveBlockOutput(block({ kind: 'mermaid', source: 'graph TD' })).type).toBe('mermaid');
+    expect(resolveBlockOutput(block({ kind: 'dot', svg: '<svg id="dot"/>' }))).toMatchObject({ type: 'svg', svg: '<svg id="dot"/>' });
+    expect(resolveBlockOutput(block({ kind: 'ics', svg: '<svg id="ics"/>' }))).toMatchObject({ type: 'svg' });
+    expect(resolveBlockOutput(block({ kind: 'canvas', svg: '<svg id="c"/>' }))).toMatchObject({ type: 'svg' });
+  });
+
+  it('a dot block with no pre-built SVG is unsupported with a kind-specific reason', () => {
+    registerBuiltinBlockRenderers();
+    const out = resolveBlockOutput(block({ kind: 'dot' }));
+    expect(out.type).toBe('unsupported');
+    if (out.type !== 'unsupported') throw new Error('expected unsupported');
+    expect(out.reason).toMatch(/Graphviz DOT/);
+  });
+
+  it('ensureBuiltinBlockRenderers re-registers after a reset (idempotent)', () => {
+    ensureBuiltinBlockRenderers();
+    expect(hasBlockRenderer('mermaid')).toBe(true);
+    resetBlockRendererRegistry();
+    expect(hasBlockRenderer('mermaid')).toBe(false);
+    ensureBuiltinBlockRenderers();
+    expect(hasBlockRenderer('mermaid')).toBe(true);
+  });
+});

--- a/src/views/rich-markdown/__tests__/svg.test.ts
+++ b/src/views/rich-markdown/__tests__/svg.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { svgToImageDataUri } from '../svg';
+import { SAMPLE_DOT_SVG } from '../sample-document';
+
+function decode(dataUri: string): string {
+  const match = dataUri.match(/^data:image\/svg\+xml;base64,(.*)$/);
+  if (!match) throw new Error(`not an svg data URI: ${dataUri.slice(0, 40)}…`);
+  return Buffer.from(match[1], 'base64').toString('utf8');
+}
+
+describe('svgToImageDataUri — untrusted SVG is rendered inert (#427 security)', () => {
+  it('encodes SVG as a data:image/svg+xml URL (consumed by an inert <img>)', () => {
+    const uri = svgToImageDataUri(SAMPLE_DOT_SVG);
+    expect(uri.startsWith('data:image/svg+xml;base64,')).toBe(true);
+    expect(decode(uri)).toBe(SAMPLE_DOT_SVG.trim());
+  });
+
+  it('neutralizes hostile active content — encoded as image payload, never live markup', () => {
+    const hostile = [
+      '<svg xmlns="http://www.w3.org/2000/svg" onload="alert(1)">',
+      '  <script>alert(2)</script>',
+      '  <a href="javascript:alert(3)"><text>x</text></a>',
+      '  <foreignObject><iframe src="javascript:alert(4)"></iframe></foreignObject>',
+      '  <image href="http://evil.example/x.svg"/>',
+      '  <use href="http://evil.example/x.svg#y"/>',
+      '  <style>* { background: url(http://evil.example/leak) }</style>',
+      '</svg>',
+    ].join('\n');
+
+    const uri = svgToImageDataUri(hostile);
+
+    // It is a data:image/svg+xml URL — the consumer renders it via <img src>,
+    // where SVG loads in secure static mode (no scripts/handlers, no external
+    // fetches, no interactivity), so the markup is inert regardless of contents.
+    expect(uri.startsWith('data:image/svg+xml;base64,')).toBe(true);
+
+    // None of the active-content vectors appear as live/executable markup in the
+    // URL — they are base64-encoded payload, never injected into the live DOM.
+    for (const token of ['<script', 'onload=', 'javascript:', '<foreignObject', '<iframe', '<use']) {
+      expect(uri).not.toContain(token);
+    }
+
+    // …and the payload round-trips intact (content is preserved, not corrupted).
+    expect(decode(uri)).toContain('<script>alert(2)</script>');
+  });
+
+  it('handles unicode content without throwing', () => {
+    const uri = svgToImageDataUri('<svg><text>café — 数据 — ✅</text></svg>');
+    expect(decode(uri)).toContain('café — 数据 — ✅');
+  });
+});

--- a/src/views/rich-markdown/index.ts
+++ b/src/views/rich-markdown/index.ts
@@ -1,0 +1,51 @@
+/**
+ * Public API for the rich-Markdown rendering feature (Wave 0b — #427).
+ *
+ * Import this barrel to read a node's rich-Markdown payload, plan how a prose
+ * fence renders, or register/resolve block renderers. The block-renderer
+ * registry is the open seam — modeled on the viewer registry — that lets new
+ * block kinds (`mermaid` live, `dot` / `ics` / `canvas` via pre-built SVG) be
+ * added without editing any core type.
+ *
+ * @example
+ * ```ts
+ * import { getRichMarkdownDocument, planProseFence } from './views/rich-markdown';
+ * const doc = getRichMarkdownDocument(node);
+ * const output = planProseFence('dot', fenceSource, doc?.blocks); // → { type: 'svg', … }
+ * ```
+ */
+export {
+  type BlockRange,
+  type RichMarkdownBlock,
+  type RichMarkdownDocument,
+  getRichMarkdownDocument,
+  isRichMarkdownNode,
+  normalizeBlockSource,
+} from './types';
+
+export {
+  type BlockOutput,
+  type BlockRenderContext,
+  type BlockRenderer,
+  registerBlockRenderer,
+  hasBlockRenderer,
+  getBlockRenderer,
+  getRegisteredBlockKinds,
+  resetBlockRendererRegistry,
+  resolveBlockOutput,
+  svgFallbackOutput,
+} from './registry';
+
+export {
+  mermaidBlockRenderer,
+  dotBlockRenderer,
+  icsBlockRenderer,
+  canvasBlockRenderer,
+  registerBuiltinBlockRenderers,
+  ensureBuiltinBlockRenderers,
+} from './renderers';
+
+export { findBlockForFence, planProseFence } from './plan';
+
+export { FrontmatterFacts } from './FrontmatterFacts';
+export { RichMarkdownDocumentView } from './RichMarkdownDocumentView';

--- a/src/views/rich-markdown/index.ts
+++ b/src/views/rich-markdown/index.ts
@@ -46,6 +46,7 @@ export {
 } from './renderers';
 
 export { findBlockForFence, planProseFence } from './plan';
+export { svgToImageDataUri } from './svg';
 
 export { FrontmatterFacts } from './FrontmatterFacts';
 export { RichMarkdownDocumentView } from './RichMarkdownDocumentView';

--- a/src/views/rich-markdown/plan.ts
+++ b/src/views/rich-markdown/plan.ts
@@ -1,0 +1,90 @@
+/**
+ * Prose-fence planning (Wave 0b — #427).
+ *
+ * Bridges a rendered prose code fence (`<pre><code class="language-X">…`) to a
+ * {@link BlockOutput} decision. This is the seam that **replaces the raw-code
+ * display** in `ReadingView`'s inline prose walk: Mermaid keeps its existing live
+ * path, while any other fence that matches a provider block renders through the
+ * block registry (pre-built SVG when available) instead of dumping raw code.
+ *
+ * Pure (no DOM/React) so it stays node-testable; `ReadingView` applies the
+ * decision imperatively to the live prose DOM.
+ */
+import { getDiagramRenderPlan } from '../diagram';
+import type { RichMarkdownBlock } from './types';
+import { normalizeBlockSource } from './types';
+import { ensureBuiltinBlockRenderers } from './renderers';
+import { resolveBlockOutput, type BlockOutput } from './registry';
+
+/**
+ * Match a rendered prose fence to the provider block it came from.
+ *
+ * Matching strategy (most → least specific):
+ * 1. `hash` equality (when both the fence's expected hash and a block hash are known).
+ * 2. Normalized-source equality (whitespace-insensitive; the common path).
+ * 3. Same `kind`/language + normalized-source equality (defensive tie-break).
+ */
+export function findBlockForFence(
+  source: string,
+  blocks: readonly RichMarkdownBlock[] | undefined,
+  options: { language?: string; hash?: string } = {},
+): RichMarkdownBlock | undefined {
+  if (!blocks || blocks.length === 0) return undefined;
+
+  const { language, hash } = options;
+  if (hash) {
+    const byHash = blocks.find((b) => b.hash && b.hash === hash);
+    if (byHash) return byHash;
+  }
+
+  const norm = normalizeBlockSource(source);
+  const bySource = blocks.find((b) => normalizeBlockSource(b.source) === norm);
+  if (bySource) return bySource;
+
+  if (language) {
+    const lang = language.trim().toLowerCase();
+    return blocks.find(
+      (b) => b.kind.trim().toLowerCase() === lang && normalizeBlockSource(b.source) === norm,
+    );
+  }
+  return undefined;
+}
+
+/**
+ * Decide how a prose code fence renders.
+ *
+ * 1. Mermaid (explicit or inferred) keeps its existing **live** path — this is
+ *    what preserves back-compat with the current inline-Mermaid behavior.
+ * 2. Otherwise, if the fence matches a provider block, resolve it through the
+ *    block registry — yielding a pre-built SVG when one exists (the fallback
+ *    that replaces today's raw-code display).
+ * 3. Otherwise, fall back to the raw source (`unsupported`).
+ */
+export function planProseFence(
+  language: string | undefined,
+  source: string,
+  blocks?: readonly RichMarkdownBlock[],
+  options: { hash?: string; isDark?: boolean } = {},
+): BlockOutput {
+  ensureBuiltinBlockRenderers();
+
+  const diagram = getDiagramRenderPlan(source, language);
+  if (diagram.kind === 'mermaid') {
+    return { type: 'mermaid', source: diagram.source };
+  }
+
+  const block = findBlockForFence(source, blocks, { language, hash: options.hash });
+  if (block) {
+    return resolveBlockOutput(block, { isDark: options.isDark });
+  }
+
+  return {
+    type: 'unsupported',
+    kind: language ?? 'unknown',
+    source,
+    reason:
+      diagram.kind === 'unsupported'
+        ? diagram.reason
+        : `No renderer for "${language ?? 'unknown'}" and no matching pre-built block.`,
+  };
+}

--- a/src/views/rich-markdown/registry.ts
+++ b/src/views/rich-markdown/registry.ts
@@ -1,0 +1,119 @@
+/**
+ * Block-renderer registry (Wave 0b — #427).
+ *
+ * Modeled on the viewer registry ({@link ../viewers/registry}): an open seam
+ * that maps a block `kind` to a renderer. This is what lets a `mermaid` block
+ * render live while a `dot` / `ics` / `canvas` block renders from a pre-built
+ * SVG — without editing any core type or render switch. Unknown kinds resolve to
+ * the **universal pre-built-SVG fallback**, so a block with an SVG never falls
+ * back to a raw code dump.
+ *
+ * A renderer returns a pure {@link BlockOutput} **decision** (no DOM/React) so
+ * the registry stays node-testable; the React/DOM layer turns the decision into
+ * an element (live Mermaid SVG, inline pre-built SVG, or a raw-code fallback).
+ */
+import type { RichMarkdownBlock } from './types';
+
+/**
+ * What a block renderer decided to produce.
+ *
+ * - `mermaid` — hand the source to the live Mermaid path (renders to SVG client-side).
+ * - `svg` — inline a pre-built SVG (the fallback contract).
+ * - `unsupported` — no live renderer and no SVG; show the raw source as a last resort.
+ */
+export type BlockOutput =
+  | { type: 'mermaid'; source: string; title?: string }
+  | { type: 'svg'; svg: string; title?: string }
+  | { type: 'unsupported'; kind: string; source: string; reason: string };
+
+/** Context threaded to renderers (e.g. for theme-aware live rendering). */
+export interface BlockRenderContext {
+  /** Active dark/light flag, for renderers that theme their output. */
+  isDark?: boolean;
+}
+
+/** A block renderer maps a block to a {@link BlockOutput} decision. */
+export type BlockRenderer = (
+  block: RichMarkdownBlock,
+  ctx?: BlockRenderContext,
+) => BlockOutput;
+
+const registry = new Map<string, BlockRenderer>();
+
+function normalizeKey(kind: string): string {
+  return kind.trim().toLowerCase();
+}
+
+/** Register a renderer for a block `kind`. Last registration wins (override). */
+export function registerBlockRenderer(kind: string, renderer: BlockRenderer): void {
+  const key = normalizeKey(kind ?? '');
+  if (!key) return; // reject empty / whitespace-only keys
+  registry.set(key, renderer);
+}
+
+/** True if a renderer is registered for the given block `kind`. */
+export function hasBlockRenderer(kind: string | undefined | null): boolean {
+  if (!kind) return false;
+  return registry.has(normalizeKey(kind));
+}
+
+/** Resolve the renderer registered for `kind`, or `undefined`. */
+export function getBlockRenderer(
+  kind: string | undefined | null,
+): BlockRenderer | undefined {
+  if (!kind) return undefined;
+  return registry.get(normalizeKey(kind));
+}
+
+/** List the registered block-kind keys. */
+export function getRegisteredBlockKinds(): string[] {
+  return [...registry.keys()];
+}
+
+/** Remove all registered renderers — primarily for tests. */
+export function resetBlockRendererRegistry(): void {
+  registry.clear();
+}
+
+/**
+ * The universal pre-built-SVG fallback. Used when no renderer claims a kind, and
+ * as a safety net when a registered renderer reports `unsupported` but an SVG is
+ * nonetheless available. This is the contract that **replaces the raw-code
+ * display**: a block with an SVG always renders the SVG.
+ */
+export function svgFallbackOutput(block: RichMarkdownBlock): BlockOutput {
+  if (typeof block.svg === 'string' && block.svg.trim()) {
+    return { type: 'svg', svg: block.svg, title: block.title };
+  }
+  return {
+    type: 'unsupported',
+    kind: block.kind,
+    source: block.source,
+    reason: `No live renderer for "${block.kind}" block and no pre-built SVG was provided.`,
+  };
+}
+
+/**
+ * Resolve a block to its render decision. Precedence:
+ *
+ * 1. A renderer registered for `block.kind`.
+ * 2. The universal pre-built-SVG fallback ({@link svgFallbackOutput}).
+ *
+ * If a registered renderer reports `unsupported` but the block carries an SVG,
+ * the SVG fallback still wins — guaranteeing a block **never** degrades to raw
+ * code when an SVG exists, regardless of how a renderer is implemented.
+ */
+export function resolveBlockOutput(
+  block: RichMarkdownBlock,
+  ctx?: BlockRenderContext,
+): BlockOutput {
+  const renderer = getBlockRenderer(block.kind);
+  if (renderer) {
+    const output = renderer(block, ctx);
+    if (output.type === 'unsupported' && typeof block.svg === 'string' && block.svg.trim()) {
+      return svgFallbackOutput(block);
+    }
+    return output;
+  }
+  return svgFallbackOutput(block);
+}

--- a/src/views/rich-markdown/renderers.ts
+++ b/src/views/rich-markdown/renderers.ts
@@ -1,0 +1,84 @@
+/**
+ * Built-in block renderers (Wave 0b — #427).
+ *
+ * - `mermaid` — the one **live** renderer: it reuses the existing inline-Mermaid
+ *   path (the source is handed back to `ReadingView`'s Mermaid renderer, which
+ *   produces an SVG client-side).
+ * - `dot` / `ics` / `canvas` — kinds with **no live engine yet**: they render
+ *   from the provider's pre-built SVG (the fallback contract). Each is a thin,
+ *   SVG-preferring renderer so the registry lists them as first-class kinds and
+ *   each can carry a kind-specific "no SVG" explanation.
+ */
+import type { RichMarkdownBlock } from './types';
+import {
+  registerBlockRenderer,
+  hasBlockRenderer,
+  type BlockOutput,
+  type BlockRenderer,
+} from './registry';
+
+/**
+ * Live Mermaid renderer — defers actual SVG production to the inline-Mermaid
+ * path in `ReadingView`. Reusing that path is an explicit goal of #427.
+ */
+export const mermaidBlockRenderer: BlockRenderer = (block) => ({
+  type: 'mermaid',
+  source: block.source,
+  title: block.title,
+});
+
+/**
+ * Build an SVG-preferring renderer for a kind that has no live engine. It emits
+ * the pre-built SVG when present, else an `unsupported` decision with a
+ * kind-specific reason (which still becomes a raw-code fallback downstream).
+ */
+function svgPreferringRenderer(label: string): BlockRenderer {
+  return (block: RichMarkdownBlock): BlockOutput => {
+    if (typeof block.svg === 'string' && block.svg.trim()) {
+      return { type: 'svg', svg: block.svg, title: block.title };
+    }
+    return {
+      type: 'unsupported',
+      kind: block.kind,
+      source: block.source,
+      reason: `${label} blocks render from a pre-built SVG, but none was provided for this block.`,
+    };
+  };
+}
+
+/** Graphviz DOT — rendered from a pre-built SVG. */
+export const dotBlockRenderer = svgPreferringRenderer('Graphviz DOT');
+/** iCalendar (`.ics`) — rendered from a pre-built SVG (e.g. an agenda card). */
+export const icsBlockRenderer = svgPreferringRenderer('iCalendar (ics)');
+/** Generic drawing canvas — rendered from a pre-built SVG. */
+export const canvasBlockRenderer = svgPreferringRenderer('Canvas');
+
+/** The built-in renderers, keyed by block kind (and common aliases). */
+const BUILTIN_BLOCK_RENDERERS: Record<string, BlockRenderer> = {
+  mermaid: mermaidBlockRenderer,
+  dot: dotBlockRenderer,
+  graphviz: dotBlockRenderer,
+  ics: icsBlockRenderer,
+  ical: icsBlockRenderer,
+  icalendar: icsBlockRenderer,
+  canvas: canvasBlockRenderer,
+};
+
+/**
+ * Register the built-in block renderers. Idempotent (last registration wins), so
+ * it is safe to call repeatedly.
+ */
+export function registerBuiltinBlockRenderers(): void {
+  for (const [kind, renderer] of Object.entries(BUILTIN_BLOCK_RENDERERS)) {
+    registerBlockRenderer(kind, renderer);
+  }
+}
+
+/**
+ * Ensure the built-in renderers are registered without clobbering caller
+ * overrides on every render. Re-registers after a registry reset (used by the
+ * render path so the registry is always populated regardless of import order).
+ */
+export function ensureBuiltinBlockRenderers(): void {
+  if (!hasBlockRenderer('mermaid')) registerBuiltinBlockRenderers();
+}

--- a/src/views/rich-markdown/sample-document.ts
+++ b/src/views/rich-markdown/sample-document.ts
@@ -1,0 +1,154 @@
+/**
+ * A sample rich-Markdown document + node (Wave 0b — #427).
+ *
+ * This is the fixture the acceptance criteria describe: a document whose prose
+ * embeds a **live Mermaid** block plus `dot` / `ics` / `canvas` blocks that have
+ * no live renderer and therefore ship a **pre-built SVG**. It matches the
+ * provider shape (`node.data.richMarkdown.blocks`) so this template and the
+ * sibling provider (kbexplorer-cli#133) meet on the same contract.
+ *
+ * Used by:
+ *  - the unit tests (asserting no block falls back to raw code when an SVG exists);
+ *  - the `?demo=richmd` seam, which injects {@link buildSampleRichMarkdownNode}
+ *    into the graph so the document is viewable (and Playwright-verifiable).
+ */
+import { marked } from 'marked';
+import type { KBNode } from '../../types';
+import type { RichMarkdownBlock, RichMarkdownDocument } from './types';
+import { hashBlockSource } from './types';
+
+/** Pre-built SVG for the Graphviz DOT block (build → test → deploy). */
+export const SAMPLE_DOT_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 80" role="img" aria-label="build to test to deploy">
+  <rect x="4" y="24" width="64" height="32" rx="6" fill="#1f6feb"/>
+  <text x="36" y="44" fill="#ffffff" font-size="12" text-anchor="middle">build</text>
+  <rect x="88" y="24" width="64" height="32" rx="6" fill="#1f6feb"/>
+  <text x="120" y="44" fill="#ffffff" font-size="12" text-anchor="middle">test</text>
+  <rect x="172" y="24" width="64" height="32" rx="6" fill="#1f6feb"/>
+  <text x="204" y="44" fill="#ffffff" font-size="12" text-anchor="middle">deploy</text>
+  <line x1="68" y1="40" x2="88" y2="40" stroke="#8b949e" stroke-width="2"/>
+  <line x1="152" y1="40" x2="172" y2="40" stroke="#8b949e" stroke-width="2"/>
+</svg>`;
+
+/** Pre-built SVG for the iCalendar (`ics`) block (an agenda card). */
+export const SAMPLE_ICS_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 96" role="img" aria-label="Sprint Review event">
+  <rect x="1" y="1" width="238" height="94" rx="8" fill="#161b22" stroke="#30363d"/>
+  <rect x="1" y="1" width="238" height="24" rx="8" fill="#a371f7"/>
+  <text x="12" y="17" fill="#ffffff" font-size="12" font-weight="bold">Sprint Review</text>
+  <text x="12" y="50" fill="#c9d1d9" font-size="11">Jul 1, 2026 · 16:00 UTC</text>
+  <text x="12" y="72" fill="#8b949e" font-size="10">iCalendar event</text>
+</svg>`;
+
+/** Pre-built SVG for the `canvas` block (a small whiteboard sketch). */
+export const SAMPLE_CANVAS_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 100" role="img" aria-label="Canvas whiteboard demo">
+  <rect x="0" y="0" width="160" height="100" fill="#0d1117"/>
+  <rect x="16" y="16" width="128" height="68" fill="none" stroke="#3fb950" stroke-width="2"/>
+  <circle cx="80" cy="48" r="26" fill="#388bfd" opacity="0.8"/>
+  <text x="80" y="94" fill="#8b949e" font-size="10" text-anchor="middle">canvas sketch</text>
+</svg>`;
+
+const MERMAID_SOURCE = `flowchart LR
+  A[Build] --> B[Test]
+  B --> C[Deploy]`;
+
+const DOT_SOURCE = `digraph G {
+  build -> test;
+  test -> deploy;
+}`;
+
+const ICS_SOURCE = `BEGIN:VEVENT
+SUMMARY:Sprint Review
+DTSTART:20260701T160000Z
+END:VEVENT`;
+
+const CANVAS_SOURCE = `{ "shapes": [ { "rect": [0, 0, 128, 80] }, { "circle": [80, 48, 26] } ] }`;
+
+/** The document's frontmatter facts (rendered in the structured view). */
+export const SAMPLE_FRONTMATTER: Record<string, unknown> = {
+  title: 'Release Pipeline',
+  status: 'active',
+  owner: 'Team Atlas',
+  updated: '2026-06-30',
+  tags: ['release', 'ci', 'pipeline'],
+};
+
+/** The document's prose, in Markdown, with one fenced block per kind. */
+export const SAMPLE_RICH_MARKDOWN_RAW = `# Release Pipeline
+
+This document describes the **release pipeline** and embeds several block kinds —
+a live diagram plus three blocks that render from a pre-built SVG.
+
+## Flow (live Mermaid)
+
+\`\`\`mermaid
+${MERMAID_SOURCE}
+\`\`\`
+
+## Dependency graph (Graphviz DOT)
+
+\`\`\`dot
+${DOT_SOURCE}
+\`\`\`
+
+## Schedule (iCalendar)
+
+\`\`\`ics
+${ICS_SOURCE}
+\`\`\`
+
+## Whiteboard (canvas)
+
+\`\`\`canvas
+${CANVAS_SOURCE}
+\`\`\`
+`;
+
+/** Build a block, attaching a content hash and the source offsets (range). */
+function makeBlock(
+  kind: string,
+  source: string,
+  extra: { svg?: string; title?: string } = {},
+): RichMarkdownBlock {
+  const start = SAMPLE_RICH_MARKDOWN_RAW.indexOf(source);
+  const block: RichMarkdownBlock = { kind, source, hash: hashBlockSource(source) };
+  if (start >= 0) block.range = { start, end: start + source.length };
+  if (extra.svg) block.svg = extra.svg;
+  if (extra.title) block.title = extra.title;
+  return block;
+}
+
+/** The sample document's embedded blocks, in document order. */
+export function buildSampleBlocks(): RichMarkdownBlock[] {
+  return [
+    makeBlock('mermaid', MERMAID_SOURCE, { title: 'Release flow' }),
+    makeBlock('dot', DOT_SOURCE, { svg: SAMPLE_DOT_SVG, title: 'Build dependency graph' }),
+    makeBlock('ics', ICS_SOURCE, { svg: SAMPLE_ICS_SVG, title: 'Sprint Review' }),
+    makeBlock('canvas', CANVAS_SOURCE, { svg: SAMPLE_CANVAS_SVG, title: 'Whiteboard sketch' }),
+  ];
+}
+
+/** Build the full {@link RichMarkdownDocument} fixture. */
+export function buildSampleRichMarkdownDocument(): RichMarkdownDocument {
+  return { frontmatter: SAMPLE_FRONTMATTER, blocks: buildSampleBlocks() };
+}
+
+/**
+ * Build the sample rich-Markdown {@link KBNode}. `content` is rendered the same
+ * way the engine renders any node (`marked.parse`), so the inline prose walk
+ * finds the same `<pre><code class="language-…">` fences at runtime.
+ */
+export function buildSampleRichMarkdownNode(id = 'demo-richmd-doc'): KBNode {
+  const content = marked.parse(SAMPLE_RICH_MARKDOWN_RAW, { async: false }) as string;
+  return {
+    id,
+    title: 'Release Pipeline',
+    cluster: 'docs',
+    content,
+    rawContent: SAMPLE_RICH_MARKDOWN_RAW,
+    emoji: 'DocumentRegular',
+    display: 'rich-markdown',
+    connections: [],
+    source: { type: 'derived', generator: 'rich-markdown-demo' },
+    provider: 'demo-richmd',
+    data: { richMarkdown: buildSampleRichMarkdownDocument() },
+  };
+}

--- a/src/views/rich-markdown/svg.ts
+++ b/src/views/rich-markdown/svg.ts
@@ -1,0 +1,34 @@
+/**
+ * Inert rendering of untrusted SVG (Wave 0b — #427, security hardening).
+ *
+ * A pre-built fallback `block.svg` is **provider/source-supplied (untrusted)**:
+ * it may carry active content — event-handler attributes (`onload`, `onclick`,
+ * …), `javascript:` URLs in `href`/`xlink:href`, `<script>`, `<foreignObject>`
+ * (arbitrary HTML), external `<use>`/`<image>` references, `<style>`. Parsing it
+ * and inserting it into the live DOM would be an XSS sink.
+ *
+ * Instead we encode the SVG into a `data:image/svg+xml` URL and render it via an
+ * `<img>`. The browser loads SVG referenced by `<img>` in **secure static mode**:
+ * no scripts run, no event handlers fire, no external resources load, and there
+ * is no interactivity. The SVG is therefore inert regardless of its contents —
+ * no allow/deny list to keep in sync, no parser-differential bypass surface.
+ */
+
+/** Base64-encode UTF-8 text. `btoa` + `TextEncoder` are available in browsers
+ * and in the node test runtime, so this is portable across both. */
+function base64Utf8(text: string): string {
+  // UTF-8 bytes → Latin1 binary string → base64 (handles non-ASCII safely).
+  const utf8 = new TextEncoder().encode(text);
+  let binary = '';
+  for (const byte of utf8) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}
+
+/**
+ * Encode an (untrusted) SVG string into an inert `data:image/svg+xml` URL for an
+ * `<img src>`. The markup is embedded verbatim but, loaded as an image, cannot
+ * execute script or fetch external resources — see the module header.
+ */
+export function svgToImageDataUri(svg: string): string {
+  return `data:image/svg+xml;base64,${base64Utf8(svg.trim())}`;
+}

--- a/src/views/rich-markdown/types.ts
+++ b/src/views/rich-markdown/types.ts
@@ -1,0 +1,138 @@
+/**
+ * Rich-Markdown document contract (Wave 0b — #427).
+ *
+ * A rich-Markdown node carries an open `data.richMarkdown` bag emitted by the
+ * provider (anokye-labs/kbexplorer-cli#133). It pairs the document's prose
+ * (`node.content` / `node.rawContent`) with a list of **embedded blocks** — each
+ * a fenced region (`mermaid` / `dot` / `ics` / `canvas` / …) the provider lifts
+ * out, hashes, and (for kinds with no live renderer) pre-renders to SVG.
+ *
+ * These are **data only** — no DOM, no React — so they stay node-testable. The
+ * block-renderer registry ({@link ./registry}) turns a block into a render
+ * decision; the React/DOM layer turns that decision into pixels.
+ */
+import type { KBNode } from '../../types';
+
+/** Character offsets of a block within the original markdown source. */
+export interface BlockRange {
+  /** Inclusive start offset into the original markdown. */
+  start: number;
+  /** Exclusive end offset into the original markdown. */
+  end: number;
+}
+
+/**
+ * One embedded block inside a rich-Markdown document.
+ *
+ * `kind` is an **open** discriminator (`'mermaid' | 'dot' | 'ics' | 'canvas' | …`)
+ * so new block kinds need no core change. `svg` is the pre-built-SVG fallback
+ * contract: when a kind has no live renderer, the provider ships a rendered SVG
+ * so the block never degrades to a raw code dump.
+ */
+export interface RichMarkdownBlock {
+  /** Open block-kind discriminator, e.g. `'mermaid'`, `'dot'`, `'ics'`, `'canvas'`. */
+  kind: string;
+  /** Verbatim block source (the fenced-code body). */
+  source: string;
+  /**
+   * Content hash of `source` (e.g. `'sha256:…'`). A stable identity used for
+   * caching and as a fast-path key when matching a rendered prose fence back to
+   * its provider block. Matching also works without it (by normalized source).
+   */
+  hash?: string;
+  /** Character offsets of the block in the original markdown source. */
+  range?: BlockRange;
+  /**
+   * Pre-built SVG markup — the fallback contract for blocks with no live
+   * renderer. When present the block renders this SVG instead of raw code.
+   */
+  svg?: string;
+  /** Optional human-facing caption/label for the block. */
+  title?: string;
+}
+
+/** The structured payload carried on `node.data.richMarkdown`. */
+export interface RichMarkdownDocument {
+  /** Frontmatter facts surfaced in the structured view. */
+  frontmatter?: Record<string, unknown>;
+  /** Embedded blocks, in document order. */
+  blocks: RichMarkdownBlock[];
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Narrow + validate a single raw block into a {@link RichMarkdownBlock}. */
+function coerceBlock(raw: unknown): RichMarkdownBlock | null {
+  if (!isObject(raw)) return null;
+  if (typeof raw.kind !== 'string' || typeof raw.source !== 'string') return null;
+
+  const block: RichMarkdownBlock = { kind: raw.kind, source: raw.source };
+  if (typeof raw.hash === 'string') block.hash = raw.hash;
+  if (typeof raw.svg === 'string') block.svg = raw.svg;
+  if (typeof raw.title === 'string') block.title = raw.title;
+  if (
+    isObject(raw.range) &&
+    typeof raw.range.start === 'number' &&
+    typeof raw.range.end === 'number'
+  ) {
+    block.range = { start: raw.range.start, end: raw.range.end };
+  }
+  return block;
+}
+
+/**
+ * Read + validate a node's `data.richMarkdown` into a {@link RichMarkdownDocument}.
+ *
+ * Returns `null` when the node carries no (valid) rich-Markdown payload, so a
+ * caller can cleanly fall back to plain prose rendering. Malformed blocks are
+ * skipped rather than throwing — a single bad block must never blank the page.
+ */
+export function getRichMarkdownDocument(
+  node: Pick<KBNode, 'data'>,
+): RichMarkdownDocument | null {
+  const rm = node.data?.richMarkdown;
+  if (!isObject(rm)) return null;
+
+  const rawBlocks = Array.isArray(rm.blocks) ? rm.blocks : [];
+  const blocks = rawBlocks
+    .map(coerceBlock)
+    .filter((b): b is RichMarkdownBlock => b !== null);
+
+  const doc: RichMarkdownDocument = { blocks };
+  if (isObject(rm.frontmatter)) doc.frontmatter = rm.frontmatter;
+  return doc;
+}
+
+/** True when a node carries a valid rich-Markdown payload. */
+export function isRichMarkdownNode(node: Pick<KBNode, 'data'>): boolean {
+  return getRichMarkdownDocument(node) !== null;
+}
+
+/**
+ * Normalize a block's source for stable comparison: CRLF → LF, strip trailing
+ * per-line whitespace, then trim ends. Lets a rendered prose fence be matched to
+ * its provider block regardless of incidental whitespace differences.
+ */
+export function normalizeBlockSource(source: string): string {
+  return source.replace(/\r\n/g, '\n').replace(/[ \t]+$/gm, '').trim();
+}
+
+/**
+ * Compute a stable content hash of a block's (normalized) source.
+ *
+ * Uses a dependency-free, synchronous FNV-1a so it works identically in the
+ * browser and in node tests. The provider may emit a stronger hash (e.g.
+ * `sha256:…`); block matching never depends on the algorithm (it falls back to
+ * normalized-source equality), so this stays an honest, illustrative identity.
+ */
+export function hashBlockSource(source: string): string {
+  const normalized = normalizeBlockSource(source);
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < normalized.length; i++) {
+    hash ^= normalized.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return `fnv1a:${(hash >>> 0).toString(16).padStart(8, '0')}`;
+}


### PR DESCRIPTION
Closes #427.

Renders a rich-Markdown document with **inline embedded blocks**: a block-renderer registry (modeled on the viewer registry), a `RichMarkdownDocumentView` composing frontmatter facts + prose + blocks, reuse of the inline-Mermaid path as the one *live* renderer, and a **pre-built-SVG fallback** that replaces the raw-code display for blocks with no live renderer.

## Acceptance (from the issue) — verified
- ✅ Sample doc renders **frontmatter in the structured view** (reuses `GenericStructuredView`).
- ✅ A **live Mermaid** block renders to SVG (existing inline path, unchanged).
- ✅ `dot` / `canvas` blocks render **via the pre-built-SVG fallback**.
- ✅ **No block falls back to raw code when an SVG exists** (universal SVG fallback in `resolveBlockOutput`; the raw source is tucked into a collapsed `<details>`).
- ✅ **Existing Mermaid tests stay green** (unit `diagram.test.ts` + e2e `display-modes` Mermaid test).

## What's here
- **First step:** bumped `@anokye-labs/kbexplorer-core` to **`github:…#v0.1.0`** (was a pre-tag commit; lockfile now pins `2ce200b`).
- **`src/views/rich-markdown/`** — the pure, node-testable core + thin React layer:
  - `types.ts` — `RichMarkdownBlock` / `RichMarkdownDocument`, `getRichMarkdownDocument(node)`, source hashing/normalization.
  - `registry.ts` — open block-renderer registry (`register`/`resolve`/`has`/`list`/`reset`) + `resolveBlockOutput` (universal pre-built-SVG fallback).
  - `renderers.ts` — built-in `mermaid` (live) + `dot`/`ics`/`canvas` (SVG-preferring) renderers.
  - `plan.ts` — `planProseFence(...)`: Mermaid keeps its live path; other fences match a provider block (by source/hash) and render via the registry.
  - `FrontmatterFacts.tsx`, `RichMarkdownDocumentView.tsx` — the composition.
  - `sample-document.ts` — a sample doc (mermaid + dot/ics/canvas with pre-built SVGs) matching the provider shape.
- **`ReadingView.tsx`** — generalized `ProseContent` so a matched non-Mermaid fence renders its pre-built SVG (replacing the raw-code display at the old `:368-371` branch); added the `rich-markdown` display case. Ordinary code fences and the live-Mermaid path are untouched.
- **`?demo=richmd`** seam (`demo-entities.ts` + `useKnowledgeBase.ts`) injects the sample doc so it's viewable/verifiable without a provider. Query-only (no new persisted key → no `CACHE_VERSION` bump needed).
- **Side fix from the bump:** `validateSourceContent` now accepts the full `NodeSourceFile['format']` union (core v0.1.0 added `'markdown'`).

## Coordination
Designed to consume `node.data.richMarkdown.blocks` (each block: `kind`, `source`, content `hash`, source `range`, optional pre-built `svg`) emitted by the sibling provider (kbexplorer-cli#133). Built against own fixtures matching that shape — the two meet on the contract.

## Verification
- Unit: **793 passed** (69 files; +31 new). Lint: **0 errors**. `tsc -b`: clean. `vite build`: ok.
- E2E (local-manifest mode, like CI): **5/5** — the existing Mermaid back-compat test + the new rich-Markdown test (frontmatter structured view, live Mermaid SVG, dot/canvas SVG fallback, no raw-code dump).

> Note: please ignore any red `dependency-review` check (known non-blocking repo-setting issue). PRs authored as `hoopsomuah` don't auto-merge — ready for manual review/merge.