### PR TITLE
feat: register the copilot Representation target (#440)

### DIFF
--- a/e2e/canvas-embed.spec.ts
+++ b/e2e/canvas-embed.spec.ts
@@ -62,4 +62,39 @@ test.describe('Embeddable canvas mount (#406)', () => {
     const appErrors = errors.filter(e => !e.includes('403') && !e.includes('rate limit'));
     expect(appErrors).toHaveLength(0);
   });
+
+  test('defaults to the copilot target and renders it host-themed (#440)', async ({ page }) => {
+    const errors: string[] = [];
+    page.on('console', msg => {
+      if (msg.type() === 'error' && !msg.text().includes('@griffel')) errors.push(msg.text());
+    });
+
+    // Boot with NO explicit target — the canvas surface defaults to `copilot`.
+    await page.addInitScript(() => {
+      (window as unknown as { __KBX_CANVAS__: unknown }).__KBX_CANVAS__ = {
+        local: false,
+        visualMode: 'inherit-host',
+        anchorNodeId: 'readme',
+      };
+    });
+    await page.goto('/canvas.html', { timeout: 60000 });
+
+    const surface = page.locator('[data-kbx-surface="canvas"]');
+    await expect(surface).toBeVisible({ timeout: 15000 });
+    // The registry-selected target the canvas resolved is `copilot`, not `spa`.
+    await expect(surface).toHaveAttribute('data-kbx-target', 'copilot');
+
+    // The copilot target reuses the `spa` reading viewer → anchored prose renders.
+    await expect(page.locator('.kb-prose')).toBeVisible({ timeout: 15000 });
+    await expect.poll(() => page.evaluate(() => location.hash)).toBe('#/node/readme');
+
+    // Host-themed via inherit-host (semantic vars mirrored onto the iframe root).
+    await mirrorHostVars(page);
+    await expect(surface).toHaveCSS('background-color', HOST_BG);
+    await expect(surface).toHaveCSS('color', HOST_FG);
+
+    await page.waitForTimeout(1000);
+    const appErrors = errors.filter(e => !e.includes('403') && !e.includes('rate limit'));
+    expect(appErrors).toHaveLength(0);
+  });
 });

--- a/src/canvas/EmbeddableApp.tsx
+++ b/src/canvas/EmbeddableApp.tsx
@@ -2,10 +2,12 @@
  * Embeddable headless mount (#406, epic #407 / #401).
  *
  * The canvas-mode counterpart to the full-page `App`. It renders the SAME pure
- * `KBGraph` through the SAME `spa` representation (ReadingView / OverviewView /
- * HomePage → node viewers, `kg://` identity + relations) but WITHOUT the full-
- * page chrome: no HUD, no favicon, no dock padding, no theme `t`-cycle. It is a
- * narrow, panel-friendly surface meant to sit inside a Copilot canvas iframe.
+ * `KBGraph` through a registry-selected representation (`boot.target`, default
+ * `copilot` — #440) but WITHOUT the full-page chrome: no HUD, no favicon, no
+ * dock padding, no theme `t`-cycle. It is a narrow, panel-friendly surface meant
+ * to sit inside a Copilot canvas iframe. The `copilot` target initially reuses
+ * the spa viewers (ReadingView / OverviewView / HomePage → node viewers,
+ * `kg://` identity + relations); the bespoke anchor-first layout lands in #408.
  *
  * This is ADDITIVE: the full-page `App`/`main.tsx` path is untouched. The theme
  * is host-driven via {@link useCanvasTheme} (`inherit-host`), and an optional
@@ -44,13 +46,14 @@ function CanvasExplorer({ boot }: { boot: CanvasBootConfig }): ReactNode {
       // Panel-friendly: fill the iframe, no full-page chrome/dock padding.
       style={{ minHeight: '100vh', width: '100%' }}
       data-kbx-surface="canvas"
+      data-kbx-target={boot.target}
     >
       <IsDarkContext.Provider value={isDark}>
         {state.status === 'loading' && <LoadingScreen />}
         {state.status === 'error' && <ErrorScreen message={state.error} />}
         {state.status === 'ready' && (
           <HashRouter>
-            {representationRegistry.resolve<ReactNode>('spa').render(state.graph, {
+            {representationRegistry.resolve<ReactNode>(boot.target).render(state.graph, {
               config: state.config,
               fluentTheme,
               landingPath: resolveCanvasLandingPath(state.config, boot.anchorNodeId),

--- a/src/canvas/__tests__/bootConfig.test.ts
+++ b/src/canvas/__tests__/bootConfig.test.ts
@@ -51,6 +51,15 @@ describe('parseCanvasBootConfig', () => {
     expect(parseCanvasBootConfig({ target: 42 }).target).toBe('copilot');
   });
 
+  it('trims surrounding whitespace on visualMode and target before validating', () => {
+    expect(parseCanvasBootConfig({ target: 'copilot ' }).target).toBe('copilot');
+    expect(parseCanvasBootConfig({ target: '  spa\n' }).target).toBe('spa');
+    expect(parseCanvasBootConfig({ visualMode: 'inherit-host\n' }).visualMode).toBe(
+      'inherit-host',
+    );
+    expect(parseCanvasBootConfig({ visualMode: ' config ' }).visualMode).toBe('config');
+  });
+
   it('falls back to inherit-host for an unknown visualMode', () => {
     expect(parseCanvasBootConfig({ visualMode: 'neon' }).visualMode).toBe('inherit-host');
   });

--- a/src/canvas/__tests__/bootConfig.test.ts
+++ b/src/canvas/__tests__/bootConfig.test.ts
@@ -11,9 +11,10 @@ describe('parseCanvasBootConfig', () => {
     }
   });
 
-  it('defaults visualMode to inherit-host and local to false when absent', () => {
+  it('defaults visualMode to inherit-host, target to copilot and local to false when absent', () => {
     const cfg = parseCanvasBootConfig({});
     expect(cfg.visualMode).toBe('inherit-host');
+    expect(cfg.target).toBe('copilot');
     expect(cfg.local).toBe(false);
     expect(cfg.searchServiceUrl).toBeUndefined();
     expect(cfg.anchorNodeId).toBeUndefined();
@@ -23,12 +24,14 @@ describe('parseCanvasBootConfig', () => {
     const cfg = parseCanvasBootConfig({
       local: true,
       visualMode: 'inherit-host',
+      target: 'spa',
       searchServiceUrl: 'http://127.0.0.1:9099/search',
       anchorNodeId: 'kg://issue/406',
     });
     expect(cfg).toEqual({
       local: true,
       visualMode: 'inherit-host',
+      target: 'spa',
       searchServiceUrl: 'http://127.0.0.1:9099/search',
       anchorNodeId: 'kg://issue/406',
     });
@@ -36,6 +39,16 @@ describe('parseCanvasBootConfig', () => {
 
   it('accepts the config visual mode', () => {
     expect(parseCanvasBootConfig({ visualMode: 'config' }).visualMode).toBe('config');
+  });
+
+  it('accepts the spa and copilot targets', () => {
+    expect(parseCanvasBootConfig({ target: 'spa' }).target).toBe('spa');
+    expect(parseCanvasBootConfig({ target: 'copilot' }).target).toBe('copilot');
+  });
+
+  it('falls back to copilot for an unknown target', () => {
+    expect(parseCanvasBootConfig({ target: 'json-ld' }).target).toBe('copilot');
+    expect(parseCanvasBootConfig({ target: 42 }).target).toBe('copilot');
   });
 
   it('falls back to inherit-host for an unknown visualMode', () => {

--- a/src/canvas/bootConfig.ts
+++ b/src/canvas/bootConfig.ts
@@ -20,6 +20,15 @@
  */
 export type CanvasVisualMode = 'inherit-host' | 'config';
 
+/**
+ * Which registered {@link RepresentationTarget} the embeddable canvas resolves.
+ * Defaults to `copilot` — the bespoke, agent-driven surface (#440, epic #407).
+ * `spa` is retained as an escape hatch so a host can fall back to the full
+ * explorer route tree unchanged. The full-page `App`/`main.tsx` path always
+ * renders `spa` and is unaffected by this field.
+ */
+export type CanvasRepresentationTarget = 'copilot' | 'spa';
+
 /** The boot object the canvas host mirrors onto `window.__KBX_CANVAS__`. */
 export interface CanvasBootConfig {
   /**
@@ -31,6 +40,13 @@ export interface CanvasBootConfig {
   local: boolean;
   /** Visual mode — defaults to `inherit-host` for the canvas surface. */
   visualMode: CanvasVisualMode;
+  /**
+   * Representation target the canvas resolves — defaults to `copilot` (#440),
+   * the bespoke agent-driven surface. Set to `spa` to render the full explorer
+   * route tree instead. Initially both render the same viewers; the `copilot`
+   * target is the seam the anchor-first bespoke view (#408) replaces.
+   */
+  target: CanvasRepresentationTarget;
   /**
    * Loopback search-service URL the host exposes for semantic search.
    *
@@ -53,9 +69,14 @@ export interface CanvasBootConfig {
 export const DEFAULT_CANVAS_BOOT_CONFIG: CanvasBootConfig = {
   local: false,
   visualMode: 'inherit-host',
+  target: 'copilot',
 };
 
 const VISUAL_MODES: readonly CanvasVisualMode[] = ['inherit-host', 'config'];
+const REPRESENTATION_TARGETS: readonly CanvasRepresentationTarget[] = [
+  'copilot',
+  'spa',
+];
 
 function optionalString(value: unknown): string | undefined {
   return typeof value === 'string' && value.trim() !== '' ? value : undefined;
@@ -74,9 +95,16 @@ export function parseCanvasBootConfig(raw: unknown): CanvasBootConfig {
     ? (obj.visualMode as CanvasVisualMode)
     : DEFAULT_CANVAS_BOOT_CONFIG.visualMode;
 
+  const target = REPRESENTATION_TARGETS.includes(
+    obj.target as CanvasRepresentationTarget,
+  )
+    ? (obj.target as CanvasRepresentationTarget)
+    : DEFAULT_CANVAS_BOOT_CONFIG.target;
+
   return {
     local: typeof obj.local === 'boolean' ? obj.local : DEFAULT_CANVAS_BOOT_CONFIG.local,
     visualMode,
+    target,
     searchServiceUrl: optionalString(obj.searchServiceUrl),
     anchorNodeId: optionalString(obj.anchorNodeId),
   };

--- a/src/canvas/bootConfig.ts
+++ b/src/canvas/bootConfig.ts
@@ -83,6 +83,15 @@ function optionalString(value: unknown): string | undefined {
 }
 
 /**
+ * A trimmed string candidate for enum-style fields: strings are trimmed (so a
+ * host value like `'copilot '` or `'inherit-host\n'` still matches the allowed
+ * set), non-strings become `undefined` (⇒ the caller falls back to its default).
+ */
+function enumCandidate(value: unknown): string | undefined {
+  return typeof value === 'string' ? value.trim() : undefined;
+}
+
+/**
  * Normalize an arbitrary raw value (typically `window.__KBX_CANVAS__`) into a
  * complete {@link CanvasBootConfig}. Unknown/invalid fields fall back to the
  * documented defaults; a non-object input yields the full default config.
@@ -91,14 +100,16 @@ export function parseCanvasBootConfig(raw: unknown): CanvasBootConfig {
   if (!raw || typeof raw !== 'object') return { ...DEFAULT_CANVAS_BOOT_CONFIG };
   const obj = raw as Record<string, unknown>;
 
-  const visualMode = VISUAL_MODES.includes(obj.visualMode as CanvasVisualMode)
-    ? (obj.visualMode as CanvasVisualMode)
+  const visualModeCandidate = enumCandidate(obj.visualMode);
+  const visualMode = VISUAL_MODES.includes(visualModeCandidate as CanvasVisualMode)
+    ? (visualModeCandidate as CanvasVisualMode)
     : DEFAULT_CANVAS_BOOT_CONFIG.visualMode;
 
+  const targetCandidate = enumCandidate(obj.target);
   const target = REPRESENTATION_TARGETS.includes(
-    obj.target as CanvasRepresentationTarget,
+    targetCandidate as CanvasRepresentationTarget,
   )
-    ? (obj.target as CanvasRepresentationTarget)
+    ? (targetCandidate as CanvasRepresentationTarget)
     : DEFAULT_CANVAS_BOOT_CONFIG.target;
 
   return {

--- a/src/representation/__tests__/registry.test.ts
+++ b/src/representation/__tests__/registry.test.ts
@@ -7,6 +7,7 @@ import {
   jsonLdRepresentation,
   llmContextRepresentation,
   spaRepresentation,
+  copilotRepresentation,
 } from '../targets';
 
 const EMPTY_GRAPH: KBGraph = { nodes: [], edges: [], clusters: [], related: {} };
@@ -41,17 +42,23 @@ describe('RepresentationRegistry (F6 #334)', () => {
   });
 });
 
-describe('default registry resolves all three built-in targets (F6 #333)', () => {
-  it('resolves spa, json-ld and llm-context', () => {
+describe('default registry resolves all built-in targets (F6 #333, B1 #440)', () => {
+  it('resolves spa, json-ld, llm-context and copilot', () => {
     const registry = createDefaultRegistry();
-    expect(registry.list()).toEqual(['json-ld', 'llm-context', 'spa']);
+    expect(registry.list()).toEqual(['copilot', 'json-ld', 'llm-context', 'spa']);
     expect(registry.resolve('spa')).toBe(spaRepresentation);
     expect(registry.resolve('json-ld')).toBe(jsonLdRepresentation);
     expect(registry.resolve('llm-context')).toBe(llmContextRepresentation);
+    expect(registry.resolve('copilot')).toBe(copilotRepresentation);
   });
 
   it('exposes a shared default registry instance', () => {
-    expect(representationRegistry.list()).toEqual(['json-ld', 'llm-context', 'spa']);
+    expect(representationRegistry.list()).toEqual([
+      'copilot',
+      'json-ld',
+      'llm-context',
+      'spa',
+    ]);
   });
 
   it('json-ld renders an empty graph deterministically', () => {

--- a/src/representation/targets/__tests__/copilot.test.ts
+++ b/src/representation/targets/__tests__/copilot.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import type { ReactElement } from 'react';
+import type { KBConfig, KBGraph } from '../../../types';
+import { webDarkTheme } from '@fluentui/react-components';
+import {
+  copilotRepresentation,
+  renderCopilotSurface,
+} from '../copilot';
+import { renderSpaRoutes, spaRepresentation, type SpaRenderOptions } from '../spa';
+
+const EMPTY_GRAPH: KBGraph = { nodes: [], edges: [], clusters: [], related: {} };
+const CONFIG = { landing: {} } as unknown as KBConfig;
+const OPTIONS: SpaRenderOptions = {
+  config: CONFIG,
+  fluentTheme: webDarkTheme,
+  landingPath: '/node/home',
+};
+
+describe('copilot representation target (B1 #440)', () => {
+  it('registers under the distinct "copilot" target name', () => {
+    expect(copilotRepresentation.target).toBe('copilot');
+    expect(copilotRepresentation.target).not.toBe(spaRepresentation.target);
+  });
+
+  it('initially delegates to the spa route tree (reuses viewers)', () => {
+    const copilotEl = renderCopilotSurface(EMPTY_GRAPH, OPTIONS) as ReactElement;
+    const spaEl = renderSpaRoutes(EMPTY_GRAPH, OPTIONS) as ReactElement;
+    // Same element type (the spa <Routes> tree) — copilot is a thin seam #408 replaces.
+    expect(copilotEl.type).toBe(spaEl.type);
+  });
+
+  it('render() forwards through to renderCopilotSurface', () => {
+    const viaTarget = copilotRepresentation.render(EMPTY_GRAPH, OPTIONS) as ReactElement;
+    const direct = renderCopilotSurface(EMPTY_GRAPH, OPTIONS) as ReactElement;
+    expect(viaTarget.type).toBe(direct.type);
+  });
+});

--- a/src/representation/targets/copilot.tsx
+++ b/src/representation/targets/copilot.tsx
@@ -32,6 +32,8 @@ export function renderCopilotSurface(
   graph: Parameters<typeof renderSpaRoutes>[0],
   options: CopilotRenderOptions,
 ): ReactNode {
+  // SEAM (#408): currently delegates to the `spa` route tree (reuses the node
+  // viewers) — replace this body with the anchor-first bespoke layout.
   return renderSpaRoutes(graph, options);
 }
 

--- a/src/representation/targets/copilot.tsx
+++ b/src/representation/targets/copilot.tsx
@@ -1,0 +1,44 @@
+/**
+ * `copilot` representation (B1 #440, epic #407 / #401).
+ *
+ * The destination surface for Copilot: a distinct {@link RepresentationTarget}
+ * the embeddable canvas resolves so the panel can render a Copilot-bespoke view
+ * of the SAME pure `KBGraph` the `spa` target renders. Registering it as its own
+ * named target — rather than reusing `spa` from the canvas mount — gives the
+ * bespoke children a stable seam to build on: the anchor-first home view (#408),
+ * the agent-action surface (#409), the affordance-aware launchpad (#411), etc.
+ *
+ * INITIALLY it delegates to the `spa` route tree ({@link renderSpaRoutes}) so it
+ * reuses the existing node viewers (`src/views/viewers/*`), `kg://` identity +
+ * relations, and `graph.related` / `llm-context` expansion unchanged. This keeps
+ * #440 purely additive — the target NAME the canvas resolves is the only change
+ * vs. #406. #408 replaces the render body below with the narrow-column,
+ * agent-driven, anchor-first layout without touching the registration/wiring.
+ */
+import type { ReactNode } from 'react';
+import type { Representation } from '@anokye-labs/kbexplorer-core';
+import { renderSpaRoutes, type SpaRenderOptions } from './spa';
+
+/**
+ * Runtime context the copilot view needs beyond the pure graph. Identical to
+ * {@link SpaRenderOptions} today because the render delegates to the spa route
+ * tree; kept as its own alias so #408 can widen it (agent actions, anchors)
+ * without disturbing the spa target's option shape.
+ */
+export type CopilotRenderOptions = SpaRenderOptions;
+
+/** Render the copilot surface for an already-built graph (reuses spa viewers). */
+export function renderCopilotSurface(
+  graph: Parameters<typeof renderSpaRoutes>[0],
+  options: CopilotRenderOptions,
+): ReactNode {
+  return renderSpaRoutes(graph, options);
+}
+
+/** The registered `copilot` representation target. */
+export const copilotRepresentation: Representation<ReactNode> = {
+  target: 'copilot',
+  render(graph, options) {
+    return renderCopilotSurface(graph, options as CopilotRenderOptions);
+  },
+};

--- a/src/representation/targets/index.ts
+++ b/src/representation/targets/index.ts
@@ -2,27 +2,31 @@
  * Representation targets (Phase 6 / F6 #333) and the default registry.
  *
  * Each target renders the pure `KBGraph` for a {@link RepresentationTarget}:
- * `spa` (the explorer website), `json-ld` (deterministic JSON-LD document) and
- * `llm-context` (neighbor-anchored, token-budgeted Markdown pack). They are
- * interchangeable behind the {@link RepresentationRegistry}.
+ * `spa` (the explorer website), `json-ld` (deterministic JSON-LD document),
+ * `llm-context` (neighbor-anchored, token-budgeted Markdown pack) and `copilot`
+ * (the embeddable canvas surface, #440 — initially reusing the spa viewers).
+ * They are interchangeable behind the {@link RepresentationRegistry}.
  */
 import { RepresentationRegistry } from '../registry';
 import { jsonLdRepresentation } from './json-ld';
 import { llmContextRepresentation } from './llm-context';
 import { spaRepresentation } from './spa';
+import { copilotRepresentation } from './copilot';
 
 export * from './urn';
 export * from './json-ld';
 export * from './llm-context';
 export * from './spa';
+export * from './copilot';
 
-/** Build a registry pre-populated with the three built-in targets. */
+/** Build a registry pre-populated with the built-in targets. */
 export function createDefaultRegistry(): RepresentationRegistry {
   return new RepresentationRegistry()
     .register(spaRepresentation)
     .register(jsonLdRepresentation)
-    .register(llmContextRepresentation);
+    .register(llmContextRepresentation)
+    .register(copilotRepresentation);
 }
 
-/** Shared default registry instance (spa + json-ld + llm-context). */
+/** Shared default registry instance (spa + json-ld + llm-context + copilot). */
 export const representationRegistry = createDefaultRegistry();


### PR DESCRIPTION
## B1 #440 — register the `copilot` Representation target (in-template)

Part of epic #407; implements the #413 decision (in-template, reuse viewers via the existing registry — no package extraction). Branches off latest `main` (#406 embeddable mount + inherit-host).

### What this does
Registers a distinct **`copilot`** `RepresentationTarget` in `src/representation/registry.ts` (via `createDefaultRegistry`) and wires the embeddable canvas path to select it, so the Copilot canvas resolves a *named* Copilot-bespoke target instead of hardcoding `spa`. This is the seam the bespoke children build on (#408 anchor-first view, #409 agent actions, #411 launchpad, …).

Core needs **zero change** — `RepresentationTarget` is an open union (`… | (string & {})`, core#16), so `'copilot'` registers without a cast.

### Additive by design
The `copilot` target **initially delegates to the `spa` route tree** (`renderSpaRoutes`), reusing the existing node viewers (`src/views/viewers/*`), `kg://` identity + relations, and expansion logic unchanged. The `spa` target and the full-page `App`/`main.tsx` path are untouched. #408 replaces the copilot render body with the narrow-column, agent-driven, anchor-first layout without touching this registration/wiring.

### Selection
- New `CanvasBootConfig.target` field (`'copilot' | 'spa'`), defensively parsed, **default `'copilot'`** for the canvas surface.
- `EmbeddableApp` resolves `boot.target` (was hardcoded `'spa'`) and exposes `data-kbx-target` for observability.

### Changes
- `src/representation/targets/copilot.tsx` — `copilotRepresentation` + `renderCopilotSurface` (delegates to spa)
- `src/representation/targets/index.ts` — register `copilot` in `createDefaultRegistry`
- `src/canvas/bootConfig.ts` — `CanvasRepresentationTarget` + `target` parse/default
- `src/canvas/EmbeddableApp.tsx` — resolve `boot.target`; `data-kbx-target`
- Tests: copilot target unit test; registry + bootConfig coverage; e2e copilot-target render

### Verification (0 fail)
- **Unit:** 897 passed (83 files) — incl. new copilot target + boot/registry coverage
- **tsc / vite build:** clean
- **eslint:** 0 errors (3 warnings all pre-existing, unrelated)
- **Playwright** (`e2e/canvas-embed.spec.ts`, local build): 2 passed — canvas defaults to the `copilot` target, renders host-themed via `inherit-host` (`data-kbx-target="copilot"`, anchored prose renders), **zero console errors**

Unblocks #408 and the other bespoke #407 children.

Closes #440