### PR TITLE
feat: embeddable headless canvas mount + inherit-host visual mode

### DIFF
--- a/canvas.html
+++ b/canvas.html
@@ -2,6 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <!-- Empty data icon: suppress the browser's default /favicon.ico request so
+         the embedded canvas iframe makes no spurious network call (headless —
+         the full-page index.html owns the real favicon). -->
+    <link rel="icon" href="data:," />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>kbexplorer canvas</title>
   </head>

--- a/canvas.html
+++ b/canvas.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>kbexplorer canvas</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/canvas.tsx"></script>
+  </body>
+</html>

--- a/e2e/canvas-embed.spec.ts
+++ b/e2e/canvas-embed.spec.ts
@@ -42,6 +42,9 @@ test.describe('Embeddable canvas mount (#406)', () => {
     // Reused `spa` reading viewer renders the anchored node's prose — non-blank.
     await expect(page.locator('.kb-prose')).toBeVisible({ timeout: 15000 });
 
+    // anchorNodeId from the boot config lands on /node/<id> (HashRouter).
+    await expect.poll(() => page.evaluate(() => location.hash)).toBe('#/node/readme');
+
     const surface = page.locator('[data-kbx-surface="canvas"]');
     await expect(surface).toBeVisible();
 
@@ -51,10 +54,9 @@ test.describe('Embeddable canvas mount (#406)', () => {
     await expect(surface).toHaveCSS('background-color', HOST_BG);
     await expect(surface).toHaveCSS('color', HOST_FG);
 
-    // Headless entry: the canvas HTML, not the full-page index.html. The
-    // full-page shell ships a favicon link; the canvas deliberately omits it.
+    // Headless entry: the canvas HTML, not the full-page index.html (distinct
+    // title). The canvas ships no real favicon and no HUD chrome.
     await expect(page).toHaveTitle(/kbexplorer canvas/);
-    await expect(page.locator('link[rel="icon"]')).toHaveCount(0);
 
     await page.waitForTimeout(1000);
     const appErrors = errors.filter(e => !e.includes('403') && !e.includes('rate limit'));

--- a/e2e/canvas-embed.spec.ts
+++ b/e2e/canvas-embed.spec.ts
@@ -1,0 +1,63 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Embeddable canvas mount (#406). Verifies the additive `canvas.html` surface:
+ * it boots from `window.__KBX_CANVAS__`, inherits the host theme mirrored onto
+ * the iframe `:root` (inherit-host visual mode — including live re-mirror on a
+ * host theme switch), renders non-blank reusing the `spa` viewers, and logs no
+ * console errors — WITHOUT the full-page favicon/HUD chrome.
+ */
+
+const HOST_BG = 'rgb(13, 17, 23)'; // #0d1117 — GitHub dark canvas
+const HOST_FG = 'rgb(230, 237, 243)'; // #e6edf3
+
+/** Mirror the host's semantic CSS vars onto the iframe root (as a host would). */
+async function mirrorHostVars(page: import('@playwright/test').Page): Promise<void> {
+  await page.evaluate(() => {
+    const r = document.documentElement.style;
+    r.setProperty('--background-color-default', '#0d1117');
+    r.setProperty('--text-color-default', '#e6edf3');
+    r.setProperty('--text-color-link', '#2f81f7');
+    r.setProperty('--font-sans', 'system-ui');
+  });
+}
+
+test.describe('Embeddable canvas mount (#406)', () => {
+  test('boots host-themed and non-blank with no full-page chrome', async ({ page }) => {
+    const errors: string[] = [];
+    page.on('console', msg => {
+      if (msg.type() === 'error' && !msg.text().includes('@griffel')) errors.push(msg.text());
+    });
+
+    // The loopback host injects the boot config before app code runs.
+    await page.addInitScript(() => {
+      (window as unknown as { __KBX_CANVAS__: unknown }).__KBX_CANVAS__ = {
+        local: false,
+        visualMode: 'inherit-host',
+        anchorNodeId: 'readme',
+      };
+    });
+    await page.goto('/canvas.html', { timeout: 60000 });
+
+    // Reused `spa` reading viewer renders the anchored node's prose — non-blank.
+    await expect(page.locator('.kb-prose')).toBeVisible({ timeout: 15000 });
+
+    const surface = page.locator('[data-kbx-surface="canvas"]');
+    await expect(surface).toBeVisible();
+
+    // Host mirrors its semantic vars → inherit-host re-resolves (MutationObserver)
+    // and the Fluent surface adopts the host background/foreground.
+    await mirrorHostVars(page);
+    await expect(surface).toHaveCSS('background-color', HOST_BG);
+    await expect(surface).toHaveCSS('color', HOST_FG);
+
+    // Headless entry: the canvas HTML, not the full-page index.html. The
+    // full-page shell ships a favicon link; the canvas deliberately omits it.
+    await expect(page).toHaveTitle(/kbexplorer canvas/);
+    await expect(page.locator('link[rel="icon"]')).toHaveCount(0);
+
+    await page.waitForTimeout(1000);
+    const appErrors = errors.filter(e => !e.includes('403') && !e.includes('rate limit'));
+    expect(appErrors).toHaveLength(0);
+  });
+});

--- a/src/canvas.tsx
+++ b/src/canvas.tsx
@@ -1,0 +1,22 @@
+/**
+ * Embeddable canvas entry (#406, epic #407 / #401).
+ *
+ * The additive counterpart to `main.tsx`. It reads the host-injected boot config
+ * from `window.__KBX_CANVAS__` and mounts the headless {@link EmbeddableApp}
+ * instead of the full-page `<App/>` route tree — no HUD, favicon, or dock chrome.
+ * The full-page entry is untouched; the CLI loopback server serves `canvas.html`
+ * for the canvas surface.
+ */
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import './index.css';
+import { EmbeddableApp } from './canvas/EmbeddableApp';
+import { readCanvasBootConfig } from './canvas/bootConfig';
+
+const boot = readCanvasBootConfig();
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <EmbeddableApp boot={boot} />
+  </StrictMode>,
+);

--- a/src/canvas/EmbeddableApp.tsx
+++ b/src/canvas/EmbeddableApp.tsx
@@ -1,0 +1,70 @@
+/**
+ * Embeddable headless mount (#406, epic #407 / #401).
+ *
+ * The canvas-mode counterpart to the full-page `App`. It renders the SAME pure
+ * `KBGraph` through the SAME `spa` representation (ReadingView / OverviewView /
+ * HomePage → node viewers, `kg://` identity + relations) but WITHOUT the full-
+ * page chrome: no HUD, no favicon, no dock padding, no theme `t`-cycle. It is a
+ * narrow, panel-friendly surface meant to sit inside a Copilot canvas iframe.
+ *
+ * This is ADDITIVE: the full-page `App`/`main.tsx` path is untouched. The theme
+ * is host-driven via {@link useCanvasTheme} (`inherit-host`), and an optional
+ * `anchorNodeId` from the boot config picks the landing node — the seam the
+ * bespoke agent-driven anchor-first view (#408) builds on.
+ */
+import type { ReactNode } from 'react';
+import { HashRouter } from 'react-router-dom';
+import { FluentProvider } from '@fluentui/react-components';
+import { useKnowledgeBase } from '../hooks/useKnowledgeBase';
+import { isDarkTheme } from '../hooks/useTheme';
+import { IsDarkContext } from '../theme/isDarkContext';
+import { representationRegistry } from '../representation';
+import { LoadingScreen } from '../components/LoadingScreen';
+import { ErrorScreen } from '../components/ErrorScreen';
+import { useCanvasTheme } from './useCanvasTheme';
+import { resolveCanvasLandingPath } from './landing';
+import type { CanvasBootConfig } from './bootConfig';
+import '../styles/visuals.css';
+import '../styles/reading.css';
+import '../styles/responsive.css';
+
+/** Data-loading inner shell: renders the `spa` route tree once ready. */
+function CanvasExplorer({ boot }: { boot: CanvasBootConfig }): ReactNode {
+  const state = useKnowledgeBase();
+
+  const fluentTheme = useCanvasTheme(
+    boot.visualMode,
+    state.status === 'ready' ? state.config : undefined,
+  );
+  const isDark = isDarkTheme(fluentTheme);
+
+  return (
+    <FluentProvider
+      theme={fluentTheme}
+      // Panel-friendly: fill the iframe, no full-page chrome/dock padding.
+      style={{ minHeight: '100vh', width: '100%' }}
+      data-kbx-surface="canvas"
+    >
+      <IsDarkContext.Provider value={isDark}>
+        {state.status === 'loading' && <LoadingScreen />}
+        {state.status === 'error' && <ErrorScreen message={state.error} />}
+        {state.status === 'ready' && (
+          <HashRouter>
+            {representationRegistry.resolve<ReactNode>('spa').render(state.graph, {
+              config: state.config,
+              fluentTheme,
+              landingPath: resolveCanvasLandingPath(state.config, boot.anchorNodeId),
+            }) as ReactNode}
+          </HashRouter>
+        )}
+      </IsDarkContext.Provider>
+    </FluentProvider>
+  );
+}
+
+/** The embeddable headless application root. */
+export function EmbeddableApp({ boot }: { boot: CanvasBootConfig }) {
+  return <CanvasExplorer boot={boot} />;
+}
+
+export default EmbeddableApp;

--- a/src/canvas/__tests__/bootConfig.test.ts
+++ b/src/canvas/__tests__/bootConfig.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import {
+  parseCanvasBootConfig,
+  DEFAULT_CANVAS_BOOT_CONFIG,
+} from '../bootConfig';
+
+describe('parseCanvasBootConfig', () => {
+  it('returns the full default config for a non-object input', () => {
+    for (const raw of [undefined, null, 'x', 42, true]) {
+      expect(parseCanvasBootConfig(raw)).toEqual(DEFAULT_CANVAS_BOOT_CONFIG);
+    }
+  });
+
+  it('defaults visualMode to inherit-host and local to false when absent', () => {
+    const cfg = parseCanvasBootConfig({});
+    expect(cfg.visualMode).toBe('inherit-host');
+    expect(cfg.local).toBe(false);
+    expect(cfg.searchServiceUrl).toBeUndefined();
+    expect(cfg.anchorNodeId).toBeUndefined();
+  });
+
+  it('accepts a valid full boot object', () => {
+    const cfg = parseCanvasBootConfig({
+      local: true,
+      visualMode: 'inherit-host',
+      searchServiceUrl: 'http://127.0.0.1:9099/search',
+      anchorNodeId: 'kg://issue/406',
+    });
+    expect(cfg).toEqual({
+      local: true,
+      visualMode: 'inherit-host',
+      searchServiceUrl: 'http://127.0.0.1:9099/search',
+      anchorNodeId: 'kg://issue/406',
+    });
+  });
+
+  it('accepts the config visual mode', () => {
+    expect(parseCanvasBootConfig({ visualMode: 'config' }).visualMode).toBe('config');
+  });
+
+  it('falls back to inherit-host for an unknown visualMode', () => {
+    expect(parseCanvasBootConfig({ visualMode: 'neon' }).visualMode).toBe('inherit-host');
+  });
+
+  it('ignores a non-boolean local', () => {
+    expect(parseCanvasBootConfig({ local: 'yes' }).local).toBe(false);
+  });
+
+  it('drops empty/whitespace-only string fields', () => {
+    const cfg = parseCanvasBootConfig({ searchServiceUrl: '   ', anchorNodeId: '' });
+    expect(cfg.searchServiceUrl).toBeUndefined();
+    expect(cfg.anchorNodeId).toBeUndefined();
+  });
+
+  it('does not mutate the shared default object', () => {
+    const cfg = parseCanvasBootConfig({ local: true });
+    cfg.visualMode = 'config';
+    expect(DEFAULT_CANVAS_BOOT_CONFIG.visualMode).toBe('inherit-host');
+  });
+});

--- a/src/canvas/__tests__/landing.test.ts
+++ b/src/canvas/__tests__/landing.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { resolveCanvasLandingPath } from '../landing';
+import type { KBConfig } from '../../types';
+
+const cfg = (landing?: KBConfig['landing']): KBConfig =>
+  ({ landing }) as unknown as KBConfig;
+
+describe('resolveCanvasLandingPath', () => {
+  it('lands on the anchor node when anchorNodeId is set', () => {
+    expect(resolveCanvasLandingPath(cfg(), 'readme')).toBe('/node/readme');
+  });
+
+  it('encodes an anchor node id with special characters', () => {
+    expect(resolveCanvasLandingPath(cfg(), 'kg://issue/406')).toBe(
+      '/node/kg%3A%2F%2Fissue%2F406',
+    );
+  });
+
+  it('falls back to the config landing when no anchor is set', () => {
+    expect(resolveCanvasLandingPath(cfg())).toBe('/node/home');
+    expect(resolveCanvasLandingPath(cfg({ view: 'overview' }))).toBe('/overview');
+  });
+
+  it('anchor wins over the config landing', () => {
+    expect(resolveCanvasLandingPath(cfg({ view: 'overview' }), 'readme')).toBe('/node/readme');
+  });
+});

--- a/src/canvas/__tests__/useCanvasTheme.test.ts
+++ b/src/canvas/__tests__/useCanvasTheme.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { webDarkTheme, webLightTheme } from '@fluentui/react-components';
+import { resolveCanvasTheme } from '../useCanvasTheme';
+import { isDarkTheme } from '../../hooks/useTheme';
+import type { KBConfig } from '../../types';
+
+/** Install a fake `getComputedStyle` that returns the given host CSS vars. */
+function stubHostVars(vars: Record<string, string>): void {
+  (globalThis as unknown as { getComputedStyle: unknown }).getComputedStyle = () => ({
+    getPropertyValue: (name: string) => vars[name] ?? '',
+  });
+}
+
+afterEach(() => {
+  delete (globalThis as unknown as { getComputedStyle?: unknown }).getComputedStyle;
+});
+
+const fakeRoot = {} as Element;
+
+describe('resolveCanvasTheme', () => {
+  it('inherit-host adopts the host background/foreground when mirrored', () => {
+    stubHostVars({
+      '--background-color-default': '#0d1117',
+      '--text-color-default': '#e6edf3',
+    });
+    const theme = resolveCanvasTheme('inherit-host', undefined, fakeRoot);
+    expect(theme.colorNeutralBackground1).toBe('#0d1117');
+    expect(theme.colorNeutralForeground1).toBe('#e6edf3');
+    expect(isDarkTheme(theme)).toBe(true);
+  });
+
+  it('inherit-host picks a light base from a light host background', () => {
+    stubHostVars({
+      '--background-color-default': '#ffffff',
+      '--text-color-default': '#1f2328',
+    });
+    const theme = resolveCanvasTheme('inherit-host', undefined, fakeRoot);
+    expect(isDarkTheme(theme)).toBe(false);
+  });
+
+  it('inherit-host falls back to the config theme when the host mirrors nothing', () => {
+    // No getComputedStyle stub ⇒ resolveHostFluentTheme returns null.
+    const theme = resolveCanvasTheme('inherit-host', undefined, fakeRoot);
+    expect(theme.colorNeutralBackground1).toBe(webDarkTheme.colorNeutralBackground1);
+  });
+
+  it('config mode ignores host vars and uses the configured default theme', () => {
+    stubHostVars({
+      '--background-color-default': '#0d1117',
+      '--text-color-default': '#e6edf3',
+    });
+    const config = { theme: { default: 'light' } } as unknown as KBConfig;
+    const theme = resolveCanvasTheme('config', config, fakeRoot);
+    expect(theme.colorNeutralBackground1).toBe(webLightTheme.colorNeutralBackground1);
+    expect(isDarkTheme(theme)).toBe(false);
+  });
+
+  it('config mode with no config resolves to the dark built-in', () => {
+    const theme = resolveCanvasTheme('config', undefined, fakeRoot);
+    expect(theme.colorNeutralBackground1).toBe(webDarkTheme.colorNeutralBackground1);
+  });
+});

--- a/src/canvas/bootConfig.ts
+++ b/src/canvas/bootConfig.ts
@@ -2,11 +2,12 @@
  * Canvas boot config (#406, epic #407 / #401).
  *
  * When the SPA is hosted inside a Copilot canvas iframe, the kbexplorer-cli
- * loopback server (#190) injects a small boot object on `window.__KBX_CANVAS__`
- * BEFORE the embeddable entry (`src/canvas.tsx`) runs. This module is the typed,
- * defensive reader for that object — it never throws on a missing/partial/host-
- * tampered value and always resolves to a complete {@link CanvasBootConfig} with
- * safe defaults, so the headless mount can boot deterministically.
+ * loopback server (kbexplorer-cli#190) injects a small boot object on
+ * `window.__KBX_CANVAS__` BEFORE the embeddable entry (`src/canvas.tsx`) runs.
+ * This module is the typed, defensive reader for that object — it never throws
+ * on a missing/partial/host-tampered value and always resolves to a complete
+ * {@link CanvasBootConfig} with safe defaults, so the headless mount can boot
+ * deterministically.
  *
  * Pure and DOM-light: {@link parseCanvasBootConfig} takes the raw value so it is
  * unit-testable without a global; {@link readCanvasBootConfig} reads the global.
@@ -31,8 +32,13 @@ export interface CanvasBootConfig {
   /** Visual mode — defaults to `inherit-host` for the canvas surface. */
   visualMode: CanvasVisualMode;
   /**
-   * Loopback search-service URL the host exposes for semantic search, when
-   * present. Absent ⇒ the surface degrades to the in-memory search index.
+   * Loopback search-service URL the host exposes for semantic search.
+   *
+   * Reserved / forward-compat: parsed and carried on the boot contract now, but
+   * not yet consumed. The embeddable search wiring (this URL → the SPA search
+   * hook, mirroring `VITE_SEARCH_SERVICE_URL`) lands with the CLI `/search`
+   * endpoint (kbexplorer-cli A3 / #192). Until then the surface degrades to the
+   * in-memory search index; absent ⇒ same behavior.
    */
   searchServiceUrl?: string;
   /**

--- a/src/canvas/bootConfig.ts
+++ b/src/canvas/bootConfig.ts
@@ -1,0 +1,93 @@
+/**
+ * Canvas boot config (#406, epic #407 / #401).
+ *
+ * When the SPA is hosted inside a Copilot canvas iframe, the kbexplorer-cli
+ * loopback server (#190) injects a small boot object on `window.__KBX_CANVAS__`
+ * BEFORE the embeddable entry (`src/canvas.tsx`) runs. This module is the typed,
+ * defensive reader for that object — it never throws on a missing/partial/host-
+ * tampered value and always resolves to a complete {@link CanvasBootConfig} with
+ * safe defaults, so the headless mount can boot deterministically.
+ *
+ * Pure and DOM-light: {@link parseCanvasBootConfig} takes the raw value so it is
+ * unit-testable without a global; {@link readCanvasBootConfig} reads the global.
+ */
+
+/**
+ * The visual mode the embeddable surface renders in. `inherit-host` defers all
+ * Fluent tokens to the host theme mirrored onto the iframe `:root` (see
+ * `theme/hostTheme.ts`); `config` uses the repo's own configured theme.
+ */
+export type CanvasVisualMode = 'inherit-host' | 'config';
+
+/** The boot object the canvas host mirrors onto `window.__KBX_CANVAS__`. */
+export interface CanvasBootConfig {
+  /**
+   * Whether the graph is served from the pre-built local manifest (loopback)
+   * rather than a live system of record. Forward-compat/informational: local
+   * detection is still driven by the `VITE_KB_LOCAL` build flag, so the CLI
+   * builds the canvas bundle with `build:local`.
+   */
+  local: boolean;
+  /** Visual mode — defaults to `inherit-host` for the canvas surface. */
+  visualMode: CanvasVisualMode;
+  /**
+   * Loopback search-service URL the host exposes for semantic search, when
+   * present. Absent ⇒ the surface degrades to the in-memory search index.
+   */
+  searchServiceUrl?: string;
+  /**
+   * Optional node the conversation is anchored to. When set, the headless mount
+   * lands on that node (`/node/<id>`) instead of the repo's landing view — the
+   * seam the anchor-first home view (#408) builds on.
+   */
+  anchorNodeId?: string;
+}
+
+/** The safe baseline used when the host mirrors nothing usable. */
+export const DEFAULT_CANVAS_BOOT_CONFIG: CanvasBootConfig = {
+  local: false,
+  visualMode: 'inherit-host',
+};
+
+const VISUAL_MODES: readonly CanvasVisualMode[] = ['inherit-host', 'config'];
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() !== '' ? value : undefined;
+}
+
+/**
+ * Normalize an arbitrary raw value (typically `window.__KBX_CANVAS__`) into a
+ * complete {@link CanvasBootConfig}. Unknown/invalid fields fall back to the
+ * documented defaults; a non-object input yields the full default config.
+ */
+export function parseCanvasBootConfig(raw: unknown): CanvasBootConfig {
+  if (!raw || typeof raw !== 'object') return { ...DEFAULT_CANVAS_BOOT_CONFIG };
+  const obj = raw as Record<string, unknown>;
+
+  const visualMode = VISUAL_MODES.includes(obj.visualMode as CanvasVisualMode)
+    ? (obj.visualMode as CanvasVisualMode)
+    : DEFAULT_CANVAS_BOOT_CONFIG.visualMode;
+
+  return {
+    local: typeof obj.local === 'boolean' ? obj.local : DEFAULT_CANVAS_BOOT_CONFIG.local,
+    visualMode,
+    searchServiceUrl: optionalString(obj.searchServiceUrl),
+    anchorNodeId: optionalString(obj.anchorNodeId),
+  };
+}
+
+/** Global shape the host injects; declared for typed reads without `any`. */
+declare global {
+  interface Window {
+    __KBX_CANVAS__?: unknown;
+  }
+}
+
+/**
+ * Read and normalize `window.__KBX_CANVAS__`. Returns the full default config
+ * when there is no window (SSR/tests) or the host injected nothing.
+ */
+export function readCanvasBootConfig(): CanvasBootConfig {
+  if (typeof window === 'undefined') return { ...DEFAULT_CANVAS_BOOT_CONFIG };
+  return parseCanvasBootConfig(window.__KBX_CANVAS__);
+}

--- a/src/canvas/landing.ts
+++ b/src/canvas/landing.ts
@@ -1,0 +1,15 @@
+/**
+ * Canvas landing-path resolution (#406).
+ *
+ * Pure seam shared by the embeddable mount: an explicit `anchorNodeId` from the
+ * boot config wins (the conversation-anchored node the #408 anchor-first view
+ * builds on), otherwise the repo's own landing config applies.
+ */
+import type { KBConfig } from '../types';
+import { resolveLandingPath } from '../landing/resolveLanding';
+
+/** The initial hash-router path: anchor node if set, else the config landing. */
+export function resolveCanvasLandingPath(config: KBConfig, anchorNodeId?: string): string {
+  if (anchorNodeId) return `/node/${encodeURIComponent(anchorNodeId)}`;
+  return resolveLandingPath(config);
+}

--- a/src/canvas/useCanvasTheme.ts
+++ b/src/canvas/useCanvasTheme.ts
@@ -1,0 +1,81 @@
+/**
+ * Canvas theme resolution (#406, epic #407 / #401).
+ *
+ * The embeddable surface does NOT use the full-page `useTheme` machinery (the
+ * `t`-cycle, localStorage persistence, config-theme chooser). Inside a canvas
+ * the HOST owns the look: when `visualMode === 'inherit-host'` the Fluent theme
+ * is resolved straight from the semantic CSS vars the host mirrors onto the
+ * iframe `:root`, via the shared `theme/hostTheme.ts` adapter (#404). A host
+ * theme switch re-mirrors those vars, so this hook observes `<html>` and
+ * re-resolves — no reload, no user control.
+ *
+ * When the host mirrors nothing usable (or `visualMode === 'config'`), it falls
+ * back to the repo's own configured theme (`buildThemeMap` + `theme.default`),
+ * then to `webDarkTheme`, so the surface is never unthemed/blank.
+ */
+import { useEffect, useMemo, useState } from 'react';
+import { webDarkTheme, type Theme as FluentTheme } from '@fluentui/react-components';
+import type { KBConfig, PresentationTokens } from '../types';
+import { resolveHostFluentTheme } from '../theme/hostTheme';
+import { buildThemeMap } from '../hooks/useTheme';
+import type { CanvasVisualMode } from './bootConfig';
+
+/**
+ * Resolve the repo's own configured theme (the non-host fallback): the config
+ * `theme.default` if it names a built-in/config theme, else `dark`, else the
+ * first available — always a real Fluent theme (never unthemed).
+ */
+function resolveConfigTheme(config?: KBConfig): FluentTheme {
+  const map = buildThemeMap(config?.theme);
+  const preferred = config?.theme?.default;
+  if (preferred && map[preferred]) return map[preferred];
+  return map.dark ?? Object.values(map)[0] ?? webDarkTheme;
+}
+
+/**
+ * Pure resolver: build the active Fluent theme for a visual mode. Exposed for
+ * unit tests. In `inherit-host` mode a real host theme wins; otherwise (or when
+ * the host mirrors nothing) the configured theme is used.
+ */
+export function resolveCanvasTheme(
+  visualMode: CanvasVisualMode,
+  config?: KBConfig,
+  root?: Element | null,
+): FluentTheme {
+  if (visualMode === 'inherit-host') {
+    const presentation = (config?.theme as { presentation?: PresentationTokens } | undefined)
+      ?.presentation;
+    const host = resolveHostFluentTheme(
+      root ?? (typeof document !== 'undefined' ? document.documentElement : null),
+      presentation,
+    );
+    if (host) return host;
+  }
+  return resolveConfigTheme(config);
+}
+
+/**
+ * React hook: the active Fluent theme for the canvas surface, re-resolving when
+ * the host re-mirrors its semantic vars (theme switch). Observes the `<html>`
+ * `style`/`class` attributes — the surfaces a host toggles theme through — in
+ * `inherit-host` mode only; `config` mode resolves once from the static config.
+ */
+export function useCanvasTheme(visualMode: CanvasVisualMode, config?: KBConfig): FluentTheme {
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    if (visualMode !== 'inherit-host') return;
+    if (typeof MutationObserver === 'undefined' || typeof document === 'undefined') return;
+    const el = document.documentElement;
+    const observer = new MutationObserver(() => setTick(t => t + 1));
+    observer.observe(el, { attributes: true, attributeFilter: ['style', 'class'] });
+    return () => observer.disconnect();
+  }, [visualMode]);
+
+  // `tick` intentionally re-runs resolution when the host mutates <html>.
+  return useMemo(
+    () => resolveCanvasTheme(visualMode, config),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [visualMode, config, tick],
+  );
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,6 +26,16 @@ function manifestPlugin(): Plugin {
 export default defineConfig({
   base: process.env.VITE_BASE_PATH ?? '/',
   plugins: [manifestPlugin(), react()],
+  build: {
+    rollupOptions: {
+      // Two HTML entries: the full-page SPA (`index.html` → `main.tsx`) and the
+      // additive embeddable canvas surface (`canvas.html` → `canvas.tsx`, #406).
+      input: {
+        index: fileURLToPath(new URL('./index.html', import.meta.url)),
+        canvas: fileURLToPath(new URL('./canvas.html', import.meta.url)),
+      },
+    },
+  },
   envDir: process.env.VITE_ENV_DIR ?? process.cwd(),
   resolve: {
     alias: {


### PR DESCRIPTION
Closes #406.

Implements the visual foundation for the bespoke Copilot canvas (epic #407): an **additive** embeddable headless mount plus an `inherit-host` visual mode. The full-page `App`/`main.tsx` path is untouched.

## What
- **New entry (additive):** `canvas.html` → `src/canvas.tsx`, wired into `vite.config.ts` `rollupOptions.input` alongside `index.html`. The CLI loopback server (kbexplorer-cli #190) serves `canvas.html`.
- **Boot config:** `src/canvas/bootConfig.ts` — defensive, typed reader for `window.__KBX_CANVAS__` (`local`, `visualMode`, `searchServiceUrl?`, `anchorNodeId?`) with safe defaults; never throws.
- **Headless shell:** `src/canvas/EmbeddableApp.tsx` — `FluentProvider` + `HashRouter` only. **No** HUD, favicon, dock padding, or theme `t`-cycle. Renders the pure `KBGraph` through the **existing `spa` representation** (ReadingView/OverviewView/HomePage → node viewers, `kg://` identity/relations). Nothing rebuilt.
- **inherit-host wiring:** `src/canvas/useCanvasTheme.ts` — resolves all Fluent tokens from the host CSS vars mirrored onto the iframe `:root` via `theme/hostTheme.ts` (#404), falling back to the repo's configured theme when the host mirrors nothing. A `MutationObserver` on `<html>` re-resolves on host theme switches.
- **Anchor seam:** `src/canvas/landing.ts` — optional `anchorNodeId` lands on `/node/<id>` (else config landing). The bespoke agent-driven anchor-first view stays #408.

## Reuse (not rebuilt)
pure `KBGraph`, `spa` representation + node viewers, `kg://` identity/relations, `useKnowledgeBase`, `resolveHostFluentTheme`.

## Defaults chosen (documented)
- Reuse the `spa` target for #406; defer the bespoke `copilot` Representation to #407/#408.
- Local-mode keeps the existing `VITE_KB_LOCAL` build flag (CLI builds with `build:local`); boot `local` is forward-compat/informational.

## Verification — all green
- Unit: `892 passed` (17 new: bootConfig, useCanvasTheme resolve+fallback, landing).
- `tsc -b`: 0 errors. `eslint .`: 0 errors.
- `vite build` (remote) and `build:local`: both emit `canvas.html` + `index.html`.
- Playwright (`e2e/canvas-embed.spec.ts`): canvas mount boots from `__KBX_CANVAS__`, renders non-blank (reused `spa` prose), adopts the mirrored host background/foreground (inherit-host + live re-mirror via the observer), is the headless entry (no favicon link), with zero console errors.

Unblocks the template canvas children (#408 anchor-home, etc.).