### PR TITLE
feat: host CSS-var to Fluent theme adapter + inherit-host mode (#404)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "kbexplorer-template",
       "version": "0.3.0",
       "dependencies": {
-        "@anokye-labs/kbexplorer-core": "github:anokye-labs/kbexplorer-core#v0.1.0",
+        "@anokye-labs/kbexplorer-core": "github:anokye-labs/kbexplorer-core#v0.2.0",
         "@anokye-labs/kbexplorer-provider-rich-markdown": "github:anokye-labs/kbexplorer-provider-rich-markdown#v0.1.0",
         "@fluentui/react-components": "^9.74.2",
         "@fluentui/react-icons": "^2.0.323",
@@ -57,8 +57,8 @@
       }
     },
     "node_modules/@anokye-labs/kbexplorer-core": {
-      "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/anokye-labs/kbexplorer-core.git#2ce200b95287fe1780befbc5180743928008b2c1",
+      "version": "0.2.0",
+      "resolved": "git+ssh://git@github.com/anokye-labs/kbexplorer-core.git#c0f98102b7010ea581794fc0acaea5c20536ee26",
       "license": "MIT",
       "engines": {
         "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "explore:dtu": "node scripts/explore-dtu.mjs"
   },
   "dependencies": {
-    "@anokye-labs/kbexplorer-core": "github:anokye-labs/kbexplorer-core#v0.1.0",
+    "@anokye-labs/kbexplorer-core": "github:anokye-labs/kbexplorer-core#v0.2.0",
     "@anokye-labs/kbexplorer-provider-rich-markdown": "github:anokye-labs/kbexplorer-provider-rich-markdown#v0.1.0",
     "@fluentui/react-components": "^9.74.2",
     "@fluentui/react-icons": "^2.0.323",

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback } from 'react';
-import type { KBConfig, FluentBrandRamp, FluentBrandRampKey } from '../types';
+import type { KBConfig, FluentBrandRamp, FluentBrandRampKey, PresentationTokens } from '../types';
 import {
   webDarkTheme,
   webLightTheme,
@@ -276,7 +276,7 @@ export function useTheme(): [
     // its look by resolving a Fluent theme from those vars (with the published
     // PresentationTokens intent knobs from config). Registered last so a real
     // host theme is always available; absent host vars ⇒ null ⇒ no-op.
-    const hostPresentation = (theme as { presentation?: import('@anokye-labs/kbexplorer-core').PresentationTokens } | undefined)?.presentation;
+    const hostPresentation = (theme as { presentation?: PresentationTokens } | undefined)?.presentation;
     const hostTheme = resolveHostFluentTheme(
       typeof document !== 'undefined' ? document.documentElement : null,
       hostPresentation,

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -9,6 +9,16 @@ import {
   type BrandVariants,
 } from '@fluentui/react-components';
 import { generateBrandVariants } from '../theme/brandRamp';
+import { resolveHostFluentTheme } from '../theme/hostTheme';
+
+/**
+ * Theme key for the host-inherited Fluent theme (#404). When the SPA is embedded
+ * in a canvas host that mirrors semantic CSS vars (`--background-color-default`,
+ * `--text-color-*`, `--font-*`), `applyConfig` resolves a Fluent theme from them
+ * via {@link resolveHostFluentTheme} and registers it under this key so it joins
+ * the selectable set / `t`-cycle and can be persisted like any other theme.
+ */
+export const INHERIT_HOST_MODE = 'inherit-host';
 
 /**
  * A selectable theme key. The three built-ins (dark/light/sepia) are always
@@ -262,6 +272,16 @@ export function useTheme(): [
   // same name. Absent/empty ⇒ the map equals the config-only result (no-op).
   const applyConfig = useCallback((theme?: KBConfig['theme'], moduleThemes?: Record<string, FluentTheme>) => {
     const map = { ...buildThemeMap(theme), ...(moduleThemes ?? {}) };
+    // #404: when embedded in a canvas host that mirrors semantic CSS vars, adopt
+    // its look by resolving a Fluent theme from those vars (with the published
+    // PresentationTokens intent knobs from config). Registered last so a real
+    // host theme is always available; absent host vars ⇒ null ⇒ no-op.
+    const hostPresentation = (theme as { presentation?: import('@anokye-labs/kbexplorer-core').PresentationTokens } | undefined)?.presentation;
+    const hostTheme = resolveHostFluentTheme(
+      typeof document !== 'undefined' ? document.documentElement : null,
+      hostPresentation,
+    );
+    if (hostTheme) map[INHERIT_HOST_MODE] = hostTheme;
     setThemeMap(map);
     const modes = modesForMap(map);
     const stored = readStoredRaw(modes);

--- a/src/theme/__tests__/color.test.ts
+++ b/src/theme/__tests__/color.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { parseColor, normalizeColorToHex, colorIsDark } from '../color';
+
+describe('parseColor', () => {
+  it('parses short hex (#rgb)', () => {
+    expect(parseColor('#fff')).toEqual({ r: 255, g: 255, b: 255 });
+    expect(parseColor('#0af')).toEqual({ r: 0, g: 170, b: 255 });
+  });
+  it('parses full hex (#rrggbb)', () => {
+    expect(parseColor('#0d1117')).toEqual({ r: 13, g: 17, b: 23 });
+  });
+  it('parses comma- and space-separated rgb()/rgba()', () => {
+    expect(parseColor('rgb(47, 129, 247)')).toEqual({ r: 47, g: 129, b: 247 });
+    expect(parseColor('rgba(20, 20, 24, 0.5)')).toEqual({ r: 20, g: 20, b: 24 });
+    expect(parseColor('rgb(245 245 245)')).toEqual({ r: 245, g: 245, b: 245 });
+  });
+  it('returns null for unrecognized syntaxes', () => {
+    expect(parseColor('rebeccapurple')).toBeNull();
+    expect(parseColor('hsl(200,50%,50%)')).toBeNull();
+  });
+});
+
+describe('normalizeColorToHex', () => {
+  it('normalizes short hex and rgb() to #rrggbb', () => {
+    expect(normalizeColorToHex('#fff')).toBe('#ffffff');
+    expect(normalizeColorToHex('#0af')).toBe('#00aaff');
+    expect(normalizeColorToHex('rgb(47, 129, 247)')).toBe('#2f81f7');
+    expect(normalizeColorToHex('#0D1117')).toBe('#0d1117');
+  });
+  it('returns null when it cannot parse', () => {
+    expect(normalizeColorToHex('not-a-color')).toBeNull();
+  });
+});
+
+describe('colorIsDark', () => {
+  it('classifies short-hex and rgb() colors by luminance', () => {
+    expect(colorIsDark('#000')).toBe(true);
+    expect(colorIsDark('#fff')).toBe(false);
+    expect(colorIsDark('rgb(13, 17, 23)')).toBe(true);
+    expect(colorIsDark('rgb(245, 245, 245)')).toBe(false);
+  });
+  it('returns null for an unparseable color', () => {
+    expect(colorIsDark('chartreuse')).toBeNull();
+  });
+});

--- a/src/theme/__tests__/hostTheme.test.ts
+++ b/src/theme/__tests__/hostTheme.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from 'vitest';
+import {
+  readHostSignals,
+  hasHostTheme,
+  hostSignalsToFluentTheme,
+  resolveHostFluentTheme,
+  HOST_VAR_CANDIDATES,
+  type CssVarReader,
+} from '../hostTheme';
+
+/** Build a CssVarReader from a plain { '--name': value } map. */
+function reader(map: Record<string, string>): CssVarReader {
+  return name => map[name] ?? '';
+}
+
+describe('readHostSignals / hasHostTheme', () => {
+  it('reads each signal from its primary var name', () => {
+    const s = readHostSignals(reader({
+      '--background-color-default': '#0d1117',
+      '--text-color-default': '#e6edf3',
+      '--text-color-muted': '#8b949e',
+      '--text-color-link': '#2f81f7',
+      '--font-sans': 'Inter, sans-serif',
+      '--font-mono': 'JetBrains Mono, monospace',
+    }));
+    expect(s).toEqual({
+      background: '#0d1117',
+      foreground: '#e6edf3',
+      foregroundMuted: '#8b949e',
+      accent: '#2f81f7',
+      fontSans: 'Inter, sans-serif',
+      fontMono: 'JetBrains Mono, monospace',
+    });
+    expect(hasHostTheme(s)).toBe(true);
+  });
+
+  it('falls back to alias var names when the primary is unset', () => {
+    const s = readHostSignals(reader({
+      '--bgColor-default': '#ffffff',
+      '--fgColor-default': '#1f2328',
+    }));
+    expect(s.background).toBe('#ffffff');
+    expect(s.foreground).toBe('#1f2328');
+  });
+
+  it('treats font-only / accent-only signals as no host theme', () => {
+    expect(hasHostTheme(readHostSignals(reader({ '--font-sans': 'Inter' })))).toBe(false);
+    expect(hasHostTheme(readHostSignals(reader({ '--text-color-link': '#2f81f7' })))).toBe(false);
+    expect(hasHostTheme({})).toBe(false);
+  });
+
+  it('exposes the contract var names', () => {
+    expect(HOST_VAR_CANDIDATES.background[0]).toBe('--background-color-default');
+    expect(HOST_VAR_CANDIDATES.foreground[0]).toBe('--text-color-default');
+    expect(HOST_VAR_CANDIDATES.fontSans[0]).toBe('--font-sans');
+    expect(HOST_VAR_CANDIDATES.fontMono[0]).toBe('--font-mono');
+  });
+});
+
+describe('hostSignalsToFluentTheme', () => {
+  it('maps a dark host background/foreground/font onto Fluent neutral tokens', () => {
+    const t = hostSignalsToFluentTheme({
+      background: '#0d1117',
+      backgroundMuted: '#161b22',
+      foreground: '#e6edf3',
+      foregroundMuted: '#8b949e',
+      fontSans: 'Inter, sans-serif',
+      fontMono: 'JetBrains Mono, monospace',
+    });
+    expect(t.colorNeutralBackground1).toBe('#0d1117');
+    expect(t.colorNeutralBackground2).toBe('#161b22');
+    expect(t.colorNeutralCardBackground).toBe('#161b22');
+    expect(t.colorNeutralForeground1).toBe('#e6edf3');
+    expect(t.colorNeutralForeground2).toBe('#8b949e');
+    expect(t.fontFamilyBase).toBe('Inter, sans-serif');
+    expect(t.fontFamilyMonospace).toBe('JetBrains Mono, monospace');
+  });
+
+  it('picks a light base theme when the host background is light', () => {
+    const dark = hostSignalsToFluentTheme({ background: '#0d1117', foreground: '#ffffff' });
+    const light = hostSignalsToFluentTheme({ background: '#ffffff', foreground: '#1f2328' });
+    // Fluent dark vs light bases differ in stroke tokens we don't override.
+    expect(light.colorNeutralStroke1).not.toBe(dark.colorNeutralStroke1);
+  });
+
+  it('reseeds the brand ramp from a host accent (true-color)', () => {
+    const noAccent = hostSignalsToFluentTheme({ background: '#0d1117', foreground: '#fff' });
+    const withAccent = hostSignalsToFluentTheme({ background: '#0d1117', foreground: '#fff', accent: '#2f81f7' });
+    expect(withAccent.colorBrandBackground).not.toBe(noAccent.colorBrandBackground);
+  });
+
+  it('ignores an unparseable accent without throwing', () => {
+    const t = hostSignalsToFluentTheme({ background: '#0d1117', foreground: '#fff', accent: 'not-a-color' });
+    expect(t.colorNeutralBackground1).toBe('#0d1117');
+  });
+
+  it('folds PresentationTokens typography + corner radius into the theme', () => {
+    const t = hostSignalsToFluentTheme(
+      { background: '#0d1117', foreground: '#fff' },
+      { typography: { baseSizePx: 15, lineHeight: 1.6 }, cornerRadius: { step: 'large' } },
+    );
+    expect(t.fontSizeBase300).toBe('15px');
+    expect(t.lineHeightBase300).toBe('1.6');
+    expect(t.borderRadiusMedium).toBe('8px');
+    expect(t.borderRadiusLarge).toBe('8px');
+    expect(t.borderRadiusSmall).toBe('6px');
+  });
+
+  it('honors an explicit cornerRadius.valuePx escape hatch over the step', () => {
+    const t = hostSignalsToFluentTheme(
+      { background: '#0d1117', foreground: '#fff' },
+      { cornerRadius: { step: 'small', valuePx: 12 } },
+    );
+    expect(t.borderRadiusMedium).toBe('12px');
+  });
+});
+
+describe('resolveHostFluentTheme', () => {
+  const originalGCS = (globalThis as Record<string, unknown>).getComputedStyle;
+  const restore = () => {
+    if (originalGCS === undefined) delete (globalThis as Record<string, unknown>).getComputedStyle;
+    else (globalThis as Record<string, unknown>).getComputedStyle = originalGCS;
+  };
+
+  it('returns null with no DOM (SSR/node)', () => {
+    delete (globalThis as Record<string, unknown>).getComputedStyle;
+    try {
+      expect(resolveHostFluentTheme(null)).toBeNull();
+    } finally { restore(); }
+  });
+
+  it('returns null when the host mirrors no color signal', () => {
+    (globalThis as Record<string, unknown>).getComputedStyle = () => ({ getPropertyValue: () => '' });
+    try {
+      expect(resolveHostFluentTheme({} as Element)).toBeNull();
+    } finally { restore(); }
+  });
+
+  it('resolves a theme from host vars present on the root', () => {
+    (globalThis as Record<string, unknown>).getComputedStyle = () => ({
+      getPropertyValue: (n: string) =>
+        n === '--background-color-default' ? '#0d1117'
+          : n === '--text-color-default' ? '#e6edf3'
+            : '',
+    });
+    try {
+      const t = resolveHostFluentTheme({} as Element);
+      expect(t).not.toBeNull();
+      expect(t!.colorNeutralBackground1).toBe('#0d1117');
+      expect(t!.colorNeutralForeground1).toBe('#e6edf3');
+    } finally { restore(); }
+  });
+});

--- a/src/theme/__tests__/hostTheme.test.ts
+++ b/src/theme/__tests__/hostTheme.test.ts
@@ -94,6 +94,38 @@ describe('hostSignalsToFluentTheme', () => {
     expect(t.colorNeutralBackground1).toBe('#0d1117');
   });
 
+  // Regression (#439 review): short hex and rgb() host colors must drive the
+  // base-mode + overrides correctly, not silently fall back to a dark base or
+  // be dropped by the hex-only brand generator.
+  it('selects a LIGHT base from a short-hex light background (#fff)', () => {
+    const light = hostSignalsToFluentTheme({ background: '#fff', foreground: '#111' });
+    const dark = hostSignalsToFluentTheme({ background: '#000', foreground: '#fff' });
+    expect(light.colorNeutralStroke1).not.toBe(dark.colorNeutralStroke1);
+    // Background override is normalized to #rrggbb.
+    expect(light.colorNeutralBackground1).toBe('#ffffff');
+    expect(light.colorNeutralForeground1).toBe('#111111');
+  });
+
+  it('selects a LIGHT base from an rgb() light background', () => {
+    const light = hostSignalsToFluentTheme({ background: 'rgb(245, 245, 245)', foreground: 'rgb(20, 20, 20)' });
+    const dark = hostSignalsToFluentTheme({ background: 'rgb(13, 17, 23)', foreground: 'rgb(230, 237, 243)' });
+    expect(light.colorNeutralStroke1).not.toBe(dark.colorNeutralStroke1);
+    expect(light.colorNeutralBackground1).toBe('#f5f5f5');
+    expect(dark.colorNeutralBackground1).toBe('#0d1117');
+  });
+
+  it('reseeds the brand ramp from a SHORT-HEX accent', () => {
+    const noAccent = hostSignalsToFluentTheme({ background: '#0d1117', foreground: '#fff' });
+    const shortHex = hostSignalsToFluentTheme({ background: '#0d1117', foreground: '#fff', accent: '#0af' });
+    expect(shortHex.colorBrandBackground).not.toBe(noAccent.colorBrandBackground);
+  });
+
+  it('reseeds the brand ramp from an rgb() accent', () => {
+    const noAccent = hostSignalsToFluentTheme({ background: '#0d1117', foreground: '#fff' });
+    const rgbAccent = hostSignalsToFluentTheme({ background: '#0d1117', foreground: '#fff', accent: 'rgb(47, 129, 247)' });
+    expect(rgbAccent.colorBrandBackground).not.toBe(noAccent.colorBrandBackground);
+  });
+
   it('folds PresentationTokens typography + corner radius into the theme', () => {
     const t = hostSignalsToFluentTheme(
       { background: '#0d1117', foreground: '#fff' },

--- a/src/theme/color.ts
+++ b/src/theme/color.ts
@@ -1,0 +1,69 @@
+/**
+ * Shared color parsing / normalization for the theme adapters.
+ *
+ * Centralizes the hex + `rgb()` parsing introduced for the constellation edge
+ * colors (#402's `withAlpha`) and extends it to the color syntaxes a canvas host
+ * actually mirrors — short hex (`#fff`) and comma- OR space-separated `rgb()` —
+ * so host-theme adoption (#404) makes correct luminance/base-mode, brand-ramp,
+ * and neutral-token decisions instead of silently falling back to a dark base or
+ * dropping an `rgb()` accent. One canonical parser, no per-call-site duplication.
+ */
+
+/** Parsed RGB channels (0–255). */
+export interface Rgb {
+  r: number;
+  g: number;
+  b: number;
+}
+
+/**
+ * Parse a CSS color into RGB channels. Handles `#rgb`, `#rrggbb`, and
+ * `rgb()/rgba()` with comma- or space-separated channels. Returns `null` for
+ * any syntax it doesn't recognize (named colors, hsl(), etc.) so callers can
+ * fall back gracefully rather than mis-deriving a value.
+ */
+export function parseColor(color: string): Rgb | null {
+  const c = color.trim();
+
+  const short = /^#([0-9a-fA-F]{3})$/.exec(c);
+  if (short) {
+    const h = short[1];
+    return {
+      r: parseInt(h[0] + h[0], 16),
+      g: parseInt(h[1] + h[1], 16),
+      b: parseInt(h[2] + h[2], 16),
+    };
+  }
+
+  const full = /^#([0-9a-fA-F]{6})$/.exec(c);
+  if (full) {
+    const n = parseInt(full[1], 16);
+    return { r: (n >> 16) & 0xff, g: (n >> 8) & 0xff, b: n & 0xff };
+  }
+
+  const rgb = /^rgba?\(\s*(\d{1,3})\s*[,\s]\s*(\d{1,3})\s*[,\s]\s*(\d{1,3})/.exec(c);
+  if (rgb) {
+    return { r: +rgb[1], g: +rgb[2], b: +rgb[3] };
+  }
+
+  return null;
+}
+
+const clamp = (n: number) => Math.max(0, Math.min(255, Math.round(n)));
+const toHex2 = (n: number) => clamp(n).toString(16).padStart(2, '0');
+
+/** Normalize a recognized color to canonical `#rrggbb`; `null` if unparseable. */
+export function normalizeColorToHex(color: string): string | null {
+  const c = parseColor(color);
+  return c ? `#${toHex2(c.r)}${toHex2(c.g)}${toHex2(c.b)}` : null;
+}
+
+/**
+ * Perceived-luminance dark test (`< 0.5`). Returns `null` when the color can't
+ * be parsed so callers can choose their own default rather than guessing.
+ */
+export function colorIsDark(color: string): boolean | null {
+  const c = parseColor(color);
+  if (!c) return null;
+  return (0.299 * c.r + 0.587 * c.g + 0.114 * c.b) / 255 < 0.5;
+}

--- a/src/theme/hostTheme.ts
+++ b/src/theme/hostTheme.ts
@@ -28,6 +28,7 @@ import {
 } from '@fluentui/react-components';
 import type { PresentationTokens } from '@anokye-labs/kbexplorer-core';
 import { generateBrandVariants } from './brandRamp';
+import { colorIsDark, normalizeColorToHex } from './color';
 
 /** Reads a single CSS custom property by name (with leading `--`); '' if unset. */
 export type CssVarReader = (name: string) => string;
@@ -86,22 +87,6 @@ export function hasHostTheme(signals: HostThemeSignals): boolean {
   return Boolean(signals.background || signals.foreground);
 }
 
-/** Perceived-luminance dark test for a hex or `rgb()/rgba()` color; null if unparseable. */
-function isDarkColor(color: string): boolean | null {
-  const hex = /^#?([0-9a-fA-F]{6})$/.exec(color.trim());
-  if (hex) {
-    const n = parseInt(hex[1], 16);
-    const r = (n >> 16) & 0xff, g = (n >> 8) & 0xff, b = n & 0xff;
-    return (0.299 * r + 0.587 * g + 0.114 * b) / 255 < 0.5;
-  }
-  const rgb = /rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/.exec(color);
-  if (rgb) {
-    const r = +rgb[1], g = +rgb[2], b = +rgb[3];
-    return (0.299 * r + 0.587 * g + 0.114 * b) / 255 < 0.5;
-  }
-  return null;
-}
-
 /** Named corner-radius steps → px (mirrors core's `CornerRadiusStep`). */
 const CORNER_STEP_PX: Record<string, number> = {
   none: 0,
@@ -118,17 +103,28 @@ const CORNER_STEP_PX: Record<string, number> = {
  * Fluent brand ramp; neutral background/foreground tokens adopt the host colors;
  * fonts adopt the host's `--font-sans`/`--font-mono`. PresentationTokens fold in
  * the intent knobs (typography size/line-height, corner radius).
+ *
+ * Host colors are normalized to `#rrggbb` via the shared color util before use,
+ * so short hex (`#fff`) and `rgb()` values drive base-mode selection, brand-ramp
+ * generation, and the neutral overrides correctly (rather than defaulting to a
+ * dark base or being dropped by the hex-only brand generator).
  */
 export function hostSignalsToFluentTheme(
   signals: HostThemeSignals,
   presentation?: PresentationTokens,
 ): FluentTheme {
-  const dark = signals.background ? (isDarkColor(signals.background) ?? true) : true;
+  const bgHex = signals.background ? normalizeColorToHex(signals.background) : null;
+  const fgHex = signals.foreground ? normalizeColorToHex(signals.foreground) : null;
+  const bgMutedHex = signals.backgroundMuted ? normalizeColorToHex(signals.backgroundMuted) : null;
+  const fgMutedHex = signals.foregroundMuted ? normalizeColorToHex(signals.foregroundMuted) : null;
+  const accentHex = signals.accent ? normalizeColorToHex(signals.accent) : null;
+
+  const dark = signals.background ? (colorIsDark(signals.background) ?? true) : true;
   let base: FluentTheme = dark ? webDarkTheme : webLightTheme;
 
-  if (signals.accent) {
+  if (accentHex) {
     try {
-      const variants = generateBrandVariants(signals.accent);
+      const variants = generateBrandVariants(accentHex);
       base = (dark ? createDarkTheme : createLightTheme)(variants);
     } catch {
       /* unparseable accent → keep the neutral base */
@@ -137,16 +133,23 @@ export function hostSignalsToFluentTheme(
 
   const overrides: Record<string, string> = {};
 
-  if (signals.background) {
-    overrides.colorNeutralBackground1 = signals.background;
-    overrides.colorNeutralBackground2 = signals.backgroundMuted ?? signals.background;
-    overrides.colorNeutralBackground3 = signals.backgroundMuted ?? signals.background;
-    overrides.colorNeutralCardBackground = signals.backgroundMuted ?? signals.background;
+  // Prefer the normalized hex; fall back to the raw value for a valid-but-
+  // unrecognized syntax so we still adopt it rather than dropping it.
+  const bg = bgHex ?? signals.background;
+  const bgMuted = bgMutedHex ?? signals.backgroundMuted ?? bg;
+  const fg = fgHex ?? signals.foreground;
+  const fgMuted = fgMutedHex ?? signals.foregroundMuted ?? fg;
+
+  if (bg) {
+    overrides.colorNeutralBackground1 = bg;
+    overrides.colorNeutralBackground2 = bgMuted ?? bg;
+    overrides.colorNeutralBackground3 = bgMuted ?? bg;
+    overrides.colorNeutralCardBackground = bgMuted ?? bg;
   }
-  if (signals.foreground) {
-    overrides.colorNeutralForeground1 = signals.foreground;
-    overrides.colorNeutralForeground2 = signals.foregroundMuted ?? signals.foreground;
-    overrides.colorNeutralForeground3 = signals.foregroundMuted ?? signals.foreground;
+  if (fg) {
+    overrides.colorNeutralForeground1 = fg;
+    overrides.colorNeutralForeground2 = fgMuted ?? fg;
+    overrides.colorNeutralForeground3 = fgMuted ?? fg;
   }
   if (signals.fontSans) overrides.fontFamilyBase = signals.fontSans;
   if (signals.fontMono) overrides.fontFamilyMonospace = signals.fontMono;

--- a/src/theme/hostTheme.ts
+++ b/src/theme/hostTheme.ts
@@ -1,0 +1,193 @@
+/**
+ * Host CSS-var → Fluent `Theme` adapter (#404, epic #401).
+ *
+ * A GitHub Copilot canvas (or any embedding host) mirrors a small set of
+ * **semantic** CSS variables into the embedded surface's `:root` —
+ * `--background-color-default`, `--text-color-*`, `--font-sans` / `--font-mono`,
+ * and a true-color accent. The SPA otherwise themes only from Fluent token names
+ * (`themeModule`, external YAML, `clusterTokens`). This adapter reads those host
+ * vars and produces a Fluent `Theme` so the SPA inherits the host's look with no
+ * fork — the missing seam called out in #401/#404.
+ *
+ * It also consumes the host-neutral presentation-token contract published in
+ * `@anokye-labs/kbexplorer-core` (`PresentationTokens`, core#15): the *intent*
+ * knobs (typography size/line-height, corner-radius) are folded into the same
+ * resolved theme. Color/font come from the host's concrete (true-color) vars;
+ * the intent tokens carry portable design choices the host expresses abstractly.
+ *
+ * Pure and side-effect free: the signal-reading and theme-building steps take an
+ * injectable reader so they are unit-testable without a DOM, and degrade to
+ * `null` (no host theme) when the host mirrors nothing.
+ */
+import {
+  webDarkTheme,
+  webLightTheme,
+  createDarkTheme,
+  createLightTheme,
+  type Theme as FluentTheme,
+} from '@fluentui/react-components';
+import type { PresentationTokens } from '@anokye-labs/kbexplorer-core';
+import { generateBrandVariants } from './brandRamp';
+
+/** Reads a single CSS custom property by name (with leading `--`); '' if unset. */
+export type CssVarReader = (name: string) => string;
+
+/**
+ * Semantic host variables, each as a priority-ordered candidate list (first
+ * non-empty wins). The primary names follow #404's contract; the trailing
+ * aliases accept common host conventions (GitHub Primer / Copilot) so the
+ * adapter is resilient to the exact var names a host chooses to mirror.
+ */
+export const HOST_VAR_CANDIDATES = {
+  background:      ['--background-color-default', '--bgColor-default', '--color-canvas-default'],
+  backgroundMuted: ['--background-color-muted', '--background-color-secondary', '--bgColor-muted', '--color-canvas-subtle'],
+  foreground:      ['--text-color-default', '--text-color-primary', '--fgColor-default', '--color-fg-default'],
+  foregroundMuted: ['--text-color-muted', '--text-color-secondary', '--fgColor-muted', '--color-fg-muted'],
+  accent:          ['--text-color-link', '--accent-color', '--fgColor-accent', '--color-accent-fg'],
+  fontSans:        ['--font-sans', '--fontStack-sans', '--font-family-sans'],
+  fontMono:        ['--font-mono', '--fontStack-monospace', '--font-family-mono'],
+} as const;
+
+/** Resolved semantic signals mirrored by the host (any subset may be present). */
+export interface HostThemeSignals {
+  background?: string;
+  backgroundMuted?: string;
+  foreground?: string;
+  foregroundMuted?: string;
+  accent?: string;
+  fontSans?: string;
+  fontMono?: string;
+}
+
+function firstVar(read: CssVarReader, names: readonly string[]): string {
+  for (const n of names) {
+    const v = read(n).trim();
+    if (v) return v;
+  }
+  return '';
+}
+
+/** Read every known host signal via `read`, omitting unset ones. */
+export function readHostSignals(read: CssVarReader): HostThemeSignals {
+  const out: HostThemeSignals = {};
+  for (const key of Object.keys(HOST_VAR_CANDIDATES) as (keyof typeof HOST_VAR_CANDIDATES)[]) {
+    const v = firstVar(read, HOST_VAR_CANDIDATES[key]);
+    if (v) out[key] = v;
+  }
+  return out;
+}
+
+/**
+ * Whether the host mirrored enough to theme from — at least one of a
+ * background or foreground color. Font-only or accent-only signals are treated
+ * as "no host theme" so we never override neutrals with nothing meaningful.
+ */
+export function hasHostTheme(signals: HostThemeSignals): boolean {
+  return Boolean(signals.background || signals.foreground);
+}
+
+/** Perceived-luminance dark test for a hex or `rgb()/rgba()` color; null if unparseable. */
+function isDarkColor(color: string): boolean | null {
+  const hex = /^#?([0-9a-fA-F]{6})$/.exec(color.trim());
+  if (hex) {
+    const n = parseInt(hex[1], 16);
+    const r = (n >> 16) & 0xff, g = (n >> 8) & 0xff, b = n & 0xff;
+    return (0.299 * r + 0.587 * g + 0.114 * b) / 255 < 0.5;
+  }
+  const rgb = /rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/.exec(color);
+  if (rgb) {
+    const r = +rgb[1], g = +rgb[2], b = +rgb[3];
+    return (0.299 * r + 0.587 * g + 0.114 * b) / 255 < 0.5;
+  }
+  return null;
+}
+
+/** Named corner-radius steps → px (mirrors core's `CornerRadiusStep`). */
+const CORNER_STEP_PX: Record<string, number> = {
+  none: 0,
+  small: 2,
+  medium: 4,
+  large: 8,
+  pill: 9999,
+};
+
+/**
+ * Build a Fluent `Theme` from resolved host signals plus optional host-neutral
+ * presentation tokens. Pure: no DOM access. The base mode (dark/light) is chosen
+ * from the host background's luminance; a host accent (true-color) reseeds the
+ * Fluent brand ramp; neutral background/foreground tokens adopt the host colors;
+ * fonts adopt the host's `--font-sans`/`--font-mono`. PresentationTokens fold in
+ * the intent knobs (typography size/line-height, corner radius).
+ */
+export function hostSignalsToFluentTheme(
+  signals: HostThemeSignals,
+  presentation?: PresentationTokens,
+): FluentTheme {
+  const dark = signals.background ? (isDarkColor(signals.background) ?? true) : true;
+  let base: FluentTheme = dark ? webDarkTheme : webLightTheme;
+
+  if (signals.accent) {
+    try {
+      const variants = generateBrandVariants(signals.accent);
+      base = (dark ? createDarkTheme : createLightTheme)(variants);
+    } catch {
+      /* unparseable accent → keep the neutral base */
+    }
+  }
+
+  const overrides: Record<string, string> = {};
+
+  if (signals.background) {
+    overrides.colorNeutralBackground1 = signals.background;
+    overrides.colorNeutralBackground2 = signals.backgroundMuted ?? signals.background;
+    overrides.colorNeutralBackground3 = signals.backgroundMuted ?? signals.background;
+    overrides.colorNeutralCardBackground = signals.backgroundMuted ?? signals.background;
+  }
+  if (signals.foreground) {
+    overrides.colorNeutralForeground1 = signals.foreground;
+    overrides.colorNeutralForeground2 = signals.foregroundMuted ?? signals.foreground;
+    overrides.colorNeutralForeground3 = signals.foregroundMuted ?? signals.foreground;
+  }
+  if (signals.fontSans) overrides.fontFamilyBase = signals.fontSans;
+  if (signals.fontMono) overrides.fontFamilyMonospace = signals.fontMono;
+
+  // PresentationTokens (host-neutral intent) — typography + corner radius.
+  const typ = presentation?.typography;
+  if (typ?.baseSizePx) overrides.fontSizeBase300 = `${typ.baseSizePx}px`;
+  if (typ?.lineHeight) overrides.lineHeightBase300 = String(typ.lineHeight);
+
+  const cr = presentation?.cornerRadius;
+  const crPx = cr?.valuePx ?? (cr?.step ? CORNER_STEP_PX[cr.step] : undefined);
+  if (crPx !== undefined) {
+    overrides.borderRadiusMedium = `${crPx}px`;
+    overrides.borderRadiusLarge = `${crPx}px`;
+    overrides.borderRadiusSmall = `${Math.max(0, crPx - 2)}px`;
+  }
+
+  return { ...base, ...overrides } as FluentTheme;
+}
+
+/**
+ * Resolve a Fluent `Theme` from the host vars mirrored onto `root` (default
+ * `document.documentElement`). Returns `null` when there is no DOM (SSR/tests)
+ * or the host mirrored no usable color signal — so callers can cleanly treat
+ * "no host" as "use the built-in/config themes".
+ */
+export function resolveHostFluentTheme(
+  root?: Element | null,
+  presentation?: PresentationTokens,
+): FluentTheme | null {
+  const el = root ?? (typeof document !== 'undefined' ? document.documentElement : null);
+  if (!el || typeof getComputedStyle === 'undefined') return null;
+  let cs: CSSStyleDeclaration;
+  try {
+    cs = getComputedStyle(el);
+  } catch {
+    return null;
+  }
+  const signals = readHostSignals(name => {
+    try { return cs.getPropertyValue(name); } catch { return ''; }
+  });
+  if (!hasHostTheme(signals)) return null;
+  return hostSignalsToFluentTheme(signals, presentation);
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -38,6 +38,8 @@ import {
   type GraphStoreEntry,
   type GraphStoreInvalidation,
   type GraphStoreWrite,
+  type PresentationTokens,
+  CANVAS_TARGET,
 } from '@anokye-labs/kbexplorer-core';
 
 /**
@@ -86,6 +88,8 @@ export {
   type GraphStoreEntry,
   type GraphStoreInvalidation,
   type GraphStoreWrite,
+  type PresentationTokens,
+  CANVAS_TARGET,
 };
 
 /**


### PR DESCRIPTION
## What

Third of the canvas host-themeability trio under epic #401 — the host CSS-var → Fluent `Theme` adapter, so the SPA inherits a Copilot canvas host's look with **no fork**.

Closes #404

This PR is **independent of #437 (#402/#403)** — it touches different files (`hostTheme.ts`, `useTheme.ts`, `types/index.ts`, the core pin) and is branched from `main`, so it can be reviewed/merged on its own.

### The adapter — `src/theme/hostTheme.ts`
- Reads the semantic host vars named in #404 — `--background-color-default`, `--text-color-*`, `--font-sans`/`--font-mono`, and a true-color accent — with common host aliases (Primer/Copilot) as graceful fallbacks.
- Builds a Fluent `Theme`: neutral background/foreground tokens adopt the host colors; the accent **reseeds the Fluent brand ramp**; fonts adopt the host stacks; base mode (dark/light) is chosen from background luminance. Degrades to `null` (no host theme) when nothing usable is mirrored.
- Pure + injectable reader → fully unit-testable without a DOM.

### Consumes the published contract (core#15, v0.2.0)
- Bumps `@anokye-labs/kbexplorer-core` pin `v0.1.0` → **`v0.2.0`** (what makes `PresentationTokens` importable).
- Folds the host-neutral `PresentationTokens` *intent* knobs (typography size/line-height, corner radius) into the same resolved theme.
- Re-exports `PresentationTokens` + `CANVAS_TARGET` from `../types`.

### Live `inherit-host` mode
- `useTheme.applyConfig` registers the resolved theme under a new `inherit-host` key when host vars are present (null ⇒ no-op), so it joins the selectable set / `t`-cycle and persists. This is the seam the headless embed mount (#406) will drive automatically.

No cached-data shape / localStorage-format change → no `CACHE_VERSION` bump.

## Testing

- **Unit:** `829 passed` (74 files) incl. new `hostTheme.test.ts` (signal reading, alias fallback, neutral/brand/font mapping, luminance base selection, PresentationTokens folding, DOM resolution + SSR-null).
- **Typecheck:** `tsc --noEmit` clean. **Lint:** `eslint .` 0 errors (3 pre-existing warnings). **Build:** `vite build` ✓.
- **Visual (Playwright, real Chromium):** injected a host theme onto `:root` (`--background-color-default:#220033`, `--text-color-default:#ffe9b0`, `--font-sans:Georgia`, accent `#ff7ab6`) and selected `inherit-host`. **Zero console errors**; the SPA adopted it end-to-end:
  - `--colorNeutralBackground1` → `#220033`, `--colorNeutralForeground1` → `#ffe9b0`, `--fontFamilyBase` → `Georgia, serif`
  - brand reseeded from accent: `--colorBrandBackground` `#FF469A` (host) vs `#115ea3` (dark)
  - constellation canvas recolored (node surfaces adopt the host background via the #403 bridge) and stayed non-blank
  - `HOST_VALIDATION: PASS`

  (A same-luminance host keeps the base palette ramp, so palette-token edge swatches intentionally don't shift — #404 maps the host's named semantic vars, not the full Fluent palette.)

## Notes
- Do not merge — orchestrator reviews + merges (required checks + conversation-resolution-required).
- Suggest merging after #437 (#402/#403). Both are independent, but they form the epic #401 trio together.
