### PR TITLE
chore(release): 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,27 @@ template ↔ kbexplorer CLI compatibility matrix and the pinning contract.
 
 ## [Unreleased]
 
+## 0.4.0
+
+### Added
+- **Bespoke Copilot canvas Representation** — the first release carrying the
+  Copilot canvas surface, served over loopback by the kbexplorer CLI's
+  canvas-server from the built template `dist/`.
+  - **Embeddable headless canvas mount + inherit-host visual mode** (#441): a
+    dedicated `canvas.html` entry that mounts the constellation as an embeddable
+    surface (distinct from the full-page `index.html`), plus an `inherit-host`
+    visual mode so the embed adopts the hosting surface's look.
+  - **Copilot Representation target** (#442): registers the `copilot`
+    Representation target so the CLI knows how to render the canvas.
+  - **Anchor-first bespoke Copilot home view** (#443): an anchor-first home view
+    tailored to the Copilot canvas.
+  - **Host CSS-var → Fluent theme adapter + inherit-host mode** (#439): adapts
+    host CSS variables into Fluent theme tokens so the embedded canvas inherits
+    the host theme.
+  - **Theme-driven constellation colors + nodeRenderer host bridge** (#437) and
+    **constellation rendering polish** (#438): overlap, labels, edges, and
+    legend refinements driven by the active theme.
+
 ## 0.3.0
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kbexplorer-template",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kbexplorer-template",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "@anokye-labs/kbexplorer-core": "github:anokye-labs/kbexplorer-core#v0.2.0",
         "@anokye-labs/kbexplorer-provider-rich-markdown": "github:anokye-labs/kbexplorer-provider-rich-markdown#v0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kbexplorer-template",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Cuts **v0.4.0** — the first release carrying the bespoke Copilot canvas Representation surface. Mirrors the #434 (`chore(release): 0.3.0`) convention exactly: bump `package.json` + `package-lock.json` `0.3.0`→`0.4.0`, and add a `## 0.4.0` heading under `## [Unreleased]` in `CHANGELOG.md`. No other changes.

### Included since v0.3.0
- **Embeddable headless canvas mount + inherit-host visual mode** (#441)
- **Register the copilot Representation target** (#442)
- **Anchor-first bespoke copilot home view** (#443)
- **Host CSS-var → Fluent theme adapter + inherit-host mode** (#439)
- **Constellation rendering polish** (#438)
- **Theme-driven constellation colors + nodeRenderer host bridge** (#437)

### Why this matters
The CLI installs the template as a git submodule pinned to the **latest release tag** (`getLatestTag`). Latest is currently v0.3.0 (pre-canvas), so no CLI install serves the canvas yet. Tagging v0.4.0 is the gate that lights up the canvas epic end-to-end.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>