### PR TITLE
feat: theme-drive constellation colors + nodeRenderer host bridge (#402, #403)

### DIFF
--- a/content/node-renderer.md
+++ b/content/node-renderer.md
@@ -11,17 +11,21 @@ The node renderer (`src/engine/nodeRenderer.ts`) is the custom canvas drawing en
 
 ## How It Works
 
-`createNodeRenderer()` returns a draw function that vis-network calls for each node on every frame:
+`createNodeRenderer()` returns a vis-network `ctxRenderer` — a draw function vis-network calls for each node on every frame with a single args object (`{ ctx, x, y, state, style }`):
 
 ```typescript
 function createNodeRenderer(
-  iconName: string,         // Fluent icon name (e.g., "Flash", "Code")
-  color: string,            // Cluster color hex
-  size: number,             // Node radius in pixels
-  theme: NodeThemeSource,   // Resolved theme-source (foreground/background/icon)
-  label?: string,           // Optional text label
-  disconnected?: boolean
-): (ctx: CanvasRenderingContext2D, x: number, y: number) => void
+  iconName: string | undefined, // Fluent icon name (e.g., "Flash", "Code"), or none
+  clusterColor: string,         // Cluster color hex
+  nodeSize: number,             // Node diameter in pixels
+  theme: NodeThemeSource,       // Resolved theme-source (foreground/background/icon)
+  label?: string,               // Optional text label
+  disconnected?: boolean,
+): (args: { ctx: CanvasRenderingContext2D; x: number; y: number; state: { selected: boolean; hover: boolean }; style: { size: number } }) => {
+  drawNode?: unknown;
+  drawExternalLabel?: unknown;
+  nodeDimensions: { width: number; height: number };
+}
 ```
 
 The renderer paints a rounded shape (circle, rounded square, or rounded rectangle depending on icon type), fills it with the cluster color at reduced opacity, then draws the Fluent icon as an SVG data URI overlay. Labels render below the shape in the current theme's foreground color.

--- a/content/node-renderer.md
+++ b/content/node-renderer.md
@@ -15,11 +15,11 @@ The node renderer (`src/engine/nodeRenderer.ts`) is the custom canvas drawing en
 
 ```typescript
 function createNodeRenderer(
-  iconName: string,   // Fluent icon name (e.g., "Flash", "Code")
-  color: string,      // Cluster color hex
-  size: number,       // Node radius in pixels
-  isDark: boolean,    // Dark mode flag
-  label?: string,     // Optional text label
+  iconName: string,         // Fluent icon name (e.g., "Flash", "Code")
+  color: string,            // Cluster color hex
+  size: number,             // Node radius in pixels
+  theme: NodeThemeSource,   // Resolved theme-source (foreground/background/icon)
+  label?: string,           // Optional text label
   disconnected?: boolean
 ): (ctx: CanvasRenderingContext2D, x: number, y: number) => void
 ```
@@ -34,9 +34,9 @@ The `ICON_NODE_SHAPE` map determines which shape each icon gets. The `inferNodeS
 
 The renderer embeds 150+ Fluent UI icon SVG paths in the `ICON_PATHS` dictionary — a subset of `@fluentui/react-icons` hand-selected for the knowledge graph use case. `getIconImage()` converts each icon to a canvas-drawable `Image` via SVG data URI construction and caches the result for performance. Icons are colored with their cluster color — never monochrome.
 
-## Dark Mode Rendering
+## Host Theme-Source Bridge
 
-In dark mode, background fills use lighter opacity and icon strokes invert. The `isDark` parameter flows from the [theme system](theme-system) through the [graph network](graph-network) factory. The `hexToRgba()` helper adjusts fill and stroke colors accordingly — without this, nodes would be invisible on dark backgrounds.
+Rather than branching on a binary `isDark` flag, the renderer paints from a resolved `NodeThemeSource` (`{ isDark, foreground, background, iconColor }`). `resolveNodeTheme(root, isDarkHint)` reads `--colorNeutralForeground2` / `--colorNeutralBackground1` off the graph container — which inherits the active `FluentProvider` (or a canvas host's mirrored) token variables — and derives `isDark` from the background's perceived luminance. Unset variables fall back to the prior dark/light hardcodes selected by `isDarkHint`. This lets the constellation adopt a host theme with no fork, while `hexToRgba()` still adjusts fill and stroke opacity so nodes stay visible on any background.
 
 ## Integration
 

--- a/src/components/HUD.tsx
+++ b/src/components/HUD.tsx
@@ -41,7 +41,7 @@ import {
 import type { KBGraph, KBConfig, KBNode } from '../types';
 import { collapseGraphClusters, trimGraphToLimits } from '../types';
 import type { TrimResult } from '../types';
-import { getEdgeStyle, getEdgeLegendKey } from '../representation/styles';
+import { getEdgeStyle, getEdgeLegendKey, styleColorVar } from '../representation/styles';
 import { BUILT_IN_VIEWS, getView, filterGraphToView } from '../representation/views';
 import type { GraphLayoutMode } from '../representation/views';
 import type { ThemeMode } from '../hooks/useTheme';
@@ -1021,7 +1021,7 @@ export function HUD({ graph, config, currentNodeId, theme, isDark, availableThem
                     <div key={key} style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '2px 0' }}>
                       <svg width={18} height={8} style={{ flexShrink: 0 }}>
                         <line x1={0} y1={4} x2={18} y2={4}
-                          stroke={s.color} strokeWidth={Math.max(s.width, 1.2)}
+                          stroke={styleColorVar(s)} strokeWidth={Math.max(s.width, 1.2)}
                           strokeDasharray={Array.isArray(s.dashes) ? s.dashes.join(',') : undefined} />
                       </svg>
                       <Caption1 style={{ color: tokens.colorNeutralForeground2 }}>{label}</Caption1>

--- a/src/engine/__tests__/nodeRenderer-theme.test.ts
+++ b/src/engine/__tests__/nodeRenderer-theme.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { resolveNodeTheme } from '../nodeRenderer';
+
+describe('resolveNodeTheme', () => {
+  const originalGCS = (globalThis as Record<string, unknown>).getComputedStyle;
+
+  afterEach(() => {
+    if (originalGCS === undefined) delete (globalThis as Record<string, unknown>).getComputedStyle;
+    else (globalThis as Record<string, unknown>).getComputedStyle = originalGCS;
+  });
+
+  it('falls back to the dark hardcodes when the DOM is unavailable', () => {
+    delete (globalThis as Record<string, unknown>).getComputedStyle;
+    const t = resolveNodeTheme(null, true);
+    expect(t.isDark).toBe(true);
+    expect(t.foreground).toBe('#d6d6d6');
+    expect(t.background).toBe('#1f1f1f');
+    expect(t.iconColor).toBe('rgba(255,255,255,0.9)');
+  });
+
+  it('falls back to the light hardcodes when isDark hint is false', () => {
+    delete (globalThis as Record<string, unknown>).getComputedStyle;
+    const t = resolveNodeTheme(null, false);
+    expect(t.isDark).toBe(false);
+    expect(t.foreground).toBe('#242424');
+    expect(t.background).toBe('#ffffff');
+    expect(t.iconColor).toBe('rgba(0,0,0,0.85)');
+  });
+
+  it('reads foreground/background from CSS vars and derives isDark from luminance', () => {
+    (globalThis as Record<string, unknown>).getComputedStyle = () => ({
+      getPropertyValue: (name: string) =>
+        name === '--colorNeutralForeground2' ? '#222222'
+          : name === '--colorNeutralBackground1' ? '#f5ecd7'
+            : '',
+    });
+    const t = resolveNodeTheme({} as Element, true);
+    expect(t.foreground).toBe('#222222');
+    expect(t.background).toBe('#f5ecd7');
+    // Light sepia-like background => not dark, despite the dark hint.
+    expect(t.isDark).toBe(false);
+    expect(t.iconColor).toBe('rgba(0,0,0,0.85)');
+  });
+
+  it('derives isDark from an rgb() background string', () => {
+    (globalThis as Record<string, unknown>).getComputedStyle = () => ({
+      getPropertyValue: (name: string) =>
+        name === '--colorNeutralBackground1' ? 'rgb(20, 20, 24)' : '',
+    });
+    const t = resolveNodeTheme({} as Element, false);
+    expect(t.isDark).toBe(true);
+  });
+});

--- a/src/engine/createGraphNetwork.ts
+++ b/src/engine/createGraphNetwork.ts
@@ -4,12 +4,12 @@
  */
 import { Network } from 'vis-network/standalone';
 import { DataSet } from 'vis-data';
-import { createNodeRenderer } from './nodeRenderer';
+import { createNodeRenderer, resolveNodeTheme, type NodeThemeSource } from './nodeRenderer';
 import { getNodeDegrees } from './graph';
 import { computeReportsToLevels } from './reports-to-layout';
 import type { KBGraph } from '../types';
 import type { GraphLayoutMode } from '../representation/views';
-import { getEdgeStyle } from '../representation/styles';
+import { getEdgeStyle, resolveStyleColor } from '../representation/styles';
 
 /**
  * Fixed seed for vis-network's force-directed initial placement.
@@ -69,6 +69,8 @@ export interface BuildVisNodeOptions {
   degrees: Map<string, number>;
   clusterColorMap: Map<string, string>;
   isDark: boolean;
+  /** Resolved theme-source for node painting (replaces the isDark branch). */
+  nodeTheme: NodeThemeSource;
   nodeSizeRange?: [number, number];
   nodeSizeStep?: number;
   labelMaxLength?: number;
@@ -124,7 +126,7 @@ export function buildVisNode(
     label: '',
     title: `${node.title}\n${deg} connection${deg === 1 ? '' : 's'}${disconnected ? '\n⚠ Disconnected node' : ''}`,
     shape: 'custom',
-    ctxRenderer: createNodeRenderer(node.emoji, color, size, options.isDark, label, disconnected),
+    ctxRenderer: createNodeRenderer(node.emoji, color, size, options.nodeTheme, label, disconnected),
     size: size / 2,
     // Audit sidecar: the rendered label is captured inside the ctxRenderer
     // closure and isn't visible through vis-network's public DataSet API.
@@ -183,6 +185,11 @@ export function createGraphNetwork(options: GraphNetworkOptions): GraphNetworkRe
   const clusterColorMap = new Map(graph.clusters.map(c => [c.id, c.color]));
   const keyNodeIds = computeKeyNodes(degrees);
 
+  // Resolve node label/surface/icon colors from the active theme's CSS vars
+  // (read off the container, which inherits the FluentProvider/host tokens).
+  // The `isDark` option is only a fallback hint when a var is unset.
+  const nodeTheme = resolveNodeTheme(container, isDark);
+
   // Build set of emphasized node IDs (current + direct neighbors)
   // Skip emphasis if the target node isn't in this graph (e.g. layer filtered out)
   const nodeIdSet = new Set(graph.nodes.map(n => n.id));
@@ -208,7 +215,7 @@ export function createGraphNetwork(options: GraphNetworkOptions): GraphNetworkRe
       ? [nodeSizeRange[0] * fadedSizeScale, nodeSizeRange[1] * fadedSizeScale]
       : nodeSizeRange;
     const visNode = buildVisNode(n, {
-      degrees, clusterColorMap, isDark, keyNodeIds,
+      degrees, clusterColorMap, isDark, nodeTheme, keyNodeIds,
       nodeSizeRange: sizeRange, nodeSizeStep, labelMaxLength,
       flagDisconnected: true,
       opacity: faded ? fadedOpacity : undefined,
@@ -238,6 +245,7 @@ export function createGraphNetwork(options: GraphNetworkOptions): GraphNetworkRe
   const inferredSpringLength = 120;
   const edgeData = graph.edges.map((e, i) => {
     const style = edgeStyle(e);
+    const styleColor = resolveStyleColor(style, container);
     const faded = effectiveEmphasis && !emphasizedIds.has(e.from) && !emphasizedIds.has(e.to);
     const nearFaded = effectiveEmphasis && !(emphasizedIds.has(e.from) && emphasizedIds.has(e.to));
     const springBase = e.source === 'inferred' ? inferredSpringLength : baseSpringLength;
@@ -251,9 +259,9 @@ export function createGraphNetwork(options: GraphNetworkOptions): GraphNetworkRe
       to: reverseForTree ? e.from : e.to,
       title: `${style.label}: ${e.description}`,
       color: {
-        color: faded ? EDGE_FADED_COLOR : nearFaded ? 'rgba(80,80,80,0.25)' : style.color,
-        hover: style.color,
-        highlight: style.color,
+        color: faded ? EDGE_FADED_COLOR : nearFaded ? 'rgba(80,80,80,0.25)' : styleColor,
+        hover: styleColor,
+        highlight: styleColor,
       },
       width: faded ? 0.5 : style.width,
       dashes: faded ? false : style.dashes,
@@ -313,7 +321,7 @@ export function createGraphNetwork(options: GraphNetworkOptions): GraphNetworkRe
         ? [nodeSizeRange[0] * fadedSizeScale, nodeSizeRange[1] * fadedSizeScale]
         : nodeSizeRange;
       nodeUpdates.push(buildVisNode(n, {
-        degrees, clusterColorMap, isDark, keyNodeIds,
+        degrees, clusterColorMap, isDark, nodeTheme, keyNodeIds,
         nodeSizeRange: sizeRange, nodeSizeStep, labelMaxLength,
         flagDisconnected: true,
         opacity: faded ? fadedOpacity : undefined,
@@ -333,11 +341,12 @@ export function createGraphNetwork(options: GraphNetworkOptions): GraphNetworkRe
     const edgeUpdates: Record<string, unknown>[] = [];
     for (const ei of edgesByIndex) {
       const style = edgeStyle(ei);
+      const styleColor = resolveStyleColor(style, container);
       if (!active) {
         // No focus — all edges at full style
         edgeUpdates.push({
           id: ei.id,
-          color: { color: style.color, hover: style.color, highlight: style.color },
+          color: { color: styleColor, hover: styleColor, highlight: styleColor },
           width: style.width,
           dashes: style.dashes,
         });
@@ -355,17 +364,17 @@ export function createGraphNetwork(options: GraphNetworkOptions): GraphNetworkRe
 
       if (maxHop <= 1) {
         // Tier 0: direct neighborhood — full prominence
-        color = style.color;
+        color = styleColor;
         width = style.width * 1.2;
         dashes = style.dashes;
       } else if (minHop <= 1) {
         // Tier 1: one endpoint is direct neighbor — visible but softer
-        color = style.color + '80'; // 50% alpha
+        color = styleColor + '80'; // 50% alpha
         width = style.width * 0.8;
         dashes = style.dashes;
       } else if (maxHop <= 2) {
         // Tier 2: 2-hop bridge — faint but colored
-        color = style.color + '40'; // 25% alpha
+        color = styleColor + '40'; // 25% alpha
         width = Math.max(style.width * 0.5, 0.8);
         dashes = style.dashes;
       } else {
@@ -377,7 +386,7 @@ export function createGraphNetwork(options: GraphNetworkOptions): GraphNetworkRe
 
       edgeUpdates.push({
         id: ei.id,
-        color: { color, hover: style.color, highlight: style.color },
+        color: { color, hover: styleColor, highlight: styleColor },
         width,
         dashes,
       });

--- a/src/engine/createGraphNetwork.ts
+++ b/src/engine/createGraphNetwork.ts
@@ -9,7 +9,7 @@ import { getNodeDegrees } from './graph';
 import { computeReportsToLevels } from './reports-to-layout';
 import type { KBGraph } from '../types';
 import type { GraphLayoutMode } from '../representation/views';
-import { getEdgeStyle, resolveStyleColor, withAlpha } from '../representation/styles';
+import { getEdgeStyle, resolveStyleColor, emphasisEdgeStyle } from '../representation/styles';
 
 /**
  * Fixed seed for vis-network's force-directed initial placement.
@@ -358,31 +358,9 @@ export function createGraphNetwork(options: GraphNetworkOptions): GraphNetworkRe
       const maxHop = Math.max(fromHop, toHop);
       const minHop = Math.min(fromHop, toHop);
 
-      let color: string;
-      let width: number;
-      let dashes: boolean | number[];
-
-      if (maxHop <= 1) {
-        // Tier 0: direct neighborhood — full prominence
-        color = styleColor;
-        width = style.width * 1.2;
-        dashes = style.dashes;
-      } else if (minHop <= 1) {
-        // Tier 1: one endpoint is direct neighbor — visible but softer
-        color = withAlpha(styleColor, 0.5);
-        width = style.width * 0.8;
-        dashes = style.dashes;
-      } else if (maxHop <= 2) {
-        // Tier 2: 2-hop bridge — faint but colored
-        color = withAlpha(styleColor, 0.25);
-        width = Math.max(style.width * 0.5, 0.8);
-        dashes = style.dashes;
-      } else {
-        // Tier 3: distant — barely visible
-        color = isDark ? 'rgba(60,60,60,0.15)' : 'rgba(180,180,180,0.15)';
-        width = 0.4;
-        dashes = false;
-      }
+      const { color, width, dashes } = emphasisEdgeStyle(
+        styleColor, style.width, style.dashes, maxHop, minHop, isDark,
+      );
 
       edgeUpdates.push({
         id: ei.id,

--- a/src/engine/createGraphNetwork.ts
+++ b/src/engine/createGraphNetwork.ts
@@ -9,7 +9,7 @@ import { getNodeDegrees } from './graph';
 import { computeReportsToLevels } from './reports-to-layout';
 import type { KBGraph } from '../types';
 import type { GraphLayoutMode } from '../representation/views';
-import { getEdgeStyle, resolveStyleColor } from '../representation/styles';
+import { getEdgeStyle, resolveStyleColor, withAlpha } from '../representation/styles';
 
 /**
  * Fixed seed for vis-network's force-directed initial placement.
@@ -369,12 +369,12 @@ export function createGraphNetwork(options: GraphNetworkOptions): GraphNetworkRe
         dashes = style.dashes;
       } else if (minHop <= 1) {
         // Tier 1: one endpoint is direct neighbor — visible but softer
-        color = styleColor + '80'; // 50% alpha
+        color = withAlpha(styleColor, 0.5);
         width = style.width * 0.8;
         dashes = style.dashes;
       } else if (maxHop <= 2) {
         // Tier 2: 2-hop bridge — faint but colored
-        color = styleColor + '40'; // 25% alpha
+        color = withAlpha(styleColor, 0.25);
         width = Math.max(style.width * 0.5, 0.8);
         dashes = style.dashes;
       } else {

--- a/src/engine/nodeRenderer.ts
+++ b/src/engine/nodeRenderer.ts
@@ -2680,22 +2680,90 @@ interface CtxRendererArgs {
 }
 
 /**
+ * Resolved host/theme color source for node rendering.
+ *
+ * Replaces the old binary `isDark` flag: instead of branching between two
+ * hardcoded palettes, the renderer paints from theme tokens resolved from CSS
+ * variables (Fluent `colorNeutral*`, or a canvas host's mirrored equivalents).
+ * `isDark` is retained only as a derived hint for icon contrast.
+ */
+export interface NodeThemeSource {
+  /** Derived from background luminance — drives icon contrast only. */
+  isDark: boolean;
+  /** Label fill — semantic primary/secondary foreground. */
+  foreground: string;
+  /** Label outline + opaque node base — semantic surface background. */
+  background: string;
+  /** Icon glyph color, contrast-matched to the background. */
+  iconColor: string;
+}
+
+/** Whether a hex/`rgb()` background reads as dark (perceived luminance < 0.5). */
+function backgroundIsDark(bg: string, hint?: boolean): boolean {
+  const hex = /^#?([0-9a-fA-F]{6})$/.exec(bg.trim());
+  if (hex) {
+    const n = parseInt(hex[1], 16);
+    const r = (n >> 16) & 0xff, g = (n >> 8) & 0xff, b = n & 0xff;
+    return (0.299 * r + 0.587 * g + 0.114 * b) / 255 < 0.5;
+  }
+  const rgb = /rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/.exec(bg);
+  if (rgb) {
+    const r = +rgb[1], g = +rgb[2], b = +rgb[3];
+    return (0.299 * r + 0.587 * g + 0.114 * b) / 255 < 0.5;
+  }
+  return hint ?? true;
+}
+
+function readCssVar(root: Element | null, name: string, fallback: string): string {
+  if (!root || typeof getComputedStyle === 'undefined') return fallback;
+  try {
+    const v = getComputedStyle(root).getPropertyValue(name).trim();
+    return v || fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+/**
+ * Resolve a {@link NodeThemeSource} from the active theme's CSS variables.
+ *
+ * `root` should be an element inside the active `FluentProvider` subtree (the
+ * graph container) so it inherits that theme's token variables; a canvas host
+ * mirrors the same semantic vars, so the SPA adopts the host look with no fork.
+ * Falls back to the prior dark/light hardcodes (selected by `isDarkHint`) when a
+ * variable is unset or the DOM is unavailable (SSR/tests).
+ */
+export function resolveNodeTheme(root?: Element | null, isDarkHint?: boolean): NodeThemeSource {
+  const el = root ?? (typeof document !== 'undefined' ? document.documentElement : null);
+  const dark = isDarkHint ?? true;
+  const foreground = readCssVar(el, '--colorNeutralForeground2', dark ? '#d6d6d6' : '#242424');
+  const background = readCssVar(el, '--colorNeutralBackground1', dark ? '#1f1f1f' : '#ffffff');
+  const isDark = backgroundIsDark(background, isDarkHint);
+  return {
+    isDark,
+    foreground,
+    background,
+    iconColor: isDark ? 'rgba(255,255,255,0.9)' : 'rgba(0,0,0,0.85)',
+  };
+}
+
+/**
  * Creates a ctxRenderer function for a vis-network custom node.
  */
 export function createNodeRenderer(
   iconName: string | undefined,
   clusterColor: string,
   nodeSize: number,
-  isDark: boolean,
+  theme: NodeThemeSource,
   label?: string,
   disconnected?: boolean,
 ){
   const shapeType: NodeShapeType = (iconName && ICON_NODE_SHAPE[iconName]) || 'circle';
-  const iconColor = isDark ? 'rgba(255,255,255,0.9)' : 'rgba(0,0,0,0.85)';
+  const iconColor = theme.iconColor;
   const iconImg = iconName ? getIconImage(iconName, iconColor) : null;
-  const labelColor = isDark ? '#d6d6d6' : '#242424';
-  const labelStroke = isDark ? '#1f1f1f' : '#ffffff';
-  const bgFill = isDark ? '#1f1f1f' : '#ffffff';
+  const labelColor = theme.foreground;
+  const labelStroke = theme.background;
+  const bgFill = theme.background;
 
   return function ctxRenderer({ ctx, x, y, state }: CtxRendererArgs) {
     const s = nodeSize;

--- a/src/representation/__tests__/theme-colors.test.ts
+++ b/src/representation/__tests__/theme-colors.test.ts
@@ -2,10 +2,27 @@ import { describe, it, expect, afterEach } from 'vitest';
 import {
   styleColorVar,
   resolveStyleColor,
+  withAlpha,
   EDGE_TYPE_STYLES,
   RELATION_STYLES,
   NODE_LAYER_META,
 } from '../styles';
+
+describe('withAlpha', () => {
+  it('converts a hex color to rgba with the given alpha', () => {
+    expect(withAlpha('#a78bfa', 0.5)).toBe('rgba(167, 139, 250, 0.5)');
+    expect(withAlpha('#000000', 0.25)).toBe('rgba(0, 0, 0, 0.25)');
+  });
+
+  it('re-alphas an rgb()/rgba() color instead of producing an invalid suffix', () => {
+    expect(withAlpha('rgb(160, 173, 184)', 0.5)).toBe('rgba(160, 173, 184, 0.5)');
+    expect(withAlpha('rgba(20, 20, 24, 1)', 0.25)).toBe('rgba(20, 20, 24, 0.25)');
+  });
+
+  it('returns the original string for an unparseable color', () => {
+    expect(withAlpha('var(--x)', 0.5)).toBe('var(--x)');
+  });
+});
 
 describe('styleColorVar', () => {
   it('wraps a tokenized color as a var() with the hex as fallback', () => {

--- a/src/representation/__tests__/theme-colors.test.ts
+++ b/src/representation/__tests__/theme-colors.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  styleColorVar,
+  resolveStyleColor,
+  EDGE_TYPE_STYLES,
+  RELATION_STYLES,
+  NODE_LAYER_META,
+} from '../styles';
+
+describe('styleColorVar', () => {
+  it('wraps a tokenized color as a var() with the hex as fallback', () => {
+    expect(styleColorVar({ color: '#a78bfa', token: 'colorPalettePurpleForeground2' }))
+      .toBe('var(--colorPalettePurpleForeground2, #a78bfa)');
+  });
+
+  it('returns the literal hex when no token is present', () => {
+    expect(styleColorVar({ color: '#123456' })).toBe('#123456');
+  });
+});
+
+describe('resolveStyleColor', () => {
+  const originalGCS = (globalThis as Record<string, unknown>).getComputedStyle;
+
+  afterEach(() => {
+    if (originalGCS === undefined) delete (globalThis as Record<string, unknown>).getComputedStyle;
+    else (globalThis as Record<string, unknown>).getComputedStyle = originalGCS;
+  });
+
+  it('falls back to the literal hex when the DOM is unavailable (SSR/node)', () => {
+    delete (globalThis as Record<string, unknown>).getComputedStyle;
+    expect(resolveStyleColor({ color: '#a78bfa', token: 'colorPalettePurpleForeground2' }, null))
+      .toBe('#a78bfa');
+  });
+
+  it('returns the hex when there is no token even with a DOM present', () => {
+    (globalThis as Record<string, unknown>).getComputedStyle = () => ({ getPropertyValue: () => '#ffffff' });
+    expect(resolveStyleColor({ color: '#abcdef' }, {} as Element)).toBe('#abcdef');
+  });
+
+  it('reads the resolved CSS variable from the root when set', () => {
+    (globalThis as Record<string, unknown>).getComputedStyle = (el: unknown) => ({
+      getPropertyValue: (name: string) =>
+        name === '--colorPalettePurpleForeground2' && el ? '  #c6b1de  ' : '',
+    });
+    expect(resolveStyleColor({ color: '#a78bfa', token: 'colorPalettePurpleForeground2' }, {} as Element))
+      .toBe('#c6b1de');
+  });
+
+  it('falls back to the hex when the variable resolves empty', () => {
+    (globalThis as Record<string, unknown>).getComputedStyle = () => ({ getPropertyValue: () => '' });
+    expect(resolveStyleColor({ color: '#a78bfa', token: 'colorPalettePurpleForeground2' }, {} as Element))
+      .toBe('#a78bfa');
+  });
+});
+
+describe('tokenized style tables', () => {
+  it('assigns a Fluent CSS-var token to every edge type', () => {
+    for (const style of Object.values(EDGE_TYPE_STYLES)) {
+      expect(style.token).toBeTruthy();
+      expect(style.color).toMatch(/^#[0-9a-fA-F]{6}$/);
+    }
+  });
+
+  it('assigns a token to every relation style', () => {
+    for (const style of Object.values(RELATION_STYLES)) {
+      expect(style.token).toBeTruthy();
+    }
+  });
+
+  it('assigns a token to every node layer', () => {
+    for (const meta of Object.values(NODE_LAYER_META)) {
+      expect(meta.token).toBeTruthy();
+      expect(meta.color).toMatch(/^#[0-9a-fA-F]{6}$/);
+    }
+  });
+});

--- a/src/representation/__tests__/theme-colors.test.ts
+++ b/src/representation/__tests__/theme-colors.test.ts
@@ -3,10 +3,16 @@ import {
   styleColorVar,
   resolveStyleColor,
   withAlpha,
+  emphasisEdgeStyle,
   EDGE_TYPE_STYLES,
   RELATION_STYLES,
   NODE_LAYER_META,
 } from '../styles';
+
+/** A bare hex suffix appended to an rgb() string — the bug this guards against. */
+const INVALID_RGB_SUFFIX = /rgba?\([^)]*\)[0-9a-fA-F]{2}\b/;
+/** Accepts hex (#rrggbb), rgb(...) or rgba(...) — the valid CSS color forms we emit. */
+const VALID_COLOR = /^(#[0-9a-fA-F]{6}|rgba?\([^)]*\))$/;
 
 describe('withAlpha', () => {
   it('converts a hex color to rgba with the given alpha', () => {
@@ -21,6 +27,33 @@ describe('withAlpha', () => {
 
   it('returns the original string for an unparseable color', () => {
     expect(withAlpha('var(--x)', 0.5)).toBe('var(--x)');
+  });
+});
+
+describe('emphasisEdgeStyle', () => {
+  // The regression: focus/emphasis must never append a hex alpha suffix to a
+  // resolved rgb() color (e.g. `rgb(205, 214, 216)80`). Assert every tier emits
+  // a VALID color for BOTH a hex-fallback color and a CSS-var-resolved rgb() one.
+  for (const base of ['#a0adb8', 'rgb(205, 214, 216)']) {
+    it(`emits valid colors across all tiers for base ${base}`, () => {
+      // (maxHop, minHop) per tier: direct, tier1, tier2, distant.
+      const cases: Array<[number, number]> = [[1, 0], [2, 1], [2, 2], [5, 3]];
+      for (const [maxHop, minHop] of cases) {
+        const r = emphasisEdgeStyle(base, 2, false, maxHop, minHop, true);
+        expect(r.color).toMatch(VALID_COLOR);
+        expect(r.color).not.toMatch(INVALID_RGB_SUFFIX);
+        expect(r.width).toBeGreaterThan(0);
+      }
+    });
+  }
+
+  it('applies the expected translucency per tier', () => {
+    const c = 'rgb(205, 214, 216)';
+    expect(emphasisEdgeStyle(c, 2, false, 1, 0, true).color).toBe(c);                 // direct: full
+    expect(emphasisEdgeStyle(c, 2, false, 2, 1, true).color).toBe('rgba(205, 214, 216, 0.5)');  // tier 1
+    expect(emphasisEdgeStyle(c, 2, false, 2, 2, true).color).toBe('rgba(205, 214, 216, 0.25)'); // tier 2
+    expect(emphasisEdgeStyle(c, 2, false, 5, 3, true).color).toBe('rgba(60,60,60,0.15)');       // distant (dark)
+    expect(emphasisEdgeStyle(c, 2, false, 5, 3, false).color).toBe('rgba(180,180,180,0.15)');   // distant (light)
   });
 });
 

--- a/src/representation/styles.ts
+++ b/src/representation/styles.ts
@@ -188,3 +188,42 @@ export function withAlpha(color: string, alpha: number): string {
   }
   return color;
 }
+
+/** Per-tier visual treatment for an edge during focus/neighborhood emphasis. */
+export interface EmphasisEdgeStyle {
+  color: string;
+  width: number;
+  dashes: boolean | number[];
+}
+
+/**
+ * Resolve an edge's emphasis treatment by hop distance from the focused node.
+ * `styleColor` is the already-resolved base color (hex OR `rgb()` from a theme
+ * var). Translucency is applied via {@link withAlpha} so the output is ALWAYS a
+ * valid CSS color — never a bare hex-suffix appended to an `rgb()` string, the
+ * bug that broke focus rendering once colors could resolve from CSS variables.
+ *
+ *  - Tier 0 (`maxHop ≤ 1`): direct neighborhood — full color, wider.
+ *  - Tier 1 (`minHop ≤ 1`): one endpoint adjacent — 50% alpha.
+ *  - Tier 2 (`maxHop ≤ 2`): 2-hop bridge — 25% alpha, thinner.
+ *  - Tier 3 (distant): theme-neutral barely-visible wash.
+ */
+export function emphasisEdgeStyle(
+  styleColor: string,
+  baseWidth: number,
+  baseDashes: boolean | number[],
+  maxHop: number,
+  minHop: number,
+  isDark: boolean,
+): EmphasisEdgeStyle {
+  if (maxHop <= 1) {
+    return { color: styleColor, width: baseWidth * 1.2, dashes: baseDashes };
+  }
+  if (minHop <= 1) {
+    return { color: withAlpha(styleColor, 0.5), width: baseWidth * 0.8, dashes: baseDashes };
+  }
+  if (maxHop <= 2) {
+    return { color: withAlpha(styleColor, 0.25), width: Math.max(baseWidth * 0.5, 0.8), dashes: baseDashes };
+  }
+  return { color: isDark ? 'rgba(60,60,60,0.15)' : 'rgba(180,180,180,0.15)', width: 0.4, dashes: false };
+}

--- a/src/representation/styles.ts
+++ b/src/representation/styles.ts
@@ -22,46 +22,58 @@ export const EDGE_TYPE_WEIGHTS: Record<KnownEdgeType, number> = {
   related: 0.3,
 };
 
-/** Visual style for each edge type */
+/**
+ * Visual style for each edge type.
+ *
+ * `color` is the literal hex fallback (theme-independent). `token`, when present,
+ * names a Fluent CSS variable (without the leading `--`) that the active theme —
+ * including a canvas host's mirrored tokens — resolves to a theme-adaptive color.
+ * Renderers go through {@link styleColorVar} (CSS/SVG) or {@link resolveStyleColor}
+ * (canvas) so the same style recolors under any theme while still degrading to the
+ * hex when the variable is unset. Fluent's `…Foreground2` palette ramp is used
+ * because it stays legible on both dark and light neutral backgrounds.
+ */
 export interface EdgeTypeStyle {
   color: string;
+  /** Fluent CSS-var token name (no `--`) resolved against the active theme. */
+  token?: string;
   dashes: boolean | number[];
   width: number;
   label: string;
 }
 
 export const EDGE_TYPE_STYLES: Record<KnownEdgeType, EdgeTypeStyle> = {
-  contains:         { color: '#a0adb8', dashes: false,      width: 2,   label: 'Contains' },
-  derived_from:     { color: '#e8a854', dashes: false,      width: 2,   label: 'Derived from' },
-  imports:          { color: '#a78bfa', dashes: false,      width: 1.5, label: 'Imports' },
-  references:       { color: '#79c0ff', dashes: false,      width: 1.5, label: 'References' },
-  frontmatter:      { color: '#7ee787', dashes: [6, 4],     width: 1.5, label: 'Frontmatter' },
-  cross_references: { color: '#f9a8d4', dashes: false,      width: 1.5, label: 'Cross-ref' },
-  modifies:         { color: '#e3b341', dashes: [4, 4],     width: 1.5, label: 'Modifies' },
-  closes:           { color: '#56d364', dashes: false,      width: 2,   label: 'Closes' },
-  mentions:         { color: '#b1bac4', dashes: [3, 4],     width: 1.2, label: 'Mentions' },
-  related:          { color: '#8b949e', dashes: [3, 3],     width: 1.2, label: 'Related' },
+  contains:         { color: '#a0adb8', token: 'colorPalettePlatinumForeground2',  dashes: false,  width: 2,   label: 'Contains' },
+  derived_from:     { color: '#e8a854', token: 'colorPaletteDarkOrangeForeground2', dashes: false,  width: 2,   label: 'Derived from' },
+  imports:          { color: '#a78bfa', token: 'colorPalettePurpleForeground2',     dashes: false,  width: 1.5, label: 'Imports' },
+  references:       { color: '#79c0ff', token: 'colorPaletteBlueForeground2',       dashes: false,  width: 1.5, label: 'References' },
+  frontmatter:      { color: '#7ee787', token: 'colorPaletteLightGreenForeground2', dashes: [6, 4], width: 1.5, label: 'Frontmatter' },
+  cross_references: { color: '#f9a8d4', token: 'colorPalettePinkForeground2',       dashes: false,  width: 1.5, label: 'Cross-ref' },
+  modifies:         { color: '#e3b341', token: 'colorPaletteMarigoldForeground2',   dashes: [4, 4], width: 1.5, label: 'Modifies' },
+  closes:           { color: '#56d364', token: 'colorPaletteGreenForeground2',      dashes: false,  width: 2,   label: 'Closes' },
+  mentions:         { color: '#b1bac4', token: 'colorPaletteBeigeForeground2',       dashes: [3, 4], width: 1.2, label: 'Mentions' },
+  related:          { color: '#8b949e', token: 'colorNeutralForeground3',            dashes: [3, 3], width: 1.2, label: 'Related' },
 };
 
 /** Visual styles for the relation taxonomy (rendered data-drivenly in the legend). */
 export const RELATION_STYLES: Record<KnownRelation, EdgeTypeStyle> = {
-  leads:            { color: '#f0883e', dashes: false,     width: 2.5, label: 'Leads' },
-  staffs:           { color: '#3fb950', dashes: false,     width: 1.5, label: 'Staffs' },
-  'reports-to':     { color: '#a371f7', dashes: false,     width: 1.8, label: 'Reports to' },
-  structural:       { color: '#a0adb8', dashes: false,     width: 2,   label: 'Structural' },
-  derived:          { color: '#e8a854', dashes: [6, 4],    width: 1.5, label: 'Derived' },
-  deprecated:       { color: '#8b949e', dashes: [2, 3],    width: 1.2, label: 'Deprecated' },
+  leads:            { color: '#f0883e', token: 'colorPaletteDarkOrangeForeground2', dashes: false,  width: 2.5, label: 'Leads' },
+  staffs:           { color: '#3fb950', token: 'colorPaletteGreenForeground2',      dashes: false,  width: 1.5, label: 'Staffs' },
+  'reports-to':     { color: '#a371f7', token: 'colorPalettePurpleForeground2',     dashes: false,  width: 1.8, label: 'Reports to' },
+  structural:       { color: '#a0adb8', token: 'colorPalettePlatinumForeground2',   dashes: false,  width: 2,   label: 'Structural' },
+  derived:          { color: '#e8a854', token: 'colorPaletteDarkOrangeForeground2', dashes: [6, 4], width: 1.5, label: 'Derived' },
+  deprecated:       { color: '#8b949e', token: 'colorNeutralForeground3',           dashes: [2, 3], width: 1.2, label: 'Deprecated' },
   // Work-graph organizational-layer relations (#233)
-  owns:             { color: '#4A9CC8', dashes: false,     width: 2,   label: 'Owns' },
-  'has-priority':   { color: '#E8A838', dashes: [4, 3],    width: 1.8, label: 'Has priority' },
-  'tracked-in':     { color: '#a371f7', dashes: [6, 3],    width: 1.5, label: 'Tracked in' },
+  owns:             { color: '#4A9CC8', token: 'colorPaletteSteelForeground2',      dashes: false,  width: 2,   label: 'Owns' },
+  'has-priority':   { color: '#E8A838', token: 'colorPaletteMarigoldForeground2',   dashes: [4, 3], width: 1.8, label: 'Has priority' },
+  'tracked-in':     { color: '#a371f7', token: 'colorPalettePurpleForeground2',     dashes: [6, 3], width: 1.5, label: 'Tracked in' },
   // Person-node active-work relations (#235)
-  'assigned-to':    { color: '#56d364', dashes: false,     width: 1.8, label: 'Assigned to' },
-  'authored':       { color: '#79c0ff', dashes: [4, 3],    width: 1.5, label: 'Authored' },
-  'member-of':      { color: '#f0883e', dashes: false,     width: 1.8, label: 'Member of' },
+  'assigned-to':    { color: '#56d364', token: 'colorPaletteGreenForeground2',      dashes: false,  width: 1.8, label: 'Assigned to' },
+  'authored':       { color: '#79c0ff', token: 'colorPaletteBlueForeground2',       dashes: [4, 3], width: 1.5, label: 'Authored' },
+  'member-of':      { color: '#f0883e', token: 'colorPaletteDarkOrangeForeground2', dashes: false,  width: 1.8, label: 'Member of' },
 };
 
-const DEFAULT_RELATION_STYLE: EdgeTypeStyle = { color: '#79c0ff', dashes: [2, 2], width: 1.5, label: 'Related' };
+const DEFAULT_RELATION_STYLE: EdgeTypeStyle = { color: '#79c0ff', token: 'colorPaletteBlueForeground2', dashes: [2, 2], width: 1.5, label: 'Related' };
 
 /** Title-case an arbitrary relation/edge key for display in the legend. */
 function humanizeKey(key: string): string {
@@ -108,8 +120,48 @@ export function getEdgeWeight(type: EdgeType | undefined): number {
 /** The graph layer a node is classified into for layer-based views/legends. */
 export type NodeLayer = 'file' | 'content' | 'work';
 
-export const NODE_LAYER_META: Record<NodeLayer, { label: string; color: string }> = {
-  file:    { label: 'Files',   color: '#9A8A78' },
-  content: { label: 'Content', color: '#58a6ff' },
-  work:    { label: 'Work',    color: '#d29922' },
+export const NODE_LAYER_META: Record<NodeLayer, { label: string; color: string; token: string }> = {
+  file:    { label: 'Files',   color: '#9A8A78', token: 'colorPaletteBrownForeground2' },
+  content: { label: 'Content', color: '#58a6ff', token: 'colorPaletteBlueForeground2' },
+  work:    { label: 'Work',    color: '#d29922', token: 'colorPaletteMarigoldForeground2' },
 };
+
+/**
+ * A theme-aware color carrier: a literal `color` hex (fallback) plus an optional
+ * Fluent CSS-var `token`. Both {@link EdgeTypeStyle} and {@link NODE_LAYER_META}
+ * entries satisfy this, so the resolvers below work for edges, relations, and
+ * node layers alike.
+ */
+export interface TokenizedColor {
+  color: string;
+  token?: string;
+}
+
+/**
+ * CSS color expression for SVG/HTML contexts (legend swatches, inline styles).
+ * Prefers the theme token and degrades to the literal hex when the variable is
+ * unset, so a non-default or host theme recolors the legend with no code change.
+ */
+export function styleColorVar(style: TokenizedColor): string {
+  return style.token ? `var(--${style.token}, ${style.color})` : style.color;
+}
+
+/**
+ * Resolve a concrete color string for canvas rendering, which cannot use
+ * `var()`. Reads the style's Fluent CSS variable from `root` (defaulting to
+ * `document.documentElement`) and returns the literal hex fallback when the
+ * variable is unset, when there is no `token`, or when the DOM is unavailable
+ * (SSR/tests). `root` should be an element inside the active `FluentProvider`
+ * subtree so it inherits that theme's token variables.
+ */
+export function resolveStyleColor(style: TokenizedColor, root?: Element | null): string {
+  if (!style.token) return style.color;
+  const el = root ?? (typeof document !== 'undefined' ? document.documentElement : null);
+  if (!el || typeof getComputedStyle === 'undefined') return style.color;
+  try {
+    const v = getComputedStyle(el).getPropertyValue(`--${style.token}`).trim();
+    return v || style.color;
+  } catch {
+    return style.color;
+  }
+}

--- a/src/representation/styles.ts
+++ b/src/representation/styles.ts
@@ -165,3 +165,26 @@ export function resolveStyleColor(style: TokenizedColor, root?: Element | null):
     return style.color;
   }
 }
+
+/**
+ * Apply an alpha to a resolved color robustly, regardless of its format.
+ *
+ * Edge colors now resolve from theme CSS variables, so a value may be a hex
+ * (`#rrggbb`) OR an `rgb()/rgba()` string (e.g. when a host theme overrides a
+ * token with an `rgb()` value). The old `color + '80'` hex-suffix trick produced
+ * invalid strings like `rgb(…)80` for the non-hex case; this parses both forms
+ * and emits a valid `rgba(...)`, falling back to the original color when it can't
+ * be parsed.
+ */
+export function withAlpha(color: string, alpha: number): string {
+  const hex = /^#([0-9a-fA-F]{6})$/.exec(color.trim());
+  if (hex) {
+    const n = parseInt(hex[1], 16);
+    return `rgba(${(n >> 16) & 0xff}, ${(n >> 8) & 0xff}, ${n & 0xff}, ${alpha})`;
+  }
+  const rgb = /rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/.exec(color);
+  if (rgb) {
+    return `rgba(${rgb[1]}, ${rgb[2]}, ${rgb[3]}, ${alpha})`;
+  }
+  return color;
+}


### PR DESCRIPTION
## What

First two of the canvas host-themeability trio under epic #401 — make the constellation/legend recolor from the active theme (including a Copilot canvas host's mirrored tokens) instead of hardcoded hex.

Closes #402
Closes #403

### #402 — Detokenize `styles.ts`
- `EdgeTypeStyle` gains an optional `token` (a Fluent CSS-var name); each edge/relation entry and every `NODE_LAYER_META` layer now references a theme-adaptive Fluent palette token (`…Foreground2` ramp) with the **current hex kept as the fallback**.
- New resolvers:
  - `styleColorVar(style)` → `var(--token, hex)` for SVG/HTML (legend swatches).
  - `resolveStyleColor(style, root?)` → concrete color read from the theme's CSS var off the FluentProvider subtree (canvas can't use `var()`), degrading to the hex when unset / in SSR/tests.
- Consumers wired through the resolvers: the data-driven HUD legend (SVG stroke) and the `createGraphNetwork` canvas edges (static + focus-emphasis tiers). Legend behavior stays fully data-driven.

### #403 — `nodeRenderer` host theme-source bridge
- Replaces the binary `isDark` flag with a `NodeThemeSource` (`{ isDark, foreground, background, iconColor }`) resolved from `--colorNeutralForeground2` / `--colorNeutralBackground1`, deriving `isDark` from background luminance (handles hex and `rgb()`).
- `createGraphNetwork` resolves the source **once** from the graph container (which inherits the host/Fluent tokens) and threads it through `buildVisNode`. Falls back to the prior dark/light hardcodes when a var is unset.

No cached-data shape, localStorage key, or node/edge-production changes → `CACHE_VERSION` bump not required.

## Testing

- **Unit:** `829 passed` (75 files), incl. new `theme-colors.test.ts` and `nodeRenderer-theme.test.ts` covering var resolution, hex fallback, and luminance-derived isDark.
- **Typecheck:** `tsc --noEmit` clean.
- **Lint:** `eslint .` — 0 errors (3 pre-existing warnings unrelated to this change).
- **Build:** `vite build` succeeds (also local-mode build).
- **Visual (Playwright, real Chromium):** constellation MAP overlay under `dark` / `ocean` / `light`, **zero console errors** in every theme:
  - legend edge-style stroke recolors `rgb(205,214,216)` (dark) → `rgb(59,68,71)` (light)
  - purple palette var recolors `#c6b1de` (dark) → `#341a51` (light)
  - canvas pixel signature recolors dark `17.57M` → light `41.03M` (and dark→ocean `14.90M` via brand), ~66k non-blank px each
  - `VISUAL_VALIDATION: PASS`

  (Named theme `ocean` derives from `base: dark` + a brand seed, so palette-token edge colors intentionally match dark while brand-driven surfaces shift — base-mode and host-token switches drive the edge recolor.)

## Notes
- #404 (host CSS-var → Fluent adapter) is intentionally **not** in this PR — it consumes the presentation-token contract kbexplorer-core#15 and follows once that's published.
- Do not merge — orchestrator reviews + merges (required checks + conversation-resolution-required).
