### PR TITLE
fix: polish constellation rendering (overlap, labels, edges, legend)

### DIFF
--- a/src/components/HUD.tsx
+++ b/src/components/HUD.tsx
@@ -1029,6 +1029,41 @@ export function HUD({ graph, config, currentNodeId, theme, isDark, availableThem
                   ))}
                 </>
               )}
+              {/* Node-identity key — explains what node shape / selection state
+                  encode, which the cluster-colour + edge-type rows above don't
+                  cover (#435). Shapes mirror nodeRenderer's inference: circle =
+                  topic / issue, rounded square = container / structure, rounded
+                  rect = document, plus the selected glow. */}
+              <div style={{ borderTop: `1px solid ${tokens.colorNeutralStroke2}`, margin: '4px 0' }} />
+              {([
+                { key: 'circle', label: 'Topic / issue', shape: 'circle' as const },
+                { key: 'square', label: 'Container / structure', shape: 'square' as const },
+                { key: 'rect', label: 'Document', shape: 'rect' as const },
+                { key: 'selected', label: 'Selected', shape: 'selected' as const },
+              ]).map(({ key, label, shape }) => {
+                const stroke = tokens.colorNeutralForeground2;
+                const fill = tokens.colorNeutralBackground3;
+                return (
+                  <div key={key} data-kbe-legend={`node-${key}`} style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '2px 0' }}>
+                    <svg width={18} height={14} style={{ flexShrink: 0 }} aria-hidden>
+                      {shape === 'circle' && (
+                        <circle cx={9} cy={7} r={5} fill={fill} stroke={stroke} strokeWidth={1.5} />
+                      )}
+                      {shape === 'selected' && (
+                        <circle cx={9} cy={7} r={5} fill={fill} stroke={tokens.colorBrandForeground1} strokeWidth={2}
+                          style={{ filter: `drop-shadow(0 0 2px ${tokens.colorBrandForeground1})` }} />
+                      )}
+                      {shape === 'square' && (
+                        <rect x={3.5} y={1.5} width={11} height={11} rx={2.5} fill={fill} stroke={stroke} strokeWidth={1.5} />
+                      )}
+                      {shape === 'rect' && (
+                        <rect x={1.5} y={3} width={15} height={8} rx={2} fill={fill} stroke={stroke} strokeWidth={1.5} />
+                      )}
+                    </svg>
+                    <Caption1 style={{ color: tokens.colorNeutralForeground2 }}>{label}</Caption1>
+                  </div>
+                );
+              })}
             </div>
             {/* Zoom & Detail sliders */}
             <div style={{

--- a/src/engine/__tests__/labelLayout.test.ts
+++ b/src/engine/__tests__/labelLayout.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { assignLabelPlacements, type LabelItem } from '../labelLayout';
+
+/** Convenience builder with sensible defaults. */
+function item(p: Partial<LabelItem> & { id: string }): LabelItem {
+  return {
+    x: 0, y: 0, radius: 10, width: 40, height: 13, priority: 0,
+    ...p,
+  };
+}
+
+describe('assignLabelPlacements', () => {
+  it('places an isolated label below the node (preferred anchor)', () => {
+    const out = assignLabelPlacements([item({ id: 'a' })]);
+    expect(out.get('a')).toEqual({ anchor: 'below', hidden: false });
+  });
+
+  it('never overlaps a node body with a label', () => {
+    // Two nodes stacked vertically and close: the lower node's body sits where
+    // the upper node's "below" label would go, forcing an alternate anchor.
+    const items = [
+      item({ id: 'top', x: 0, y: 0, radius: 10, width: 60 }),
+      item({ id: 'bottom', x: 0, y: 28, radius: 10, width: 60 }),
+    ];
+    const out = assignLabelPlacements(items);
+    // 'top' cannot go below (bottom node body is there) → must pick another anchor.
+    expect(out.get('top')!.anchor).not.toBe('below');
+    expect(out.get('top')!.hidden).toBe(false);
+  });
+
+  it('resolves two labels that would collide by choosing different anchors', () => {
+    // Two nodes side-by-side; both "below" labels are wide enough to overlap.
+    const items = [
+      item({ id: 'l', x: 0, y: 0, radius: 10, width: 80, priority: 2 }),
+      item({ id: 'r', x: 30, y: 0, radius: 10, width: 80, priority: 1 }),
+    ];
+    const out = assignLabelPlacements(items);
+    // Higher-priority 'l' keeps 'below'; 'r' must move off 'below'.
+    expect(out.get('l')).toEqual({ anchor: 'below', hidden: false });
+    expect(out.get('r')!.anchor).not.toBe('below');
+  });
+
+  it('hides a label when no anchor is collision-free', () => {
+    // Surround the target so every candidate anchor is occupied by a node body.
+    const r = 10;
+    const gap = 6;
+    const off = r + gap + 7; // just inside each candidate label box
+    const items = [
+      item({ id: 'center', x: 0, y: 0, radius: r, width: 30, priority: 5 }),
+      item({ id: 'n', x: 0, y: -off * 2, radius: 30, priority: 0 }),
+      item({ id: 's', x: 0, y: off * 2, radius: 30, priority: 0 }),
+      item({ id: 'e', x: off * 2, y: 0, radius: 30, priority: 0 }),
+      item({ id: 'w', x: -off * 2, y: 0, radius: 30, priority: 0 }),
+    ];
+    const out = assignLabelPlacements(items, { gap });
+    expect(out.get('center')!.hidden).toBe(true);
+  });
+
+  it('treats unlabeled nodes (obstacles) as forbidden too', () => {
+    // One labeled node; an unlabeled node body sits exactly where its "below"
+    // label would land. With the node passed via `obstacles`, the label must move.
+    const labeled = item({ id: 'a', x: 0, y: 0, radius: 10, width: 40 });
+    const obstacles = [
+      { x: 0, y: 0, radius: 10 },       // the labeled node itself
+      { x: 0, y: 30, radius: 14 },      // unlabeled node blocking "below"
+    ];
+    const out = assignLabelPlacements([labeled], { obstacles });
+    expect(out.get('a')!.anchor).not.toBe('below');
+    expect(out.get('a')!.hidden).toBe(false);
+  });
+
+  it('places higher-priority labels first (deterministic)', () => {
+    const items = [
+      item({ id: 'low', x: 0, y: 0, radius: 10, width: 80, priority: 1 }),
+      item({ id: 'high', x: 20, y: 0, radius: 10, width: 80, priority: 9 }),
+    ];
+    const out = assignLabelPlacements(items);
+    // 'high' is placed first and takes the preferred 'below' anchor.
+    expect(out.get('high')).toEqual({ anchor: 'below', hidden: false });
+  });
+
+  it('is order-independent for the input array (sorts internally)', () => {
+    const a = item({ id: 'a', x: 0, y: 0, priority: 5 });
+    const b = item({ id: 'b', x: 200, y: 200, priority: 1 });
+    const out1 = assignLabelPlacements([a, b]);
+    const out2 = assignLabelPlacements([b, a]);
+    expect(out1.get('a')).toEqual(out2.get('a'));
+    expect(out1.get('b')).toEqual(out2.get('b'));
+  });
+});

--- a/src/engine/__tests__/nodeRenderer.test.ts
+++ b/src/engine/__tests__/nodeRenderer.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { createNodeRenderer, type RendererLabelState } from '../nodeRenderer';
+
+/**
+ * Minimal CanvasRenderingContext2D stub — records fillText/strokeText calls and
+ * no-ops every other method the renderer touches. Property assignments (font,
+ * fillStyle, …) are accepted and ignored.
+ */
+function makeCtx() {
+  const fillTexts: string[] = [];
+  const target: Record<string, unknown> = {
+    fillText: (text: string) => { fillTexts.push(String(text)); },
+    strokeText: () => {},
+  };
+  const ctx = new Proxy(target, {
+    get(t, prop: string) {
+      if (prop in t) return t[prop];
+      // Any other accessed method is a no-op.
+      return () => {};
+    },
+    set(t, prop: string, value) { t[prop] = value; return true; },
+  }) as unknown as CanvasRenderingContext2D;
+  return { ctx, fillTexts };
+}
+
+const args = (ctx: CanvasRenderingContext2D) => ({
+  ctx, x: 100, y: 100,
+  state: { selected: false, hover: false },
+  style: { size: 40 },
+});
+
+describe('createNodeRenderer — edge-clip geometry (#435)', () => {
+  it('returns nodeDimensions equal to the drawn circle box, not inflated by the label', () => {
+    const size = 40;
+    const render = createNodeRenderer(undefined, '#aabbcc', size, true, 'A long label here', false);
+    const { ctx } = makeCtx();
+    const out = render(args(ctx));
+    // Circle: width == height == size. Previously height was size + 28 (label box),
+    // which clipped edges to a too-tall rectangle → draw-through.
+    expect(out.nodeDimensions).toEqual({ width: size, height: size });
+  });
+
+  it('keeps the same dimensions whether or not a label is present', () => {
+    const size = 48;
+    const withLabel = createNodeRenderer(undefined, '#aabbcc', size, false, 'hello', false)(args(makeCtx().ctx));
+    const noLabel = createNodeRenderer(undefined, '#aabbcc', size, false, undefined, false)(args(makeCtx().ctx));
+    expect(withLabel.nodeDimensions).toEqual(noLabel.nodeDimensions);
+    expect(withLabel.nodeDimensions!.height).toBe(size);
+  });
+});
+
+describe('createNodeRenderer — label placement (#435)', () => {
+  it('does not paint a label when labelState marks it hidden', () => {
+    const labelState = new Map<string, RendererLabelState>([
+      ['n1', { text: 'secret', anchor: 'below', hidden: true }],
+    ]);
+    const render = createNodeRenderer(undefined, '#aabbcc', 40, true, 'secret', false, {
+      id: 'n1', labelState,
+    });
+    const { ctx, fillTexts } = makeCtx();
+    render(args(ctx));
+    expect(fillTexts).not.toContain('secret');
+  });
+
+  it('paints the full (untruncated) label text when visible', () => {
+    const full = 'A very long node title that used to be truncated';
+    const labelState = new Map<string, RendererLabelState>([
+      ['n1', { text: full, anchor: 'below', hidden: false }],
+    ]);
+    const render = createNodeRenderer(undefined, '#aabbcc', 40, true, full, false, {
+      id: 'n1', labelState,
+    });
+    const { ctx, fillTexts } = makeCtx();
+    render(args(ctx));
+    expect(fillTexts).toContain(full);
+  });
+
+  it('falls back to the static label below when no labelState entry exists', () => {
+    const render = createNodeRenderer(undefined, '#aabbcc', 40, true, 'fallback', false);
+    const { ctx, fillTexts } = makeCtx();
+    render(args(ctx));
+    expect(fillTexts).toContain('fallback');
+  });
+});

--- a/src/engine/__tests__/nodeRenderer.test.ts
+++ b/src/engine/__tests__/nodeRenderer.test.ts
@@ -82,3 +82,55 @@ describe('createNodeRenderer — label placement (#435)', () => {
     expect(fillTexts).toContain('fallback');
   });
 });
+
+describe('createNodeRenderer — focus override (#435)', () => {
+  const selected = (ctx: CanvasRenderingContext2D) => ({
+    ctx, x: 100, y: 100, state: { selected: true, hover: false }, style: { size: 40 },
+  });
+  const hovered = (ctx: CanvasRenderingContext2D) => ({
+    ctx, x: 100, y: 100, state: { selected: false, hover: true }, style: { size: 40 },
+  });
+
+  it('draws the label of a SELECTED node even when collision layout hid it', () => {
+    const full = 'Focused node title';
+    const labelState = new Map<string, RendererLabelState>([
+      ['n1', { text: full, anchor: 'below', hidden: true }],
+    ]);
+    const render = createNodeRenderer(undefined, '#aabbcc', 40, true, full, false, {
+      id: 'n1', labelState,
+    });
+    const { ctx, fillTexts } = makeCtx();
+    render(selected(ctx));
+    expect(fillTexts).toContain(full);
+  });
+
+  it('draws the label of a HOVERED node even when collision layout hid it', () => {
+    const full = 'Hovered node title';
+    const labelState = new Map<string, RendererLabelState>([
+      ['n1', { text: full, anchor: 'below', hidden: true }],
+    ]);
+    const render = createNodeRenderer(undefined, '#aabbcc', 40, true, full, false, {
+      id: 'n1', labelState,
+    });
+    const { ctx, fillTexts } = makeCtx();
+    render(hovered(ctx));
+    expect(fillTexts).toContain(full);
+  });
+
+  it('uses focusLabel for a normally-unlabelled node when selected', () => {
+    // No labelState entry and no static label (LOD-suppressed), but selecting it
+    // must still reveal its full title via focusLabel.
+    const title = 'Low-degree node';
+    const render = createNodeRenderer(undefined, '#aabbcc', 40, true, undefined, false, {
+      id: 'n2', labelState: new Map(), focusLabel: title,
+    });
+    const { ctx, fillTexts } = makeCtx();
+    // Not focused → nothing painted.
+    render(args(ctx));
+    expect(fillTexts).not.toContain(title);
+    // Selected → focusLabel painted.
+    const { ctx: ctx2, fillTexts: ft2 } = makeCtx();
+    render(selected(ctx2));
+    expect(ft2).toContain(title);
+  });
+});

--- a/src/engine/createGraphNetwork.ts
+++ b/src/engine/createGraphNetwork.ts
@@ -4,7 +4,10 @@
  */
 import { Network } from 'vis-network/standalone';
 import { DataSet } from 'vis-data';
-import { createNodeRenderer } from './nodeRenderer';
+import { createNodeRenderer, LABEL_LINE_HEIGHT, getLabelFont, ICON_NODE_SHAPE } from './nodeRenderer';
+import type { RendererLabelState } from './nodeRenderer';
+import { assignLabelPlacements } from './labelLayout';
+import type { LabelItem } from './labelLayout';
 import { getNodeDegrees } from './graph';
 import { computeReportsToLevels } from './reports-to-layout';
 import type { KBGraph } from '../types';
@@ -83,6 +86,17 @@ export interface BuildVisNodeOptions {
    * at all (the LOD that declutters the constellation), not zoom behaviour.
    */
   labelDegreeThreshold?: number;
+  /**
+   * Shared, mutable label-placement map handed to the renderer (#435). When
+   * provided, an eligible node seeds an entry here ({text, anchor:'below',
+   * hidden:false}); the collision-layout pass later rewrites anchor/hidden.
+   */
+  labelState?: Map<string, RendererLabelState>;
+  /**
+   * Sidecar geometry for the collision-layout pass — drawn node radius + shape per
+   * id, captured at build time so the pass needn't recompute sizing.
+   */
+  labelMeta?: Map<string, { radius: number }>;
 }
 
 /**
@@ -101,7 +115,6 @@ export function buildVisNode(
 ): Record<string, unknown> {
   const [minSize, maxSize] = options.nodeSizeRange ?? [44, 64];
   const step = options.nodeSizeStep ?? 4;
-  const maxLen = options.labelMaxLength ?? 25;
 
   const deg = options.degrees.get(node.id) ?? 0;
   const isKey = options.keyNodeIds?.has(node.id) ?? false;
@@ -114,17 +127,41 @@ export function buildVisNode(
   const labelDegThreshold = options.labelDegreeThreshold ?? 2;
   const labelEligible = isKey || deg >= labelDegThreshold;
   const showLabel = (options.showLabel ?? true) && labelEligible;
-  const label = showLabel
-    ? (node.title.length > maxLen ? node.title.substring(0, maxLen - 3) + '...' : node.title)
-    : undefined;
+  // Full, untruncated title — the collision-layout pass hides labels that don't
+  // fit (hide-on-collide) rather than cutting characters, so labels are never
+  // truncated when space allows (#435). `labelMaxLength` is retained on the
+  // options for back-compat but no longer truncates.
+  const label = showLabel ? node.title : undefined;
   const disconnected = options.flagDisconnected && deg === 0;
+
+  const isRect = (node.emoji && ICON_NODE_SHAPE[node.emoji] === 'roundedRect') || false;
+  const radius = (size / 2) * (isRect ? 1.2 : 1);
+
+  // Seed / clear shared label placement so the renderer + layout pass agree.
+  if (options.labelState) {
+    if (label) {
+      const existing = options.labelState.get(node.id);
+      options.labelState.set(node.id, {
+        text: label,
+        anchor: existing?.anchor ?? 'below',
+        hidden: existing?.hidden ?? false,
+      });
+      options.labelMeta?.set(node.id, { radius });
+    } else {
+      options.labelState.delete(node.id);
+      options.labelMeta?.delete(node.id);
+    }
+  }
 
   const result: Record<string, unknown> = {
     id: node.id,
     label: '',
     title: `${node.title}\n${deg} connection${deg === 1 ? '' : 's'}${disconnected ? '\n⚠ Disconnected node' : ''}`,
     shape: 'custom',
-    ctxRenderer: createNodeRenderer(node.emoji, color, size, options.isDark, label, disconnected),
+    ctxRenderer: createNodeRenderer(node.emoji, color, size, options.isDark, label, disconnected, {
+      id: node.id,
+      labelState: options.labelState,
+    }),
     size: size / 2,
     // Audit sidecar: the rendered label is captured inside the ctxRenderer
     // closure and isn't visible through vis-network's public DataSet API.
@@ -183,6 +220,13 @@ export function createGraphNetwork(options: GraphNetworkOptions): GraphNetworkRe
   const clusterColorMap = new Map(graph.clusters.map(c => [c.id, c.color]));
   const keyNodeIds = computeKeyNodes(degrees);
 
+  // Shared label-placement state for the collision-layout pass (#435). The
+  // renderer reads anchor/hidden from here; `recomputeLabels()` rewrites it after
+  // the layout settles and on drag. `labelMeta` carries the drawn node radius so
+  // the pass needn't recompute sizing.
+  const labelState = new Map<string, RendererLabelState>();
+  const labelMeta = new Map<string, { radius: number }>();
+
   // Build set of emphasized node IDs (current + direct neighbors)
   // Skip emphasis if the target node isn't in this graph (e.g. layer filtered out)
   const nodeIdSet = new Set(graph.nodes.map(n => n.id));
@@ -211,6 +255,7 @@ export function createGraphNetwork(options: GraphNetworkOptions): GraphNetworkRe
       degrees, clusterColorMap, isDark, keyNodeIds,
       nodeSizeRange: sizeRange, nodeSizeStep, labelMaxLength,
       flagDisconnected: true,
+      labelState, labelMeta,
       opacity: faded ? fadedOpacity : undefined,
       showLabel: faded ? showFadedLabels : true,
       // Always label direct neighbours of the focused node — without this
@@ -316,6 +361,7 @@ export function createGraphNetwork(options: GraphNetworkOptions): GraphNetworkRe
         degrees, clusterColorMap, isDark, keyNodeIds,
         nodeSizeRange: sizeRange, nodeSizeStep, labelMaxLength,
         flagDisconnected: true,
+        labelState, labelMeta,
         opacity: faded ? fadedOpacity : undefined,
         showLabel: faded ? showFadedLabels : true,
         // Force-label every 1-hop neighbour of the focus regardless of degree
@@ -324,6 +370,8 @@ export function createGraphNetwork(options: GraphNetworkOptions): GraphNetworkRe
       }));
     }
     nodes.update(nodeUpdates);
+    // Re-run label placement against the new label set/visibility.
+    recomputeLabels();
 
     // Update edges — multi-tier importance based on hop distance from focus
     // Tier 0: direct (both endpoints in 1-hop) → full color, full width
@@ -404,6 +452,11 @@ export function createGraphNetwork(options: GraphNetworkOptions): GraphNetworkRe
           springLength: 180,
           springConstant: 0.05,
           damping: 0.6,
+          // Enforce a minimum inter-node gap so node bodies never physically
+          // stack, even with only a handful of nodes (#435). The factor scales
+          // each node's effective repulsion radius by its drawn size, so spacing
+          // tracks the (now label-free) nodeDimensions box.
+          avoidOverlap: 1,
         },
         stabilization: { enabled: true, iterations: 500, updateInterval: 100 },
       };
@@ -472,6 +525,66 @@ export function createGraphNetwork(options: GraphNetworkOptions): GraphNetworkRe
     });
   }
 
+  // --- Label collision-avoidance pass (#435) ---------------------------------
+  // Offscreen 2D context used only to measure label widths with the renderer's
+  // exact font. Guarded for non-DOM (SSR/tests) where it's simply skipped.
+  const measureCtx: CanvasRenderingContext2D | null =
+    typeof document !== 'undefined'
+      ? document.createElement('canvas').getContext('2d')
+      : null;
+
+  /**
+   * Recompute label placement against the settled node positions and write the
+   * result back into the shared `labelState` so the renderer paints each label at
+   * a collision-free anchor (or hides it). Runs in graph-coordinate space (the
+   * space the custom renderer draws in), which is zoom-invariant — the label font
+   * scales with the view, so a single placement is correct at every zoom. No-op
+   * when there's no DOM to measure text or no labels to place.
+   */
+  function recomputeLabels(): void {
+    if (!measureCtx || labelState.size === 0) return;
+    measureCtx.font = getLabelFont();
+    const positions = network.getPositions();
+    // Every node body is an obstacle (incl. unlabeled nodes), so a label is never
+    // drawn over a node that carries no label of its own (#435).
+    const obstacles: { x: number; y: number; radius: number }[] = [];
+    for (const n of graph.nodes) {
+      const pos = positions[n.id] as { x: number; y: number } | undefined;
+      if (!pos) continue;
+      const vis = nodes.get(n.id) as { size?: number } | null;
+      const radius = labelMeta.get(n.id)?.radius ?? (vis?.size ?? 22);
+      obstacles.push({ x: pos.x, y: pos.y, radius });
+    }
+    const items: LabelItem[] = [];
+    for (const [id, st] of labelState) {
+      if (!st.text) continue;
+      const pos = positions[id] as { x: number; y: number } | undefined;
+      if (!pos) continue;
+      const radius = labelMeta.get(id)?.radius ?? 22;
+      const width = measureCtx.measureText(st.text).width;
+      // Key/high-degree nodes keep their labels first when space is tight.
+      const deg = degrees.get(id) ?? 0;
+      const priority = (keyNodeIds.has(id) ? 1000 : 0) + deg;
+      items.push({ id, x: pos.x, y: pos.y, radius, width, height: LABEL_LINE_HEIGHT, priority });
+    }
+    const placements = assignLabelPlacements(items, { obstacles });
+    let changed = false;
+    for (const [id, p] of placements) {
+      const st = labelState.get(id);
+      if (!st) continue;
+      if (st.anchor !== p.anchor || st.hidden !== p.hidden) {
+        st.anchor = p.anchor;
+        st.hidden = p.hidden;
+        changed = true;
+      }
+    }
+    if (changed) network.redraw();
+  }
+
+  // Re-place labels whenever positions settle or a node is dragged.
+  network.on('stabilized', recomputeLabels);
+  network.on('dragEnd', recomputeLabels);
+
   // Belt-and-suspenders: also kill physics on iteration done
   network.on('stabilizationIterationsDone', () => {
     network.setOptions({ physics: { enabled: false } });
@@ -495,6 +608,10 @@ export function createGraphNetwork(options: GraphNetworkOptions): GraphNetworkRe
     finalized = true;
     // Kill physics immediately — no more drifting
     network.setOptions({ physics: { enabled: false } });
+
+    // Place labels against the final positions (covers the hierarchical path,
+    // where `stabilized` never fires, and guarantees a pass before first paint).
+    recomputeLabels();
 
     // Compute bounding box of all nodes for pan clamping
     const allPositions = network.getPositions();
@@ -632,7 +749,7 @@ export function createGraphNetwork(options: GraphNetworkOptions): GraphNetworkRe
   };
 
   if (auditSlot) {
-    registerNetworkForAudit(network, container, auditSlot);
+    registerNetworkForAudit(network, container, auditSlot, labelState);
   }
 
   return { network, nodes, edges, setEmphasis };
@@ -647,15 +764,26 @@ export function createGraphNetwork(options: GraphNetworkOptions): GraphNetworkRe
  *
  * Used by `scripts/audit-visual.mjs` to assert on label coverage, node-to-
  * label ratio, and edge visibility on the actually-rendered constellation.
+ * `labelState` is the live collision-layout map so audits can assert on label
+ * placement/visibility (#435).
  */
-function registerNetworkForAudit(network: Network, container: HTMLElement, slot: string) {
+function registerNetworkForAudit(
+  network: Network,
+  container: HTMLElement,
+  slot: string,
+  labelState?: Map<string, RendererLabelState>,
+) {
   if (typeof window === 'undefined') return;
   type AuditWindow = Window & {
-    __kbeNetworks?: Record<string, { network: Network; container: HTMLElement }>;
+    __kbeNetworks?: Record<string, {
+      network: Network;
+      container: HTMLElement;
+      labelState?: Map<string, RendererLabelState>;
+    }>;
   };
   const w = window as AuditWindow;
   if (!w.__kbeNetworks) w.__kbeNetworks = {};
-  w.__kbeNetworks[slot] = { network, container };
+  w.__kbeNetworks[slot] = { network, container, labelState };
 }
 
 /**
@@ -698,6 +826,9 @@ export function computeGraphPositions(
         springLength: 180,
         springConstant: 0.05,
         damping: 0.6,
+        // Match the live constellation so minimap positions enforce the same
+        // minimum inter-node gap (#435).
+        avoidOverlap: 1,
       },
       stabilization: { iterations: 150 },
     },

--- a/src/engine/createGraphNetwork.ts
+++ b/src/engine/createGraphNetwork.ts
@@ -165,6 +165,7 @@ export function buildVisNode(
     ctxRenderer: createNodeRenderer(node.emoji, color, size, options.isDark, label, disconnected, {
       id: node.id,
       labelState: options.labelState,
+      focusLabel: node.title,
     }),
     size: size / 2,
     // Audit sidecar: the rendered label is captured inside the ctxRenderer
@@ -566,9 +567,12 @@ export function createGraphNetwork(options: GraphNetworkOptions): GraphNetworkRe
       if (!pos) continue;
       const radius = labelMeta.get(id)?.radius ?? 22;
       const width = measureCtx.measureText(st.text).width;
-      // Key/high-degree nodes keep their labels first when space is tight.
+      // Key/high-degree nodes keep their labels first when space is tight; the
+      // hovered/selected node is placed first of all so it's never hidden (#435).
       const deg = degrees.get(id) ?? 0;
-      const priority = (keyNodeIds.has(id) ? 1000 : 0) + deg;
+      const priority = id === activeLabelId
+        ? Number.MAX_SAFE_INTEGER
+        : (keyNodeIds.has(id) ? 1000 : 0) + deg;
       items.push({ id, x: pos.x, y: pos.y, radius, width, height: LABEL_LINE_HEIGHT, priority });
     }
     const placements = assignLabelPlacements(items, { obstacles });
@@ -576,14 +580,33 @@ export function createGraphNetwork(options: GraphNetworkOptions): GraphNetworkRe
     for (const [id, p] of placements) {
       const st = labelState.get(id);
       if (!st) continue;
-      if (st.anchor !== p.anchor || st.hidden !== p.hidden) {
+      // The active node never hides — the renderer also force-draws it, but keep
+      // labelState consistent so a later redraw doesn't flicker it off.
+      const hidden = id === activeLabelId ? false : p.hidden;
+      if (st.anchor !== p.anchor || st.hidden !== hidden) {
         st.anchor = p.anchor;
-        st.hidden = p.hidden;
+        st.hidden = hidden;
         changed = true;
       }
     }
     if (changed) network.redraw();
   }
+
+  // Track the hovered/selected node so its label is placed first and never
+  // hidden. The renderer also force-draws a focused node from `state`, but
+  // tracking the id lets the layout pass give it a collision-free anchor and
+  // reflow neighbours around it.
+  let activeLabelId: string | null = null;
+  const setActiveLabel = (id: string | null) => {
+    if (activeLabelId === id) return;
+    activeLabelId = id;
+    recomputeLabels();
+    network.redraw();
+  };
+  network.on('hoverNode', (p: { node: string }) => setActiveLabel(p.node));
+  network.on('blurNode', () => setActiveLabel(null));
+  network.on('selectNode', (p: { nodes: string[] }) => setActiveLabel(p.nodes?.[0] ?? null));
+  network.on('deselectNode', () => setActiveLabel(null));
 
   // Re-place labels whenever positions settle or a node is dragged.
   network.on('stabilized', recomputeLabels);

--- a/src/engine/createGraphNetwork.ts
+++ b/src/engine/createGraphNetwork.ts
@@ -137,6 +137,12 @@ export function buildVisNode(
   const isRect = (node.emoji && ICON_NODE_SHAPE[node.emoji] === 'roundedRect') || false;
   const radius = (size / 2) * (isRect ? 1.2 : 1);
 
+  // Record the drawn radius for EVERY node (labelled or not) so the collision
+  // pass has an accurate per-shape obstacle radius — unlabeled rounded-rect nodes
+  // would otherwise fall back to `vis.size` and be under-sized, letting a label
+  // sit partly over their body.
+  options.labelMeta?.set(node.id, { radius });
+
   // Seed / clear shared label placement so the renderer + layout pass agree.
   if (options.labelState) {
     if (label) {
@@ -146,10 +152,8 @@ export function buildVisNode(
         anchor: existing?.anchor ?? 'below',
         hidden: existing?.hidden ?? false,
       });
-      options.labelMeta?.set(node.id, { radius });
     } else {
       options.labelState.delete(node.id);
-      options.labelMeta?.delete(node.id);
     }
   }
 
@@ -749,7 +753,7 @@ export function createGraphNetwork(options: GraphNetworkOptions): GraphNetworkRe
   };
 
   if (auditSlot) {
-    registerNetworkForAudit(network, container, auditSlot, labelState);
+    registerNetworkForAudit(network, container, auditSlot, labelState, labelMeta);
   }
 
   return { network, nodes, edges, setEmphasis };
@@ -764,14 +768,15 @@ export function createGraphNetwork(options: GraphNetworkOptions): GraphNetworkRe
  *
  * Used by `scripts/audit-visual.mjs` to assert on label coverage, node-to-
  * label ratio, and edge visibility on the actually-rendered constellation.
- * `labelState` is the live collision-layout map so audits can assert on label
- * placement/visibility (#435).
+ * `labelState` / `labelMeta` are the live collision-layout maps so audits can
+ * assert on label placement/visibility and per-node geometry (#435).
  */
 function registerNetworkForAudit(
   network: Network,
   container: HTMLElement,
   slot: string,
   labelState?: Map<string, RendererLabelState>,
+  labelMeta?: Map<string, { radius: number }>,
 ) {
   if (typeof window === 'undefined') return;
   type AuditWindow = Window & {
@@ -779,11 +784,12 @@ function registerNetworkForAudit(
       network: Network;
       container: HTMLElement;
       labelState?: Map<string, RendererLabelState>;
+      labelMeta?: Map<string, { radius: number }>;
     }>;
   };
   const w = window as AuditWindow;
   if (!w.__kbeNetworks) w.__kbeNetworks = {};
-  w.__kbeNetworks[slot] = { network, container, labelState };
+  w.__kbeNetworks[slot] = { network, container, labelState, labelMeta };
 }
 
 /**

--- a/src/engine/labelLayout.ts
+++ b/src/engine/labelLayout.ts
@@ -1,0 +1,154 @@
+/**
+ * Label-collision layout for the force-directed constellation.
+ *
+ * vis-network draws node labels at a fixed offset with no neighbour awareness, so
+ * adjacent labels overwrite each other while also being truncated (#435). This
+ * module computes a collision-aware placement for each label in *screen space*
+ * (post-layout, zoom-aware): each label tries a set of candidate anchors around its
+ * node and takes the first that doesn't overlap an already-occupied rectangle (node
+ * bodies + already-placed labels). If none fit, the label is hidden rather than
+ * truncated — "labels at the current zoom level are not truncated when space allows;
+ * placement avoids collisions (offset/anchor selection or hide-on-collide)".
+ *
+ * The function is pure and unit-testable: callers supply measured pixel geometry and
+ * a text-size for each item; no DOM/canvas dependency lives here.
+ */
+
+export type LabelAnchor = 'below' | 'above' | 'left' | 'right';
+
+export interface LabelItem {
+  id: string;
+  /** Node centre, screen pixels. */
+  x: number;
+  y: number;
+  /** Node radius, screen pixels (half the larger of the drawn width/height). */
+  radius: number;
+  /** Measured label width, screen pixels. */
+  width: number;
+  /** Label line height, screen pixels. */
+  height: number;
+  /**
+   * Placement priority — higher wins ties and is placed first, so prominent nodes
+   * (key/high-degree, or the focused node) keep their labels when space is tight.
+   */
+  priority: number;
+}
+
+export interface LabelPlacement {
+  anchor: LabelAnchor;
+  hidden: boolean;
+}
+
+export interface AssignLabelOptions {
+  /** Gap between the node border and the label box, screen pixels. Default 6. */
+  gap?: number;
+  /**
+   * Anchor order to try, most-preferred first. Default: below, above, right, left.
+   * Stops at the first non-overlapping candidate.
+   */
+  anchors?: LabelAnchor[];
+  /**
+   * Extra padding added around each label box when testing for overlap, screen
+   * pixels. A little breathing room so labels don't kiss. Default 2.
+   */
+  padding?: number;
+  /**
+   * All node bodies that labels must avoid, as `{x, y, radius}` (screen pixels).
+   * This MUST include unlabeled nodes too — otherwise a label could be placed over
+   * a node that carries no label of its own. When omitted, the labelled `items`
+   * themselves are used as the obstacle set (back-compat).
+   */
+  obstacles?: { x: number; y: number; radius: number }[];
+}
+
+interface Rect {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+}
+
+function rectsOverlap(a: Rect, b: Rect): boolean {
+  return a.left < b.right && a.right > b.left && a.top < b.bottom && a.bottom > b.top;
+}
+
+/** Bounding box of the label box for a given anchor around the node. */
+function labelRect(item: LabelItem, anchor: LabelAnchor, gap: number, pad: number): Rect {
+  const w = item.width + pad * 2;
+  const h = item.height + pad * 2;
+  const r = item.radius;
+  switch (anchor) {
+    case 'below': {
+      const top = item.y + r + gap;
+      return { left: item.x - w / 2, right: item.x + w / 2, top, bottom: top + h };
+    }
+    case 'above': {
+      const bottom = item.y - r - gap;
+      return { left: item.x - w / 2, right: item.x + w / 2, top: bottom - h, bottom };
+    }
+    case 'right': {
+      const left = item.x + r + gap;
+      return { left, right: left + w, top: item.y - h / 2, bottom: item.y + h / 2 };
+    }
+    case 'left': {
+      const right = item.x - r - gap;
+      return { left: right - w, right, top: item.y - h / 2, bottom: item.y + h / 2 };
+    }
+  }
+}
+
+/** Bounding square of a node body (radius in screen pixels). */
+function nodeRect(item: { x: number; y: number; radius: number }): Rect {
+  return {
+    left: item.x - item.radius,
+    right: item.x + item.radius,
+    top: item.y - item.radius,
+    bottom: item.y + item.radius,
+  };
+}
+
+/**
+ * Assign a collision-free placement to each label, or hide it.
+ *
+ * Greedy: items are placed in descending priority order (ties broken by id for
+ * determinism). Occupied space starts as every node body, then each accepted label
+ * box is added. For each item we try the configured anchors in order and accept the
+ * first whose box clears all occupied rects; if none clear, the label is hidden.
+ */
+export function assignLabelPlacements(
+  items: LabelItem[],
+  options: AssignLabelOptions = {},
+): Map<string, LabelPlacement> {
+  const gap = options.gap ?? 6;
+  const pad = options.padding ?? 2;
+  const anchors = options.anchors ?? ['below', 'above', 'right', 'left'];
+
+  const result = new Map<string, LabelPlacement>();
+
+  // Every node body is a permanent obstacle — labels never overlap a node, even
+  // an unlabeled one. Callers should pass the full node set via `obstacles`; we
+  // fall back to the labelled items when omitted.
+  const occupied: Rect[] = (options.obstacles ?? items).map(nodeRect);
+
+  const ordered = [...items].sort((a, b) =>
+    b.priority - a.priority || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0),
+  );
+
+  for (const item of ordered) {
+    let placed: LabelAnchor | null = null;
+    for (const anchor of anchors) {
+      const rect = labelRect(item, anchor, gap, pad);
+      if (!occupied.some(o => rectsOverlap(rect, o))) {
+        placed = anchor;
+        occupied.push(rect);
+        break;
+      }
+    }
+    result.set(
+      item.id,
+      placed ? { anchor: placed, hidden: false } : { anchor: anchors[0], hidden: true },
+    );
+  }
+
+  return result;
+}

--- a/src/engine/nodeRenderer.ts
+++ b/src/engine/nodeRenderer.ts
@@ -2679,6 +2679,39 @@ interface CtxRendererArgs {
   style: { size: number };
 }
 
+/** Per-node, mutable label placement shared with the collision-layout pass (#435). */
+export interface RendererLabelState {
+  /** Full label text (untruncated). */
+  text: string;
+  /** Which side of the node the label is drawn on. */
+  anchor: 'below' | 'above' | 'left' | 'right';
+  /** When true the label is suppressed (hide-on-collide) rather than truncated. */
+  hidden: boolean;
+}
+
+export interface NodeRendererOptions {
+  /** Node id — used to look up live placement in `labelState`. */
+  id?: string;
+  /**
+   * Shared, mutable placement map updated by the label-collision pass. When an
+   * entry exists for `id` the renderer draws the label at that anchor (or not at
+   * all when hidden); otherwise it falls back to the static `label` argument drawn
+   * below the node (back-compat for callers without a layout pass).
+   */
+  labelState?: Map<string, RendererLabelState>;
+}
+
+const LABEL_FONT = '11px "Segoe UI", system-ui, sans-serif';
+/** Vertical gap between node border and an above/below label, in canvas units. */
+const LABEL_GAP = 6;
+/** Single label line height in canvas units (matches LABEL_FONT). */
+export const LABEL_LINE_HEIGHT = 13;
+
+/** Font used by the renderer for labels — exported so the layout pass measures identically. */
+export function getLabelFont(): string {
+  return LABEL_FONT;
+}
+
 /**
  * Creates a ctxRenderer function for a vis-network custom node.
  */
@@ -2689,6 +2722,7 @@ export function createNodeRenderer(
   isDark: boolean,
   label?: string,
   disconnected?: boolean,
+  opts?: NodeRendererOptions,
 ){
   const shapeType: NodeShapeType = (iconName && ICON_NODE_SHAPE[iconName]) || 'circle';
   const iconColor = isDark ? 'rgba(255,255,255,0.9)' : 'rgba(0,0,0,0.85)';
@@ -2759,30 +2793,57 @@ export function createNodeRenderer(
       ctx.fillText('!', wx, wy + 0.5);
     }
 
-    // Draw label below shape
-    if (label) {
-      const labelY = y + s / 2 + 14;
-      ctx.font = '11px "Segoe UI", system-ui, sans-serif';
+    // Draw label — placement comes from the shared collision-layout pass when
+    // available (anchor + hide-on-collide, no truncation), else falls back to a
+    // static label drawn below the node. The label box is intentionally NOT part
+    // of `nodeDimensions` so edges clip to the node body, not the label (#435).
+    const id = opts?.id;
+    const live = id != null ? opts?.labelState?.get(id) : undefined;
+    const labelText = live ? live.text : label;
+    const labelHidden = live ? live.hidden : false;
+    const labelAnchor = live ? live.anchor : 'below';
+    if (labelText && !labelHidden) {
+      ctx.font = LABEL_FONT;
       ctx.textAlign = 'center';
       ctx.textBaseline = 'top';
+      let lx = x;
+      let ly: number;
+      if (labelAnchor === 'above') {
+        ctx.textBaseline = 'bottom';
+        ly = y - s / 2 - LABEL_GAP;
+      } else if (labelAnchor === 'left') {
+        ctx.textAlign = 'right';
+        ctx.textBaseline = 'middle';
+        lx = x - (shapeType === 'roundedRect' ? s * 0.6 : s / 2) - LABEL_GAP;
+        ly = y;
+      } else if (labelAnchor === 'right') {
+        ctx.textAlign = 'left';
+        ctx.textBaseline = 'middle';
+        lx = x + (shapeType === 'roundedRect' ? s * 0.6 : s / 2) + LABEL_GAP;
+        ly = y;
+      } else {
+        ly = y + s / 2 + LABEL_GAP;
+      }
       // Stroke for legibility
       ctx.strokeStyle = labelStroke;
       ctx.lineWidth = 3;
       ctx.lineJoin = 'round';
-      ctx.strokeText(label, x, labelY);
+      ctx.strokeText(labelText, lx, ly);
       // Fill
       ctx.fillStyle = labelColor;
-      ctx.fillText(label, x, labelY);
+      ctx.fillText(labelText, lx, ly);
     }
 
     ctx.restore();
 
     const w = shapeType === 'roundedRect' ? s * 1.2 : s;
-    const totalH = label ? s + 28 : s;
+    // nodeDimensions is the edge-clip / overlap box: keep it to the drawn shape so
+    // vis-network terminates edges at the visible border (was `s + 28`, inflated by
+    // the label, which clipped edges to a too-tall box → draw-through, #435).
     return {
       drawNode: undefined,
       drawExternalLabel: undefined,
-      nodeDimensions: { width: w, height: totalH },
+      nodeDimensions: { width: w, height: s },
     };
   };
 }

--- a/src/engine/nodeRenderer.ts
+++ b/src/engine/nodeRenderer.ts
@@ -2699,6 +2699,13 @@ export interface NodeRendererOptions {
    * below the node (back-compat for callers without a layout pass).
    */
   labelState?: Map<string, RendererLabelState>;
+  /**
+   * Full node title used only when the node is selected/hovered, so a focused
+   * node always shows its label even if it's normally unlabelled or was hidden by
+   * the collision pass (#435). Distinct from the normal-path `label`, which stays
+   * subject to LOD + hide-on-collide.
+   */
+  focusLabel?: string;
 }
 
 const LABEL_FONT = '11px "Segoe UI", system-ui, sans-serif';
@@ -2799,24 +2806,33 @@ export function createNodeRenderer(
     // of `nodeDimensions` so edges clip to the node body, not the label (#435).
     const id = opts?.id;
     const live = id != null ? opts?.labelState?.get(id) : undefined;
-    const labelText = live ? live.text : label;
+    const baseText = live ? live.text : label;
     const labelHidden = live ? live.hidden : false;
     const labelAnchor = live ? live.anchor : 'below';
-    if (labelText && !labelHidden) {
+    // A selected or hovered node ALWAYS shows its full label, overriding both LOD
+    // (it may be normally unlabelled) and hide-on-collide, so the focused node is
+    // never left anonymous (#435). When forced, fall back to the 'below' anchor.
+    const focused = state.selected || state.hover;
+    const focusText = baseText || (focused ? opts?.focusLabel : undefined);
+    const forced = focused && (!baseText || labelHidden);
+    const drawLabel = forced ? !!focusText : !!baseText && !labelHidden;
+    const labelText = forced ? focusText : baseText;
+    const effectiveAnchor = forced ? 'below' : labelAnchor;
+    if (drawLabel && labelText) {
       ctx.font = LABEL_FONT;
       ctx.textAlign = 'center';
       ctx.textBaseline = 'top';
       let lx = x;
       let ly: number;
-      if (labelAnchor === 'above') {
+      if (effectiveAnchor === 'above') {
         ctx.textBaseline = 'bottom';
         ly = y - s / 2 - LABEL_GAP;
-      } else if (labelAnchor === 'left') {
+      } else if (effectiveAnchor === 'left') {
         ctx.textAlign = 'right';
         ctx.textBaseline = 'middle';
         lx = x - (shapeType === 'roundedRect' ? s * 0.6 : s / 2) - LABEL_GAP;
         ly = y;
-      } else if (labelAnchor === 'right') {
+      } else if (effectiveAnchor === 'right') {
         ctx.textAlign = 'left';
         ctx.textBaseline = 'middle';
         lx = x + (shapeType === 'roundedRect' ? s * 0.6 : s / 2) + LABEL_GAP;


### PR DESCRIPTION
## Summary

Fixes the four visual-craft defects in the force-directed constellation (vis-network) called out in #435 — all visible even at very low node counts.

| Defect | Fix |
| --- | --- |
| **1. Node overlap** | Enable `forceAtlas2Based.avoidOverlap: 1` in both the live network and the `computeGraphPositions` minimap pass, enforcing a minimum inter-node gap. |
| **2. Label collision + truncation** | New pure module `src/engine/labelLayout.ts` (`assignLabelPlacements`) does greedy, priority-ordered **anchor selection** (below → above → right → left) with **hide-on-collide** against *all* node bodies (incl. unlabeled) and already-placed labels. The renderer reads a shared mutable `labelState`; labels are **no longer hard-truncated** (full title), and are re-placed after layout settles and on drag. |
| **3. Edges through node bodies** | The custom node's `nodeDimensions` no longer inflates `height` by the label box (`s + 28` → `s`). vis-network clips custom-shape edges to a rectangle derived from `width`/`height`, so the inflated box made edges terminate in the wrong place. Now they clip to the visible node border. |
| **4. No legend for visual identity** | The overlay legend now has a node-identity section explaining shape (circle = topic/issue, rounded-square = container/structure, rounded-rect = document) and the selected glow, alongside the existing cluster/edge keys. |

## Why these levers

- D1 and D3 are fixed through vis-network's own options (`avoidOverlap`, honest `nodeDimensions`) per the issue's preference.
- D2 (label collision avoidance) has **no** native vis-network support, so it's a minimal custom layer: a pure, unit-tested placement function plus a post-layout pass wired into the shared graph factory (so HUD sidebar, HUD overlay, ConstellationHero and HomePage all benefit).

## Verification

**Browser (Playwright vs dev server), introspecting the live network + `labelState`:**

| Detail | Nodes | Node overlaps | Label–label collisions | Label–node collisions | Labels |
| --- | --- | --- | --- | --- | --- |
| min (issue repro) | 5 | 0 | 0 | 0 | 5 shown, full |
| default | 40 | 0 | 0 | 0 | 13 shown, 3 hidden-on-collide |
| max | 100 | 1 near-tangent pair* | 0 | 0 | 26 shown, 4 hidden |

\* `avoidOverlap` is already at its max (1); a single marginal touch at 100 nodes is far above the "handful of nodes / default zoom" acceptance bar, where spacing is clean.

Dark + light screenshots confirm edges terminating at node borders, full untruncated labels with no collisions, and the new legend.

**CI-equivalent locally:** `tsc -b`, `eslint .` (0 errors), `vitest run` (828 passing, incl. new tests), `vite build` all green.

## Tests added
- `src/engine/__tests__/labelLayout.test.ts` — anchor selection, hide-on-collide, obstacle (unlabeled-node) avoidance, priority ordering, order-independence, no-overlap invariant.
- `src/engine/__tests__/nodeRenderer.test.ts` — `nodeDimensions` equals the drawn shape box (not inflated by the label), locking the edge-clip geometry; label hidden/visible/fallback behavior.

## Notes
- **CACHE_VERSION**: render-only change (physics, label placement, edge geometry, legend); no cached node/edge/localStorage data shape changes → **no bump** (per repo convention).

Closes #435