### PR TITLE
chore(release): 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## 0.3.0
-
-- Rich-Markdown rendering: block-renderer registry, `RichMarkdownDocumentView`, inert SVG fallback (#427).
-- Authored rich-Markdown ingestion: `AuthoredRichMarkdownProvider` ingests authored docs opting in via `display: rich-markdown` frontmatter, using the `@anokye-labs/kbexplorer-provider-rich-markdown` lib (#432).
-
-
 All notable changes to **kbexplorer-template** are documented here.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
@@ -17,6 +11,8 @@ moving branch — see [`docs/compatibility.md`](docs/compatibility.md) for the
 template ↔ kbexplorer CLI compatibility matrix and the pinning contract.
 
 ## [Unreleased]
+
+## 0.3.0
 
 ### Added
 - **Rich-Markdown rendering** (#427): a rich-Markdown document view that composes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.3.0
+
+- Rich-Markdown rendering: block-renderer registry, `RichMarkdownDocumentView`, inert SVG fallback (#427).
+- Authored rich-Markdown ingestion: `AuthoredRichMarkdownProvider` ingests authored docs opting in via `display: rich-markdown` frontmatter, using the `@anokye-labs/kbexplorer-provider-rich-markdown` lib (#432).
+
+
 All notable changes to **kbexplorer-template** are documented here.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kbexplorer-template",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kbexplorer-template",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@anokye-labs/kbexplorer-core": "github:anokye-labs/kbexplorer-core#v0.1.0",
         "@anokye-labs/kbexplorer-provider-rich-markdown": "github:anokye-labs/kbexplorer-provider-rich-markdown#v0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kbexplorer-template",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Cuts `v0.3.0` — rich-Markdown rendering (#427) + authored ingestion (#432). Bumps `package.json` 0.2.0 -> 0.3.0 + CHANGELOG. Closes #433.

After merge, tag `v0.3.0` so the showcase (anokye-labs/kbexplorer#14) can bump `TEMPLATE_REF`.