### PR TITLE
feat: anchor-first bespoke copilot home view (#408)

### DIFF
--- a/e2e/canvas-embed.spec.ts
+++ b/e2e/canvas-embed.spec.ts
@@ -1,11 +1,17 @@
 import { test, expect } from '@playwright/test';
 
 /**
- * Embeddable canvas mount (#406). Verifies the additive `canvas.html` surface:
- * it boots from `window.__KBX_CANVAS__`, inherits the host theme mirrored onto
- * the iframe `:root` (inherit-host visual mode — including live re-mirror on a
- * host theme switch), renders non-blank reusing the `spa` viewers, and logs no
- * console errors — WITHOUT the full-page favicon/HUD chrome.
+ * Embeddable canvas mount (#406) + bespoke copilot target (#440) + anchor-first
+ * home view (#408). Verifies the additive `canvas.html` surface: it boots from
+ * `window.__KBX_CANVAS__`, inherits the host theme mirrored onto the iframe
+ * `:root` (inherit-host — including live re-mirror on a host theme switch),
+ * renders non-blank, and logs no console errors — WITHOUT the full-page
+ * favicon/HUD chrome.
+ *
+ * The default `copilot` target now renders the anchor-first landing (#408): the
+ * conversation anchor node + its weight-ranked neighbors, with `kg://` chips for
+ * the unexpanded remainder and the constellation demoted to an optional
+ * zoom-out. The `spa` target remains as an escape hatch (route tree + viewers).
  */
 
 const HOST_BG = 'rgb(13, 17, 23)'; // #0d1117 — GitHub dark canvas
@@ -22,18 +28,36 @@ async function mirrorHostVars(page: import('@playwright/test').Page): Promise<vo
   });
 }
 
-test.describe('Embeddable canvas mount (#406)', () => {
-  test('boots host-themed and non-blank with no full-page chrome', async ({ page }) => {
-    const errors: string[] = [];
-    page.on('console', msg => {
-      if (msg.type() === 'error' && !msg.text().includes('@griffel')) errors.push(msg.text());
-    });
+function collectErrors(page: import('@playwright/test').Page): string[] {
+  const errors: string[] = [];
+  page.on('console', msg => {
+    if (msg.type() === 'error' && !msg.text().includes('@griffel')) errors.push(msg.text());
+  });
+  return errors;
+}
+
+function appErrors(errors: string[]): string[] {
+  // Ignore infra noise: twin rate-limits (403) and missing image bytes the twin
+  // serves as 404 for `img` assets (README hero / sprites) — neither is an app
+  // or JS error surfaced by the anchor-first view.
+  return errors.filter(
+    e =>
+      !e.includes('403') &&
+      !e.includes('rate limit') &&
+      !e.includes('Failed to load resource'),
+  );
+}
+
+test.describe('Embeddable canvas mount (#406 / #440 / #408)', () => {
+  test('spa escape hatch: boots host-themed, reuses the reading viewer', async ({ page }) => {
+    const errors = collectErrors(page);
 
     // The loopback host injects the boot config before app code runs.
     await page.addInitScript(() => {
       (window as unknown as { __KBX_CANVAS__: unknown }).__KBX_CANVAS__ = {
         local: false,
         visualMode: 'inherit-host',
+        target: 'spa',
         anchorNodeId: 'readme',
       };
     });
@@ -41,33 +65,29 @@ test.describe('Embeddable canvas mount (#406)', () => {
 
     // Reused `spa` reading viewer renders the anchored node's prose — non-blank.
     await expect(page.locator('.kb-prose')).toBeVisible({ timeout: 15000 });
-
     // anchorNodeId from the boot config lands on /node/<id> (HashRouter).
     await expect.poll(() => page.evaluate(() => location.hash)).toBe('#/node/readme');
 
     const surface = page.locator('[data-kbx-surface="canvas"]');
     await expect(surface).toBeVisible();
+    await expect(surface).toHaveAttribute('data-kbx-target', 'spa');
 
-    // Host mirrors its semantic vars → inherit-host re-resolves (MutationObserver)
-    // and the Fluent surface adopts the host background/foreground.
+    // Host mirrors its semantic vars → inherit-host re-resolves (MutationObserver).
     await mirrorHostVars(page);
     await expect(surface).toHaveCSS('background-color', HOST_BG);
     await expect(surface).toHaveCSS('color', HOST_FG);
 
-    // Headless entry: the canvas HTML, not the full-page index.html (distinct
-    // title). The canvas ships no real favicon and no HUD chrome.
+    // Headless entry: the canvas HTML, not the full-page index.html.
     await expect(page).toHaveTitle(/kbexplorer canvas/);
 
     await page.waitForTimeout(1000);
-    const appErrors = errors.filter(e => !e.includes('403') && !e.includes('rate limit'));
-    expect(appErrors).toHaveLength(0);
+    expect(appErrors(errors)).toHaveLength(0);
   });
 
-  test('defaults to the copilot target and renders it host-themed (#440)', async ({ page }) => {
-    const errors: string[] = [];
-    page.on('console', msg => {
-      if (msg.type() === 'error' && !msg.text().includes('@griffel')) errors.push(msg.text());
-    });
+  test('copilot (default): anchor-first home renders the anchor + neighbors (#408)', async ({
+    page,
+  }) => {
+    const errors = collectErrors(page);
 
     // Boot with NO explicit target — the canvas surface defaults to `copilot`.
     await page.addInitScript(() => {
@@ -84,9 +104,17 @@ test.describe('Embeddable canvas mount (#406)', () => {
     // The registry-selected target the canvas resolved is `copilot`, not `spa`.
     await expect(surface).toHaveAttribute('data-kbx-target', 'copilot');
 
-    // The copilot target reuses the `spa` reading viewer → anchored prose renders.
-    await expect(page.locator('.kb-prose')).toBeVisible({ timeout: 15000 });
+    // The default landing is the anchor-first home (NOT the constellation): the
+    // conversation anchor is featured, anchored on /node/readme (HashRouter).
+    const anchorView = page.locator('[data-testid="anchor-first-view"]');
+    await expect(anchorView).toBeVisible({ timeout: 15000 });
+    await expect(anchorView).toHaveAttribute('data-anchor-id', 'readme');
     await expect.poll(() => page.evaluate(() => location.hash)).toBe('#/node/readme');
+
+    // Its weight-ranked neighbors are present, expanded inline...
+    await expect(page.locator('[data-testid="anchor-expanded-neighbor"]').first()).toBeVisible();
+    // ...and the constellation is an optional zoom-out affordance, not the landing.
+    await expect(page.locator('[data-testid="constellation-zoom-out"]')).toBeVisible();
 
     // Host-themed via inherit-host (semantic vars mirrored onto the iframe root).
     await mirrorHostVars(page);
@@ -94,7 +122,46 @@ test.describe('Embeddable canvas mount (#406)', () => {
     await expect(surface).toHaveCSS('color', HOST_FG);
 
     await page.waitForTimeout(1000);
-    const appErrors = errors.filter(e => !e.includes('403') && !e.includes('rate limit'));
-    expect(appErrors).toHaveLength(0);
+    expect(appErrors(errors)).toHaveLength(0);
+  });
+
+  test('copilot: kg:// chips re-anchor and the constellation is reachable (#408)', async ({
+    page,
+  }) => {
+    const errors = collectErrors(page);
+
+    await page.addInitScript(() => {
+      (window as unknown as { __KBX_CANVAS__: unknown }).__KBX_CANVAS__ = {
+        local: false,
+        visualMode: 'inherit-host',
+        anchorNodeId: 'readme',
+      };
+    });
+    await page.goto('/canvas.html', { timeout: 60000 });
+
+    await expect(page.locator('[data-testid="anchor-first-view"]')).toBeVisible({ timeout: 15000 });
+
+    // A relevant-but-unexpanded neighbor is a navigable kg:// chip. Clicking it
+    // re-anchors the view on that node (HashRouter /node/<id>).
+    const chip = page.locator('[data-testid="anchor-neighbor-chip"]').first();
+    await expect(chip).toBeVisible();
+    const chipNodeId = await chip.getAttribute('data-node-id');
+    expect(chipNodeId).toBeTruthy();
+    await chip.click();
+    await expect
+      .poll(() => page.evaluate(() => location.hash))
+      .toBe(`#/node/${encodeURIComponent(chipNodeId as string)}`);
+    await expect(page.locator('[data-testid="anchor-first-view"]')).toHaveAttribute(
+      'data-anchor-id',
+      chipNodeId as string,
+    );
+
+    // The constellation zoom-out is reachable from the anchor-first home.
+    await page.locator('[data-testid="constellation-zoom-out"]').click();
+    await expect.poll(() => page.evaluate(() => location.hash)).toBe('#/constellation');
+    await expect(page.getByText('Knowledge Clusters')).toBeVisible({ timeout: 15000 });
+
+    await page.waitForTimeout(500);
+    expect(appErrors(errors)).toHaveLength(0);
   });
 });

--- a/src/canvas/EmbeddableApp.tsx
+++ b/src/canvas/EmbeddableApp.tsx
@@ -57,6 +57,7 @@ function CanvasExplorer({ boot }: { boot: CanvasBootConfig }): ReactNode {
               config: state.config,
               fluentTheme,
               landingPath: resolveCanvasLandingPath(state.config, boot.anchorNodeId),
+              anchorNodeId: boot.anchorNodeId,
             }) as ReactNode}
           </HashRouter>
         )}

--- a/src/representation/targets/__tests__/copilot.test.ts
+++ b/src/representation/targets/__tests__/copilot.test.ts
@@ -1,37 +1,80 @@
 import { describe, it, expect } from 'vitest';
 import type { ReactElement } from 'react';
+import { Children, isValidElement } from 'react';
 import type { KBConfig, KBGraph } from '../../../types';
 import { webDarkTheme } from '@fluentui/react-components';
 import {
   copilotRepresentation,
   renderCopilotSurface,
+  type CopilotRenderOptions,
 } from '../copilot';
-import { renderSpaRoutes, spaRepresentation, type SpaRenderOptions } from '../spa';
+import { spaRepresentation } from '../spa';
 
 const EMPTY_GRAPH: KBGraph = { nodes: [], edges: [], clusters: [], related: {} };
-const CONFIG = { landing: {} } as unknown as KBConfig;
-const OPTIONS: SpaRenderOptions = {
-  config: CONFIG,
-  fluentTheme: webDarkTheme,
-  landingPath: '/node/home',
-};
+const CONFIG = { landing: {}, clusters: {} } as unknown as KBConfig;
 
-describe('copilot representation target (B1 #440)', () => {
+function baseOptions(overrides: Partial<CopilotRenderOptions> = {}): CopilotRenderOptions {
+  return {
+    config: CONFIG,
+    fluentTheme: webDarkTheme,
+    landingPath: '/node/home',
+    ...overrides,
+  };
+}
+
+/** Collect the `path`/`to` props of the route tree the copilot surface renders. */
+function routePaths(element: ReactElement): { paths: string[]; navigateTargets: string[] } {
+  const paths: string[] = [];
+  const navigateTargets: string[] = [];
+  const children = (element.props as { children?: unknown }).children;
+  Children.forEach(children as never, child => {
+    if (!isValidElement(child)) return;
+    const props = child.props as { path?: string; element?: ReactElement };
+    if (props.path) paths.push(props.path);
+    const routed = props.element;
+    if (routed && isValidElement(routed)) {
+      const to = (routed.props as { to?: string }).to;
+      if (typeof to === 'string') navigateTargets.push(to);
+    }
+  });
+  return { paths, navigateTargets };
+}
+
+describe('copilot representation target (B1 #440 / B2 #408)', () => {
   it('registers under the distinct "copilot" target name', () => {
     expect(copilotRepresentation.target).toBe('copilot');
     expect(copilotRepresentation.target).not.toBe(spaRepresentation.target);
   });
 
-  it('initially delegates to the spa route tree (reuses viewers)', () => {
-    const copilotEl = renderCopilotSurface(EMPTY_GRAPH, OPTIONS) as ReactElement;
-    const spaEl = renderSpaRoutes(EMPTY_GRAPH, OPTIONS) as ReactElement;
-    // Same element type (the spa <Routes> tree) — copilot is a thin seam #408 replaces.
-    expect(copilotEl.type).toBe(spaEl.type);
+  it('renders an anchor-first route tree (not the constellation as landing)', () => {
+    const el = renderCopilotSurface(EMPTY_GRAPH, baseOptions()) as ReactElement;
+    const { paths } = routePaths(el);
+    expect(paths).toContain('/node/:id'); // the anchor-first home
+    expect(paths).toContain('/constellation'); // zoom-out, not landing
+    expect(paths).toContain('/'); // initial redirect
+  });
+
+  it('lands on the conversation anchor when anchorNodeId is set', () => {
+    const el = renderCopilotSurface(
+      EMPTY_GRAPH,
+      baseOptions({ anchorNodeId: 'kb://mission/x' }),
+    ) as ReactElement;
+    const { navigateTargets } = routePaths(el);
+    expect(navigateTargets).toContain('/node/kb%3A%2F%2Fmission%2Fx');
+  });
+
+  it('falls back to the config landingPath when no anchor is supplied', () => {
+    const el = renderCopilotSurface(
+      EMPTY_GRAPH,
+      baseOptions({ landingPath: '/node/home' }),
+    ) as ReactElement;
+    const { navigateTargets } = routePaths(el);
+    expect(navigateTargets).toContain('/node/home');
   });
 
   it('render() forwards through to renderCopilotSurface', () => {
-    const viaTarget = copilotRepresentation.render(EMPTY_GRAPH, OPTIONS) as ReactElement;
-    const direct = renderCopilotSurface(EMPTY_GRAPH, OPTIONS) as ReactElement;
+    const viaTarget = copilotRepresentation.render(EMPTY_GRAPH, baseOptions()) as ReactElement;
+    const direct = renderCopilotSurface(EMPTY_GRAPH, baseOptions()) as ReactElement;
     expect(viaTarget.type).toBe(direct.type);
   });
 });

--- a/src/representation/targets/copilot-home/AnchorFirstView.tsx
+++ b/src/representation/targets/copilot-home/AnchorFirstView.tsx
@@ -1,0 +1,286 @@
+/**
+ * Anchor-first home view (B2 #408, epic #407 / #401).
+ *
+ * The bespoke `copilot` surface's landing view — NOT the constellation. It
+ * renders the conversation's anchor node (via its existing node-type viewer from
+ * the open viewer registry — REUSED, never rebuilt), then that anchor's
+ * weight-ranked neighbors: the top-ranked ones EXPANDED inline, and the
+ * relevant-but-unexpanded remainder as navigable `kg://` chips that re-anchor
+ * the view on click (`#/node/<id>`). The force-directed constellation becomes an
+ * optional zoom-out affordance, not the landing.
+ *
+ * Ranking + expansion are NOT reimplemented here: {@link expandAnchoredNeighborhood}
+ * is the same greedy partition (over the engine's `graph.related` edge-weight
+ * order) that `llm-context` uses — the view supplies a unit cost + a
+ * max-expanded count instead of a token budget/cost.
+ *
+ * NO-ANCHOR FALLBACK: when the anchor id is absent from the graph (including the
+ * no-anchor `/node/home` config landing), the constellation ({@link HomePage})
+ * renders as the sensible default.
+ *
+ * THEME: inherit-host is already wired by the embeddable mount
+ * (`useCanvasTheme`); this view consumes Fluent tokens only and never re-mirrors
+ * host vars.
+ */
+import { createElement } from 'react';
+import {
+  Badge,
+  Body1,
+  Button,
+  Caption1,
+  Card,
+  Divider,
+  Subtitle2,
+  Title3,
+  makeStyles,
+  tokens,
+} from '@fluentui/react-components';
+import { ArrowExpandRegular } from '@fluentui/react-icons';
+import { stripScheme } from '@anokye-labs/kbexplorer-core';
+import type { KBConfig, KBEdge, KBGraph } from '../../../types';
+import { resolveViewer } from '../../../views/viewers';
+import { HomePage } from '../../../views/HomePage';
+import { nodeUrn } from '../urn';
+import { expandAnchoredNeighborhood, type AnchoredNeighbor } from '../llm-context';
+
+/** Default number of top-ranked neighbors rendered inline (rest → chips). */
+export const DEFAULT_MAX_EXPANDED = 6;
+
+/** Relation label for a neighbor edge: explicit relation, else structural type. */
+function relationLabel(edge: KBEdge | undefined): string {
+  return edge?.relation ?? edge?.type ?? 'related';
+}
+
+function weightLabel(edge: KBEdge | undefined): string {
+  return (edge?.weight ?? 0).toFixed(2);
+}
+
+const useStyles = makeStyles({
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: tokens.spacingVerticalL,
+    padding: tokens.spacingHorizontalL,
+    boxSizing: 'border-box',
+    width: '100%',
+  },
+  header: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: tokens.spacingVerticalXS,
+  },
+  headerRow: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: tokens.spacingHorizontalS,
+  },
+  anchorBadges: {
+    display: 'flex',
+    gap: tokens.spacingHorizontalXS,
+    alignItems: 'center',
+    flexWrap: 'wrap',
+  },
+  anchorBody: {
+    display: 'block',
+  },
+  section: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: tokens.spacingVerticalS,
+  },
+  sectionTitle: {
+    color: tokens.colorNeutralForeground3,
+  },
+  neighborCard: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: tokens.spacingVerticalXS,
+  },
+  neighborHead: {
+    display: 'flex',
+    alignItems: 'baseline',
+    justifyContent: 'space-between',
+    gap: tokens.spacingHorizontalS,
+  },
+  neighborMeta: {
+    color: tokens.colorNeutralForeground3,
+    whiteSpace: 'nowrap',
+  },
+  chips: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: tokens.spacingHorizontalXS,
+  },
+  chip: {
+    minWidth: 0,
+    justifyContent: 'flex-start',
+    height: 'auto',
+    paddingTop: tokens.spacingVerticalXS,
+    paddingBottom: tokens.spacingVerticalXS,
+  },
+  urn: {
+    color: tokens.colorNeutralForeground3,
+    fontSize: tokens.fontSizeBase200,
+  },
+});
+
+/** A single expanded neighbor: header (title · relation · weight) + its viewer. */
+function ExpandedNeighbor({ neighbor }: { neighbor: AnchoredNeighbor }) {
+  const styles = useStyles();
+  const { node, edge } = neighbor;
+  return (
+    <Card
+      appearance="subtle"
+      size="small"
+      className={styles.neighborCard}
+      data-testid="anchor-expanded-neighbor"
+      data-node-id={node.id}
+    >
+      <a
+        href={`#/node/${encodeURIComponent(node.id)}`}
+        style={{ textDecoration: 'none', color: 'inherit' }}
+      >
+        <div className={styles.neighborHead}>
+          <Subtitle2>{node.title}</Subtitle2>
+          <Caption1 className={styles.neighborMeta}>
+            {relationLabel(edge)} · {weightLabel(edge)}
+          </Caption1>
+        </div>
+      </a>
+      {createElement(resolveViewer(node), { node })}
+    </Card>
+  );
+}
+
+/** A `kg://` chip for a relevant-but-unexpanded neighbor — navigates on click. */
+function NeighborChip({ neighbor }: { neighbor: AnchoredNeighbor }) {
+  const styles = useStyles();
+  const { node, edge } = neighbor;
+  const urn = nodeUrn(node);
+  return (
+    <Button
+      as="a"
+      href={`#/node/${encodeURIComponent(node.id)}`}
+      appearance="outline"
+      size="small"
+      className={styles.chip}
+      title={`${stripScheme(urn)} · ${relationLabel(edge)} · weight ${weightLabel(edge)}`}
+      data-testid="anchor-neighbor-chip"
+      data-node-id={node.id}
+    >
+      {node.title}
+    </Button>
+  );
+}
+
+export interface AnchorFirstViewProps {
+  graph: KBGraph;
+  config: KBConfig;
+  /** The conversation anchor node id (from `bootConfig.anchorNodeId`). */
+  anchorId: string;
+  /** Max top-ranked neighbors rendered inline; the rest become `kg://` chips. */
+  maxExpanded?: number;
+}
+
+/**
+ * Render the anchor-first home for a single anchor node. Falls back to the
+ * constellation when the anchor id is not a node in the graph.
+ */
+export function AnchorFirstView({
+  graph,
+  config,
+  anchorId,
+  maxExpanded = DEFAULT_MAX_EXPANDED,
+}: AnchorFirstViewProps) {
+  const styles = useStyles();
+
+  const anchor = graph.nodes.find(n => n.id === anchorId);
+
+  // NO-ANCHOR / bad-anchor fallback: the constellation is the sensible default.
+  if (!anchor) {
+    return (
+      <div className={styles.root} data-testid="anchor-first-fallback">
+        <Caption1 className={styles.sectionTitle}>
+          No conversation anchor — showing the full map.
+        </Caption1>
+        <HomePage graph={graph} config={config} />
+      </div>
+    );
+  }
+
+  // Reuse the shared greedy partition (llm-context): unit cost + count budget,
+  // so the top `maxExpanded` ranked neighbors expand and the rest link out.
+  const { expanded, unexpanded } = expandAnchoredNeighborhood(
+    graph,
+    [anchorId],
+    () => 1,
+    maxExpanded,
+  );
+
+  const cluster = config.clusters?.[anchor.cluster];
+
+  return (
+    <div className={styles.root} data-testid="anchor-first-view" data-anchor-id={anchor.id}>
+      <div className={styles.header}>
+        <div className={styles.headerRow}>
+          <Title3>{anchor.title}</Title3>
+          <Button
+            as="a"
+            href="#/constellation"
+            appearance="subtle"
+            size="small"
+            icon={<ArrowExpandRegular />}
+            data-testid="constellation-zoom-out"
+          >
+            Constellation
+          </Button>
+        </div>
+        <div className={styles.anchorBadges}>
+          <Badge appearance="tint" color="brand">
+            Anchor
+          </Badge>
+          {cluster?.name && (
+            <Badge appearance="tint" color="informative">
+              {cluster.name}
+            </Badge>
+          )}
+          <code className={styles.urn}>{stripScheme(nodeUrn(anchor))}</code>
+        </div>
+      </div>
+
+      <div className={styles.anchorBody}>
+        {createElement(resolveViewer(anchor), { node: anchor })}
+      </div>
+
+      {expanded.length > 0 && (
+        <>
+          <Divider />
+          <div className={styles.section} data-testid="anchor-expanded-neighbors">
+            <Body1 className={styles.sectionTitle}>Nearest neighbors</Body1>
+            {expanded.map(neighbor => (
+              <ExpandedNeighbor key={neighbor.node.id} neighbor={neighbor} />
+            ))}
+          </div>
+        </>
+      )}
+
+      {unexpanded.length > 0 && (
+        <div className={styles.section} data-testid="anchor-neighbor-chips">
+          <Body1 className={styles.sectionTitle}>Navigate — follow a link for more</Body1>
+          <div className={styles.chips}>
+            {unexpanded.map(neighbor => (
+              <NeighborChip key={neighbor.node.id} neighbor={neighbor} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {expanded.length === 0 && unexpanded.length === 0 && (
+        <Caption1 className={styles.sectionTitle} data-testid="anchor-no-neighbors">
+          This node has no ranked neighbors yet.
+        </Caption1>
+      )}
+    </div>
+  );
+}

--- a/src/representation/targets/copilot-home/AnchorFirstView.tsx
+++ b/src/representation/targets/copilot-home/AnchorFirstView.tsx
@@ -22,7 +22,7 @@
  * (`useCanvasTheme`); this view consumes Fluent tokens only and never re-mirrors
  * host vars.
  */
-import { createElement } from 'react';
+import { createElement, useMemo } from 'react';
 import {
   Badge,
   Body1,
@@ -195,7 +195,18 @@ export function AnchorFirstView({
 }: AnchorFirstViewProps) {
   const styles = useStyles();
 
-  const anchor = graph.nodes.find(n => n.id === anchorId);
+  // Memoize the anchor lookup + shared greedy partition (llm-context) so theme
+  // changes / parent re-renders don't re-run the O(n) walk. Unit cost + a count
+  // budget expand the top `maxExpanded` ranked neighbors; the rest link out.
+  // Computed before any early return so hook order stays stable.
+  const { anchor, expanded, unexpanded } = useMemo(() => {
+    const anchorNode = graph.nodes.find(n => n.id === anchorId);
+    if (!anchorNode) {
+      return { anchor: undefined, expanded: [], unexpanded: [] };
+    }
+    const partition = expandAnchoredNeighborhood(graph, [anchorId], () => 1, maxExpanded);
+    return { anchor: anchorNode, expanded: partition.expanded, unexpanded: partition.unexpanded };
+  }, [graph, anchorId, maxExpanded]);
 
   // NO-ANCHOR / bad-anchor fallback: the constellation is the sensible default.
   if (!anchor) {
@@ -208,15 +219,6 @@ export function AnchorFirstView({
       </div>
     );
   }
-
-  // Reuse the shared greedy partition (llm-context): unit cost + count budget,
-  // so the top `maxExpanded` ranked neighbors expand and the rest link out.
-  const { expanded, unexpanded } = expandAnchoredNeighborhood(
-    graph,
-    [anchorId],
-    () => 1,
-    maxExpanded,
-  );
 
   const cluster = config.clusters?.[anchor.cluster];
 

--- a/src/representation/targets/copilot-home/__tests__/anchor-first-view.test.ts
+++ b/src/representation/targets/copilot-home/__tests__/anchor-first-view.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import type { KBConfig, KBGraph, KBNode } from '../../../../types';
+import { expandAnchoredNeighborhood } from '../../llm-context';
+import { AnchorFirstView } from '../AnchorFirstView';
+
+function node(id: string): KBNode {
+  return {
+    id,
+    title: `Title ${id}`,
+    cluster: 'default',
+    content: '',
+    rawContent: `Body of ${id}`,
+    connections: [],
+    source: { type: 'file', path: '' },
+  };
+}
+
+// anchor -> n1 (weight 5), n2 (weight 3); related is weight-ranked.
+const graph: KBGraph = {
+  nodes: [node('anchor'), node('n1'), node('n2'), node('far')],
+  edges: [
+    { from: 'anchor', to: 'n1', type: 'references', relation: 'leads', description: '', source: 'inline', weight: 5 },
+    { from: 'anchor', to: 'n2', type: 'references', relation: 'staffs', description: '', source: 'inline', weight: 3 },
+  ],
+  clusters: [],
+  related: { anchor: ['n1', 'n2'], n1: ['anchor'], n2: ['anchor'] },
+};
+
+const config = {
+  clusters: { default: { name: 'Default', color: '#4A9CC8' } },
+} as unknown as KBConfig;
+
+describe('expandAnchoredNeighborhood (shared #408 / llm-context ranking)', () => {
+  it('walks graph.related in weight rank order into ranked candidates', () => {
+    const { expanded } = expandAnchoredNeighborhood(graph, ['anchor'], () => 1, 10);
+    expect(expanded.map(n => n.node.id)).toEqual(['n1', 'n2']);
+    // best-anchor edge is carried for relation/weight labelling
+    expect(expanded[0].edge?.relation).toBe('leads');
+  });
+
+  it('greedily partitions expanded vs unexpanded by the count budget', () => {
+    const { expanded, unexpanded } = expandAnchoredNeighborhood(graph, ['anchor'], () => 1, 1);
+    expect(expanded.map(n => n.node.id)).toEqual(['n1']);
+    expect(unexpanded.map(n => n.node.id)).toEqual(['n2']);
+  });
+
+  it('never expands the whole graph — only the anchor neighborhood', () => {
+    const { expanded, unexpanded } = expandAnchoredNeighborhood(graph, ['anchor'], () => 1, 10);
+    const ids = [...expanded, ...unexpanded].map(n => n.node.id);
+    expect(ids).not.toContain('far'); // two hops away
+    expect(ids).not.toContain('anchor'); // anchors are excluded from neighbors
+  });
+
+  it('degrades gracefully (no throw) for an absent anchor id', () => {
+    const { anchors, expanded } = expandAnchoredNeighborhood(graph, ['nope'], () => 1, 10);
+    expect(anchors).toEqual([]);
+    expect(expanded).toEqual([]);
+  });
+});
+
+describe('AnchorFirstView (B2 #408 landing)', () => {
+  it('renders the anchor + expanded neighbor + kg:// chip navigation', () => {
+    const html = renderToStaticMarkup(
+      createElement(AnchorFirstView, { graph, config, anchorId: 'anchor', maxExpanded: 1 }),
+    );
+    // anchor is featured
+    expect(html).toContain('data-testid="anchor-first-view"');
+    expect(html).toContain('Title anchor');
+    // top-ranked neighbor expanded inline...
+    expect(html).toContain('data-testid="anchor-expanded-neighbor"');
+    expect(html).toContain('data-node-id="n1"');
+    // ...the rest are navigable kg:// chips that re-anchor the view
+    expect(html).toContain('data-testid="anchor-neighbor-chip"');
+    expect(html).toContain('href="#/node/n2"');
+    // constellation is an optional zoom-out affordance, not the landing
+    expect(html).toContain('data-testid="constellation-zoom-out"');
+    expect(html).toContain('href="#/constellation"');
+  });
+
+  it('links the anchor URN and clicking a neighbor card re-anchors', () => {
+    const html = renderToStaticMarkup(
+      createElement(AnchorFirstView, { graph, config, anchorId: 'anchor', maxExpanded: 6 }),
+    );
+    expect(html).toContain('href="#/node/n1"');
+    expect(html).toContain('href="#/node/n2"');
+    // no chips when every neighbor fits the expansion budget
+    expect(html).not.toContain('data-testid="anchor-neighbor-chip"');
+  });
+});

--- a/src/representation/targets/copilot.tsx
+++ b/src/representation/targets/copilot.tsx
@@ -1,40 +1,81 @@
 /**
- * `copilot` representation (B1 #440, epic #407 / #401).
+ * `copilot` representation (B1 #440 + B2 #408, epic #407 / #401).
  *
  * The destination surface for Copilot: a distinct {@link RepresentationTarget}
  * the embeddable canvas resolves so the panel can render a Copilot-bespoke view
  * of the SAME pure `KBGraph` the `spa` target renders. Registering it as its own
  * named target — rather than reusing `spa` from the canvas mount — gives the
- * bespoke children a stable seam to build on: the anchor-first home view (#408),
- * the agent-action surface (#409), the affordance-aware launchpad (#411), etc.
+ * bespoke children a stable seam to build on.
  *
- * INITIALLY it delegates to the `spa` route tree ({@link renderSpaRoutes}) so it
- * reuses the existing node viewers (`src/views/viewers/*`), `kg://` identity +
- * relations, and `graph.related` / `llm-context` expansion unchanged. This keeps
- * #440 purely additive — the target NAME the canvas resolves is the only change
- * vs. #406. #408 replaces the render body below with the narrow-column,
- * agent-driven, anchor-first layout without touching the registration/wiring.
+ * #440 registered the target (initially delegating to the `spa` route tree).
+ * #408 replaces that delegation with the **anchor-first** layout: the landing
+ * view is NOT the constellation but the conversation's anchor node
+ * ({@link AnchorFirstView}) — its existing node-type viewer plus its
+ * weight-ranked neighbors (top-ranked expanded inline, the rest as navigable
+ * `kg://` chips), with the constellation demoted to an optional zoom-out. The
+ * registration/wiring #440 put in place is unchanged; only the render body is.
+ *
+ * ADDITIVE: the `spa` target and the full-page `App`/`main.tsx` path are
+ * untouched — this owns its OWN narrow `<Routes>` inside the mount's HashRouter.
+ */
+/* eslint-disable react-refresh/only-export-components --
+ * This is a representation-target module, not a hot-reloadable component file:
+ * it intentionally exports the render function and `copilot` target descriptor
+ * alongside the route tree's internal components. Fast Refresh does not apply.
  */
 import type { ReactNode } from 'react';
+import { Routes, Route, Navigate, useParams } from 'react-router-dom';
 import type { Representation } from '@anokye-labs/kbexplorer-core';
-import { renderSpaRoutes, type SpaRenderOptions } from './spa';
+import type { KBConfig, KBGraph } from '../../types';
+import { HomePage } from '../../views/HomePage';
+import { OverviewView } from '../../views/OverviewView';
+import type { SpaRenderOptions } from './spa';
+import { AnchorFirstView } from './copilot-home/AnchorFirstView';
 
 /**
- * Runtime context the copilot view needs beyond the pure graph. Identical to
- * {@link SpaRenderOptions} today because the render delegates to the spa route
- * tree; kept as its own alias so #408 can widen it (agent actions, anchors)
- * without disturbing the spa target's option shape.
+ * Runtime context the copilot view needs beyond the pure graph. Widens
+ * {@link SpaRenderOptions} (#408) with the conversation `anchorNodeId` the
+ * anchor-first home lands on; `landingPath` remains the no-anchor fallback.
  */
-export type CopilotRenderOptions = SpaRenderOptions;
+export interface CopilotRenderOptions extends SpaRenderOptions {
+  /** The conversation anchor node id from `bootConfig.anchorNodeId`, if any. */
+  anchorNodeId?: string;
+}
 
-/** Render the copilot surface for an already-built graph (reuses spa viewers). */
+/** Route element: anchor-first home for the `:id` in the hash path. */
+function AnchorRoute({ graph, config }: { graph: KBGraph; config: KBConfig }) {
+  const { id } = useParams<{ id: string }>();
+  return <AnchorFirstView graph={graph} config={config} anchorId={id ?? ''} />;
+}
+
+/**
+ * Render the copilot surface for an already-built graph.
+ *
+ * The initial path is the conversation anchor (`/node/<anchorNodeId>`) when the
+ * boot config supplies one, else the repo's configured `landingPath` (NO-ANCHOR
+ * fallback — {@link AnchorFirstView} degrades an unknown landing node, e.g.
+ * `/node/home`, to the constellation). Every `/node/:id` re-anchors the view, so
+ * clicking a `kg://` neighbor chip re-centers the panel. `/constellation` is the
+ * optional zoom-out (the force-directed {@link HomePage}).
+ */
 export function renderCopilotSurface(
-  graph: Parameters<typeof renderSpaRoutes>[0],
+  graph: KBGraph,
   options: CopilotRenderOptions,
 ): ReactNode {
-  // SEAM (#408): currently delegates to the `spa` route tree (reuses the node
-  // viewers) — replace this body with the anchor-first bespoke layout.
-  return renderSpaRoutes(graph, options);
+  const { config, landingPath, anchorNodeId } = options;
+  const initialPath = anchorNodeId
+    ? `/node/${encodeURIComponent(anchorNodeId)}`
+    : landingPath;
+
+  return (
+    <Routes>
+      <Route path="/" element={<Navigate to={initialPath} replace />} />
+      <Route path="/node/:id" element={<AnchorRoute graph={graph} config={config} />} />
+      <Route path="/constellation" element={<HomePage graph={graph} config={config} />} />
+      <Route path="/overview" element={<OverviewView graph={graph} config={config} />} />
+      <Route path="*" element={<Navigate to={initialPath} replace />} />
+    </Routes>
+  );
 }
 
 /** The registered `copilot` representation target. */

--- a/src/representation/targets/llm-context.ts
+++ b/src/representation/targets/llm-context.ts
@@ -42,24 +42,58 @@ function nodeBody(node: KBNode): string {
   return stripped || '_(no content)_';
 }
 
-/** The highest-weight edge connecting `neighborId` to any anchor (deterministic). */
-function bestAnchorEdge(
+/**
+ * Precompute the best (highest-weight) edge connecting each neighbor to any
+ * anchor, in ONE pass over `graph.edges` — O(|edges|) instead of the previous
+ * O(|candidates|·|edges|) per-candidate rescan. This runs on every render of the
+ * default anchor-first landing (#408), so the linear pass matters.
+ *
+ * The selection is byte-identical to the old per-candidate {@link bestAnchorEdge}
+ * scan: among the edges tying a neighbor to an anchor, the maximum weight wins,
+ * ties broken by the lexicographic `(anchor index, edge index)` order the nested
+ * `for anchor { for edge }` loops produced (lower anchor index first, then lower
+ * edge index). Because edges are visited in index order, an equal-weight edge
+ * only replaces the incumbent when it belongs to a strictly-lower anchor index.
+ */
+function computeBestAnchorEdges(
   graph: KBGraph,
-  anchorIds: string[],
-  neighborId: string,
-): KBEdge | undefined {
-  let best: KBEdge | undefined;
-  for (const anchorId of anchorIds) {
-    for (const edge of graph.edges) {
-      const connects =
-        (edge.from === anchorId && edge.to === neighborId) ||
-        (edge.from === neighborId && edge.to === anchorId);
-      if (connects && (best === undefined || edge.weight > best.weight)) {
-        best = edge;
-      }
+  anchorIdList: string[],
+): Map<string, KBEdge> {
+  const anchorIndex = new Map<string, number>();
+  anchorIdList.forEach((id, i) => anchorIndex.set(id, i));
+
+  const best = new Map<string, { edge: KBEdge; weight: number; anchorIndex: number }>();
+  for (const edge of graph.edges) {
+    const fromAnchor = anchorIndex.get(edge.from);
+    const toAnchor = anchorIndex.get(edge.to);
+    // Exactly one endpoint must be an anchor: that fixes the neighbor and the
+    // anchor index. Edges with neither or both endpoints as anchors never
+    // contributed a candidate neighbor's best edge in the original scan.
+    let neighborId: string;
+    let idx: number;
+    if (fromAnchor !== undefined && toAnchor === undefined) {
+      neighborId = edge.to;
+      idx = fromAnchor;
+    } else if (toAnchor !== undefined && fromAnchor === undefined) {
+      neighborId = edge.from;
+      idx = toAnchor;
+    } else {
+      continue;
+    }
+
+    const cur = best.get(neighborId);
+    if (
+      cur === undefined ||
+      edge.weight > cur.weight ||
+      (edge.weight === cur.weight && idx < cur.anchorIndex)
+    ) {
+      best.set(neighborId, { edge, weight: edge.weight, anchorIndex: idx });
     }
   }
-  return best;
+
+  const out = new Map<string, KBEdge>();
+  for (const [neighborId, record] of best) out.set(neighborId, record.edge);
+  return out;
 }
 
 /** Relation label for a neighbor edge: explicit relation, else structural type. */
@@ -148,6 +182,9 @@ export function expandAnchoredNeighborhood(
     }
   }
 
+  // Precompute each candidate's best anchor edge in one O(|edges|) pass.
+  const bestEdges = computeBestAnchorEdges(graph, anchorIdList);
+
   // Greedily expand neighbors in rank order until the budget is exhausted;
   // every remaining (relevant) neighbor stays linked for navigation.
   const expanded: AnchoredNeighbor[] = [];
@@ -156,7 +193,7 @@ export function expandAnchoredNeighborhood(
   let full = false;
   for (const id of candidates) {
     const node = byId.get(id)!;
-    const edge = bestAnchorEdge(graph, anchorIdList, id);
+    const edge = bestEdges.get(id);
     if (!full) {
       const c = cost(node, edge);
       if (used + c <= budget) {

--- a/src/representation/targets/llm-context.ts
+++ b/src/representation/targets/llm-context.ts
@@ -87,6 +87,91 @@ function dedupe(ids: string[]): string[] {
   return [...new Set(ids)];
 }
 
+/** A neighbor paired with the highest-weight edge tying it to the anchors. */
+export interface AnchoredNeighbor {
+  node: KBNode;
+  edge: KBEdge | undefined;
+}
+
+/**
+ * The anchor-first neighborhood: the resolved anchor nodes, the greedily
+ * expanded neighbors (rank order, within budget) and the relevant-but-
+ * unexpanded neighbors (over budget) — the ones a consumer surfaces as
+ * navigable `kg://` links/chips.
+ */
+export interface AnchoredNeighborhood {
+  anchors: KBNode[];
+  expanded: AnchoredNeighbor[];
+  unexpanded: AnchoredNeighbor[];
+}
+
+/**
+ * Rank + greedily partition an anchored neighborhood — the single source of
+ * truth reused by both {@link renderLlmContext} (token cost + token budget,
+ * byte-identical Markdown) and the canvas anchor-first home view (#408, unit
+ * cost + a max-expanded count).
+ *
+ * Candidates are the anchors' `graph.related` neighbors walked in the engine's
+ * existing edge-weight rank order (unseen, in-graph, non-anchor). They are then
+ * greedily expanded in that order until `budget` is exhausted; every remaining
+ * candidate is returned as unexpanded. Invalid/absent anchor ids are ignored so
+ * callers that must NOT throw (the view) can rely on graceful degradation;
+ * callers that require strict anchors validate before calling.
+ */
+export function expandAnchoredNeighborhood(
+  graph: KBGraph,
+  anchorIds: string[],
+  cost: (node: KBNode, edge: KBEdge | undefined) => number,
+  budget: number,
+): AnchoredNeighborhood {
+  const byId = new Map(graph.nodes.map(node => [node.id, node]));
+
+  const anchors: KBNode[] = [];
+  const seen = new Set<string>();
+  for (const id of anchorIds) {
+    if (seen.has(id)) continue;
+    const node = byId.get(id);
+    if (!node) continue;
+    seen.add(id);
+    anchors.push(node);
+  }
+  const anchorIdList = anchors.map(anchor => anchor.id);
+
+  // Ranked candidate neighbors: walk each anchor's weight-ranked `related`
+  // list in order, collecting unseen, in-graph, non-anchor nodes.
+  const candidates: string[] = [];
+  for (const anchorId of anchorIdList) {
+    for (const neighborId of graph.related[anchorId] ?? []) {
+      if (seen.has(neighborId) || !byId.has(neighborId)) continue;
+      seen.add(neighborId);
+      candidates.push(neighborId);
+    }
+  }
+
+  // Greedily expand neighbors in rank order until the budget is exhausted;
+  // every remaining (relevant) neighbor stays linked for navigation.
+  const expanded: AnchoredNeighbor[] = [];
+  const unexpanded: AnchoredNeighbor[] = [];
+  let used = 0;
+  let full = false;
+  for (const id of candidates) {
+    const node = byId.get(id)!;
+    const edge = bestAnchorEdge(graph, anchorIdList, id);
+    if (!full) {
+      const c = cost(node, edge);
+      if (used + c <= budget) {
+        expanded.push({ node, edge });
+        used += c;
+        continue;
+      }
+      full = true;
+    }
+    unexpanded.push({ node, edge });
+  }
+
+  return { anchors, expanded, unexpanded };
+}
+
 /**
  * Render a neighbor-anchored, token-budgeted Markdown context pack.
  *
@@ -114,38 +199,15 @@ export function renderLlmContext(
     return node;
   });
 
-  // Ranked candidate neighbors: walk each anchor's weight-ranked `related`
-  // list in order, collecting unseen, in-graph, non-anchor nodes.
-  const seen = new Set(anchorIds);
-  const candidates: string[] = [];
-  for (const anchorId of anchorIds) {
-    for (const neighborId of graph.related[anchorId] ?? []) {
-      if (seen.has(neighborId) || !byId.has(neighborId)) continue;
-      seen.add(neighborId);
-      candidates.push(neighborId);
-    }
-  }
-
-  // Greedily expand neighbors in rank order until the budget is exhausted;
-  // every remaining (relevant) neighbor becomes a navigable kg:// link.
-  const expanded: { node: KBNode; edge: KBEdge | undefined }[] = [];
-  const unexpanded: { node: KBNode; edge: KBEdge | undefined }[] = [];
-  let used = 0;
-  let full = false;
-  for (const id of candidates) {
-    const node = byId.get(id)!;
-    const edge = bestAnchorEdge(graph, anchorIds, id);
-    if (!full) {
-      const cost = estimateTokens(neighborBlock(node, edge));
-      if (used + cost <= budget) {
-        expanded.push({ node, edge });
-        used += cost;
-        continue;
-      }
-      full = true;
-    }
-    unexpanded.push({ node, edge });
-  }
+  // Rank + greedily partition the neighborhood using the shared expansion (the
+  // same logic the canvas anchor-first view reuses); cost is the neighbor's
+  // Markdown token estimate and the budget bounds ONLY this expansion.
+  const { expanded, unexpanded } = expandAnchoredNeighborhood(
+    graph,
+    anchorIds,
+    (node, edge) => estimateTokens(neighborBlock(node, edge)),
+    budget,
+  );
 
   const out: string[] = [];
   out.push('# Knowledge graph context');


### PR DESCRIPTION
## What

First bespoke Copilot view (B2 #408, epic #407). Replaces the `copilot` target's `spa` delegation — the SEAM #440 left — with the **anchor-first** landing. The default canvas view is **no longer the constellation**.

## Layout (`src/representation/targets/copilot-home/AnchorFirstView.tsx`)
- **Anchor node** rendered via its existing node-type viewer from the open registry (`resolveViewer`, reused from `src/views/viewers/*` — not rebuilt).
- **Weight-ranked neighbors** expanded inline (top-ranked), each showing its own viewer + `relation · weight`.
- **Relevant-but-unexpanded neighbors** as navigable `kg://` chips. The inline cap is a named constant `DEFAULT_MAX_EXPANDED = 6` (exported so #409/#411 can tune it); every neighbor beyond the cap still surfaces as a chip — none are dropped.

## Ranking/expansion reuse — llm-context golden unchanged
The exact `llm-context` greedy partition is extracted into a shared pure `expandAnchoredNeighborhood(graph, anchorIds, cost, budget)` over `graph.related`. `renderLlmContext` keeps consuming it (token cost + token budget) and the view consumes it with unit cost + a `maxExpanded` count. **No ranking is reimplemented.** Proof the extraction is pure: `tests/golden/local-llm-context.golden.md` is **unchanged** (not in this diff) and its golden test passes untouched.

## Navigation
The target renders its own `<Routes>` inside the mount's HashRouter: `/node/:id` → anchor-first home, so a `kg://` chip (`#/node/<id>`) **re-anchors** the view. The constellation is an optional zoom-out (`/constellation` → `HomePage`), reached via a button — not the landing. `/` redirects to the anchor.

## No-anchor fallback
If `bootConfig.anchorNodeId` is absent, `/` falls back to the repo config `landingPath`; `AnchorFirstView` degrades an unknown landing node (incl. `/node/home`) to the **constellation** as the sensible default.

## Theme
Inherit-host stays wired via `EmbeddableApp`/`useCanvasTheme`; the view consumes Fluent tokens only, no re-mirror. `anchorNodeId` is now threaded through the copilot render options.

## Additive
`spa` target and the full-page `App`/`main.tsx` path are untouched — only the `copilot` render body changes, plus new components/tests.

## Verification
- `tsc` (app) clean · `eslint` 0 errors · `vitest run` **906 passed** (incl. the llm-context golden, unchanged) · `vite build` clean
- Playwright `e2e/canvas-embed.spec.ts` (chromium) **3 passed**: canvas boots to the anchor-first view for `anchorNodeId`, anchor viewer + ranked neighbors render, `kg://` chips re-anchor, constellation reachable as zoom-out, host-themed, zero app console errors.

Closes #408