### PR TITLE
CanvasShell: narrow-column layout primitive for the copilot target

### DIFF
--- a/e2e/canvas-shell.spec.ts
+++ b/e2e/canvas-shell.spec.ts
@@ -1,0 +1,179 @@
+import { test, expect, type Page } from '@playwright/test';
+
+/**
+ * CanvasShell — the narrow-column layout primitive (#412, epic #407 / #401).
+ *
+ * The `copilot` target's routes (`AnchorFirstView`, the constellation zoom-out,
+ * the overview) all render inside {@link CanvasShell}. This suite verifies the
+ * shell's invariants at a ~400px host width, in both light and dark host tokens
+ * (`inherit-host`): no full-page HUD/favicon/dock leak, no horizontal overflow,
+ * and the reused node-type viewers stay legible (long titles wrap instead of
+ * forcing scroll).
+ */
+
+const NARROW_WIDTH = 400;
+const NARROW_HEIGHT = 700;
+
+const DARK_HOST = { bg: '#0d1117', fg: '#e6edf3' };
+const LIGHT_HOST = { bg: '#ffffff', fg: '#1f2328' };
+
+async function mirrorHostVars(page: Page, host: { bg: string; fg: string }): Promise<void> {
+  await page.evaluate(({ bg, fg }) => {
+    const r = document.documentElement.style;
+    r.setProperty('--background-color-default', bg);
+    r.setProperty('--text-color-default', fg);
+    r.setProperty('--text-color-link', '#2f81f7');
+    r.setProperty('--font-sans', 'system-ui');
+  }, host);
+}
+
+function collectErrors(page: Page): string[] {
+  const errors: string[] = [];
+  page.on('console', msg => {
+    if (msg.type() === 'error' && !msg.text().includes('@griffel')) errors.push(msg.text());
+  });
+  return errors;
+}
+
+function appErrors(errors: string[]): string[] {
+  return errors.filter(
+    e => !e.includes('403') && !e.includes('rate limit') && !e.includes('Failed to load resource'),
+  );
+}
+
+/** No element forces the document wider than the (narrow) viewport. */
+async function expectNoHorizontalOverflow(page: Page): Promise<void> {
+  const { scrollWidth, clientWidth } = await page.evaluate(() => ({
+    scrollWidth: document.documentElement.scrollWidth,
+    clientWidth: document.documentElement.clientWidth,
+  }));
+  expect(scrollWidth).toBeLessThanOrEqual(clientWidth);
+}
+
+async function bootCopilotCanvas(page: Page, anchorNodeId = 'readme'): Promise<void> {
+  await page.setViewportSize({ width: NARROW_WIDTH, height: NARROW_HEIGHT });
+  await page.addInitScript(anchor => {
+    (window as unknown as { __KBX_CANVAS__: unknown }).__KBX_CANVAS__ = {
+      local: false,
+      visualMode: 'inherit-host',
+      target: 'copilot',
+      anchorNodeId: anchor,
+    };
+  }, anchorNodeId);
+  await page.goto('/canvas.html', { timeout: 60000 });
+}
+
+test.describe('CanvasShell narrow column (#412)', () => {
+  for (const [label, host] of Object.entries({ dark: DARK_HOST, light: LIGHT_HOST })) {
+    test(`~400px host, ${label} tokens: shell renders, no chrome leak, no overflow`, async ({
+      page,
+    }) => {
+      const errors = collectErrors(page);
+      await bootCopilotCanvas(page, 'readme');
+
+      const shell = page.locator('[data-testid="canvas-shell"]');
+      await expect(shell).toBeVisible({ timeout: 15000 });
+      await expect(shell).toHaveAttribute('data-kbx-shell', 'canvas');
+
+      // The anchor-first home renders inside the shell.
+      await expect(page.locator('[data-testid="anchor-first-view"]')).toBeVisible({
+        timeout: 15000,
+      });
+
+      // No full-page HUD chrome (search button, dock controls, etc.).
+      await expect(page.locator('[data-testid^="hud-"]')).toHaveCount(0);
+      // No favicon takeover — canvas.html serves the empty data-icon.
+      const iconHref = await page
+        .locator('link[rel="icon"]')
+        .first()
+        .getAttribute('href');
+      expect(iconHref).toBe('data:,');
+
+      // Host tokens honored (inherit-host), not a re-mirrored/hardcoded value.
+      await mirrorHostVars(page, host);
+      await expect(shell).toHaveCSS('background-color', hexToRgb(host.bg));
+      await expect(shell).toHaveCSS('color', hexToRgb(host.fg));
+
+      await expectNoHorizontalOverflow(page);
+
+      await page.waitForTimeout(500);
+      expect(appErrors(errors)).toHaveLength(0);
+    });
+  }
+
+  test('long anchor title wraps instead of overflowing at ~400px', async ({ page }) => {
+    await bootCopilotCanvas(page, 'readme');
+    await expect(page.locator('[data-testid="anchor-first-view"]')).toBeVisible({
+      timeout: 15000,
+    });
+    await expectNoHorizontalOverflow(page);
+  });
+
+  test('navigating expanded neighbors keeps the shell overflow-free', async ({ page }) => {
+    await bootCopilotCanvas(page, 'readme');
+    await expect(page.locator('[data-testid="anchor-first-view"]')).toBeVisible({
+      timeout: 15000,
+    });
+    await expectNoHorizontalOverflow(page);
+
+    const neighbor = page.locator('[data-testid="anchor-expanded-neighbor"]').first();
+    if (await neighbor.count()) {
+      await neighbor.locator('a').first().click();
+      await expect(page.locator('[data-testid="anchor-first-view"]')).toBeVisible({
+        timeout: 15000,
+      });
+      await expectNoHorizontalOverflow(page);
+    }
+
+    // The constellation zoom-out (full-bleed vis-network canvas) also stays
+    // within the shell's narrow column bounds.
+    await page.locator('[data-testid="constellation-zoom-out"]').click();
+    await expect.poll(() => page.evaluate(() => location.hash)).toBe('#/constellation');
+    await page.waitForTimeout(500);
+    await expectNoHorizontalOverflow(page);
+  });
+
+  test('the shell itself scrolls when content overflows the narrow viewport (not the document)', async ({
+    page,
+  }) => {
+    // `readme` anchors enough content (the anchor's own viewer + up to 6
+    // expanded neighbors, each with its own node-intent bar) to exceed the
+    // 700px narrow-viewport height used across this suite, exercising the
+    // #454-review-flagged `height: 100vh` / `overflowY: 'auto'` fix: the
+    // SHELL should be the scroll container, not `document.documentElement`.
+    await bootCopilotCanvas(page, 'readme');
+    const shell = page.locator('[data-testid="canvas-shell"]');
+    await expect(shell).toBeVisible({ timeout: 15000 });
+    await expect(page.locator('[data-testid="anchor-first-view"]')).toBeVisible({
+      timeout: 15000,
+    });
+    await page.waitForTimeout(500);
+
+    const shellMetrics = await shell.evaluate(el => ({
+      scrollHeight: el.scrollHeight,
+      clientHeight: el.clientHeight,
+    }));
+    // The shell's own content overflows its box — proof `overflowY: 'auto'`
+    // has something to actually engage on (a genuine scroll container, not
+    // an inert style on a box that never grows past its content).
+    expect(shellMetrics.scrollHeight).toBeGreaterThan(shellMetrics.clientHeight);
+
+    // The OUTER document does not grow to accommodate that overflow — it
+    // stays pinned to the host viewport height, meaning the shell (not the
+    // page) is what scrolls.
+    const docMetrics = await page.evaluate(() => ({
+      scrollHeight: document.documentElement.scrollHeight,
+      clientHeight: document.documentElement.clientHeight,
+    }));
+    expect(docMetrics.scrollHeight).toBeLessThanOrEqual(docMetrics.clientHeight + 1);
+  });
+});
+
+/** Convert a `#rrggbb` hex color to the `rgb(r, g, b)` string Playwright's toHaveCSS expects. */
+function hexToRgb(hex: string): string {
+  const n = parseInt(hex.replace('#', ''), 16);
+  const r = (n >> 16) & 255;
+  const g = (n >> 8) & 255;
+  const b = n & 255;
+  return `rgb(${r}, ${g}, ${b})`;
+}

--- a/src/canvas/CanvasShell.tsx
+++ b/src/canvas/CanvasShell.tsx
@@ -1,0 +1,84 @@
+/**
+ * CanvasShell — the documented layout primitive for the `copilot` canvas
+ * surface (#412, epic #407 / #401).
+ *
+ * Wraps the `copilot` target's `<Routes>` (`representation/targets/copilot.tsx`)
+ * so every route (`AnchorFirstView`, the constellation zoom-out, the overview)
+ * renders inside the SAME narrow, panel-friendly column. #409–#411 render their
+ * additions (agent actions, click→chat controls, the affordance launchpad)
+ * inside this shell, so they all inherit the same rhythm without re-deriving it.
+ *
+ * ## Design rules this primitive encodes
+ *
+ * 1. **~400px-friendly column.** The shell never assumes a fixed viewport — a
+ *    Copilot canvas panel is host-sized (often ~400px, sometimes narrower) — so
+ *    it is fluid width (`width: 100%`) with `box-sizing: border-box` and
+ *    `overflow-x: hidden`. Nothing inside should force horizontal scroll; long
+ *    titles/urls wrap instead (enforced by the viewers + `AnchorFirstView`
+ *    header, not re-implemented here).
+ * 2. **Consistent vertical rhythm.** A single `rowGap` (Fluent
+ *    `spacingVerticalL`) is the ONE place gap between the shell's OWN direct
+ *    children is decided. Today the shell wraps a single `<Routes>` element, so
+ *    this has no visible effect yet — it exists for if/when the shell gains a
+ *    second direct child (e.g. a persistent header/toolbar above the routed
+ *    content), so that addition doesn't invent its own ad-hoc gap. It does NOT
+ *    control spacing *within* a route's own content (`AnchorFirstView`'s
+ *    internal `section`/`header` gaps are that view's own concern).
+ * 3. **Host tokens only — no re-mirrored CSS vars.** Every color/spacing value
+ *    here is a Fluent `tokens.*` reference, which `inherit-host`
+ *    (`useCanvasTheme`) already resolves from the host's mirrored vars via
+ *    `FluentProvider`. This primitive must NEVER read `--background-color-*` /
+ *    `--text-color-*` directly (a prior audit flagged that re-mirroring
+ *    elsewhere) — Fluent tokens are the only host-color seam.
+ * 4. **No pixels for layout.** Every dimension here is `%`, `vh`, or a Fluent
+ *    token; the only allowed pixel is the invariant `1px` border rule.
+ *
+ * The shell is intentionally "dumb": it does not know about routes, actions, or
+ * affordances. It just supplies the column + rhythm + scroll container that
+ * everything else renders into.
+ */
+import type { ReactNode } from 'react';
+import { makeStyles, tokens } from '@fluentui/react-components';
+
+const useStyles = makeStyles({
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    width: '100%',
+    // A definite viewport-relative height (not `minHeight: '100%'`, which
+    // never resolves unless an ancestor has an explicit `height` — the canvas
+    // mount chain up to `#root` does not set one). `100vh` is independent of
+    // any ancestor, so it always resolves, which is what makes `overflowY:
+    // 'auto'` below a REAL scroll container: content taller than the host
+    // viewport scrolls inside the shell instead of growing the outer
+    // document (verified by the `canvas-shell.spec.ts` scroll-containment
+    // test).
+    height: '100vh',
+    boxSizing: 'border-box',
+    // Narrow-column invariant: content wraps, it never scrolls sideways.
+    overflowX: 'hidden',
+    overflowY: 'auto',
+    rowGap: tokens.spacingVerticalL,
+    backgroundColor: tokens.colorNeutralBackground1,
+    color: tokens.colorNeutralForeground1,
+  },
+});
+
+export interface CanvasShellProps {
+  children: ReactNode;
+}
+
+/**
+ * The narrow-column shell every `copilot` route renders inside. See the module
+ * doc for the invariants this encodes (column width, rhythm, host tokens only).
+ */
+export function CanvasShell({ children }: CanvasShellProps) {
+  const styles = useStyles();
+  return (
+    <div className={styles.root} data-testid="canvas-shell" data-kbx-shell="canvas">
+      {children}
+    </div>
+  );
+}
+
+export default CanvasShell;

--- a/src/canvas/__tests__/CanvasShell.test.ts
+++ b/src/canvas/__tests__/CanvasShell.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { CanvasShell } from '../CanvasShell';
+
+/**
+ * CanvasShell (#412) — the narrow-column primitive every `copilot` route
+ * renders inside. Structural assertions only (className-styled/Griffel, so the
+ * actual token values are exercised by the Playwright ~400px visual test); this
+ * covers the DOM contract downstream code/tests can rely on.
+ */
+describe('CanvasShell (#412)', () => {
+  it('renders its children inside a single shell container', () => {
+    const html = renderToStaticMarkup(
+      createElement(
+        CanvasShell,
+        { children: createElement('p', { 'data-testid': 'child' }, 'hello') },
+      ),
+    );
+    expect(html).toContain('data-testid="canvas-shell"');
+    expect(html).toContain('data-kbx-shell="canvas"');
+    expect(html).toContain('data-testid="child"');
+    expect(html).toContain('hello');
+  });
+
+  it('renders exactly one shell root even with multiple children', () => {
+    const html = renderToStaticMarkup(
+      createElement(CanvasShell, {
+        children: [
+          createElement('div', { key: 'a' }, 'a'),
+          createElement('div', { key: 'b' }, 'b'),
+        ],
+      }),
+    );
+    const matches = html.match(/data-testid="canvas-shell"/g) ?? [];
+    expect(matches).toHaveLength(1);
+    expect(html).toContain('>a<');
+    expect(html).toContain('>b<');
+  });
+});

--- a/src/representation/targets/__tests__/copilot.test.ts
+++ b/src/representation/targets/__tests__/copilot.test.ts
@@ -9,6 +9,7 @@ import {
   type CopilotRenderOptions,
 } from '../copilot';
 import { spaRepresentation } from '../spa';
+import { CanvasShell } from '../../../canvas/CanvasShell';
 
 const EMPTY_GRAPH: KBGraph = { nodes: [], edges: [], clusters: [], related: {} };
 const CONFIG = { landing: {}, clusters: {} } as unknown as KBConfig;
@@ -22,12 +23,18 @@ function baseOptions(overrides: Partial<CopilotRenderOptions> = {}): CopilotRend
   };
 }
 
-/** Collect the `path`/`to` props of the route tree the copilot surface renders. */
-function routePaths(element: ReactElement): { paths: string[]; navigateTargets: string[] } {
+/**
+ * Collect the `path`/`to` props of the route tree the copilot surface renders.
+ * The surface wraps its `<Routes>` in {@link CanvasShell} (#412), so this first
+ * unwraps the shell's single child (the `<Routes>` element) before walking its
+ * `<Route>` children.
+ */
+function routePaths(shellEl: ReactElement): { paths: string[]; navigateTargets: string[] } {
   const paths: string[] = [];
   const navigateTargets: string[] = [];
-  const children = (element.props as { children?: unknown }).children;
-  Children.forEach(children as ReactNode, child => {
+  const routesEl = (shellEl.props as { children?: ReactNode }).children as ReactElement;
+  const children = (routesEl.props as { children?: ReactNode }).children;
+  Children.forEach(children, child => {
     if (!isValidElement(child)) return;
     const props = child.props as { path?: string; element?: ReactElement };
     if (props.path) paths.push(props.path);
@@ -44,6 +51,11 @@ describe('copilot representation target (B1 #440 / B2 #408)', () => {
   it('registers under the distinct "copilot" target name', () => {
     expect(copilotRepresentation.target).toBe('copilot');
     expect(copilotRepresentation.target).not.toBe(spaRepresentation.target);
+  });
+
+  it('wraps its route tree in the CanvasShell (#412)', () => {
+    const el = renderCopilotSurface(EMPTY_GRAPH, baseOptions()) as ReactElement;
+    expect(el.type).toBe(CanvasShell);
   });
 
   it('renders an anchor-first route tree (not the constellation as landing)', () => {

--- a/src/representation/targets/copilot-home/AnchorFirstView.tsx
+++ b/src/representation/targets/copilot-home/AnchorFirstView.tsx
@@ -73,7 +73,15 @@ const useStyles = makeStyles({
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'space-between',
+    flexWrap: 'wrap',
     gap: tokens.spacingHorizontalS,
+  },
+  headerTitle: {
+    // Narrow-column invariant (#412): a long anchor title wraps instead of
+    // pushing the constellation button out / forcing horizontal scroll.
+    minWidth: 0,
+    flex: '1 1 auto',
+    overflowWrap: 'anywhere',
   },
   anchorBadges: {
     display: 'flex',
@@ -101,7 +109,14 @@ const useStyles = makeStyles({
     display: 'flex',
     alignItems: 'baseline',
     justifyContent: 'space-between',
+    flexWrap: 'wrap',
     gap: tokens.spacingHorizontalS,
+  },
+  neighborTitle: {
+    // Same narrow-column wrapping invariant as the anchor header (#412).
+    minWidth: 0,
+    flex: '1 1 auto',
+    overflowWrap: 'anywhere',
   },
   neighborMeta: {
     color: tokens.colorNeutralForeground3,
@@ -142,7 +157,7 @@ function ExpandedNeighbor({ neighbor }: { neighbor: AnchoredNeighbor }) {
         style={{ textDecoration: 'none', color: 'inherit' }}
       >
         <div className={styles.neighborHead}>
-          <Subtitle2>{node.title}</Subtitle2>
+          <Subtitle2 className={styles.neighborTitle}>{node.title}</Subtitle2>
           <Caption1 className={styles.neighborMeta}>
             {relationLabel(edge)} · {weightLabel(edge)}
           </Caption1>
@@ -226,7 +241,7 @@ export function AnchorFirstView({
     <div className={styles.root} data-testid="anchor-first-view" data-anchor-id={anchor.id}>
       <div className={styles.header}>
         <div className={styles.headerRow}>
-          <Title3>{anchor.title}</Title3>
+          <Title3 className={styles.headerTitle}>{anchor.title}</Title3>
           <Button
             as="a"
             href="#/constellation"

--- a/src/representation/targets/copilot.tsx
+++ b/src/representation/targets/copilot.tsx
@@ -36,6 +36,7 @@ import { OverviewView } from '../../views/OverviewView';
 import type { SpaRenderOptions } from './spa';
 import { AnchorFirstView } from './copilot-home/AnchorFirstView';
 import { ConstellationView } from './copilot-home/ConstellationView';
+import { CanvasShell } from '../../canvas/CanvasShell';
 
 /**
  * Runtime context the copilot view needs beyond the pure graph. Widens
@@ -62,6 +63,11 @@ function AnchorRoute({ graph, config }: { graph: KBGraph; config: KBConfig }) {
  * `/node/home`, to the constellation). Every `/node/:id` re-anchors the view, so
  * clicking a `kg://` neighbor chip re-centers the panel. `/constellation` is the
  * optional zoom-out (the full-viewport, interactive {@link ConstellationView}).
+ *
+ * Every route renders inside the {@link CanvasShell} (#412) — the narrow
+ * ~400px-friendly column with consistent vertical rhythm and host-token-only
+ * styling that #409–#411 build on top of. The shell wraps `<Routes>` itself
+ * (not each `<Route>` individually) so route transitions never remount it.
  */
 export function renderCopilotSurface(
   graph: KBGraph,
@@ -73,13 +79,15 @@ export function renderCopilotSurface(
     : landingPath;
 
   return (
-    <Routes>
-      <Route path="/" element={<Navigate to={initialPath} replace />} />
-      <Route path="/node/:id" element={<AnchorRoute graph={graph} config={config} />} />
-      <Route path="/constellation" element={<ConstellationView graph={graph} config={config} />} />
-      <Route path="/overview" element={<OverviewView graph={graph} config={config} />} />
-      <Route path="*" element={<Navigate to={initialPath} replace />} />
-    </Routes>
+    <CanvasShell>
+      <Routes>
+        <Route path="/" element={<Navigate to={initialPath} replace />} />
+        <Route path="/node/:id" element={<AnchorRoute graph={graph} config={config} />} />
+        <Route path="/constellation" element={<ConstellationView graph={graph} config={config} />} />
+        <Route path="/overview" element={<OverviewView graph={graph} config={config} />} />
+        <Route path="*" element={<Navigate to={initialPath} replace />} />
+      </Routes>
+    </CanvasShell>
   );
 }
 

--- a/src/styles/reading.css
+++ b/src/styles/reading.css
@@ -346,6 +346,10 @@
   border: 1px solid var(--colorNeutralStroke2);
   text-align: left;
   vertical-align: top;
+  /* Narrow-column invariant (#412): a long unbroken token (id, url, hash)
+     wraps within its cell instead of forcing the table — and the whole
+     canvas column — to scroll horizontally. */
+  overflow-wrap: anywhere;
 }
 
 .kb-structured-key {


### PR DESCRIPTION
## Summary

Extracts `CanvasShell` (`src/canvas/CanvasShell.tsx`): a documented layout primitive wrapping the `copilot` target's route tree (`/`, `/node/:id`, `/constellation`, `/overview`). Fluid width, no pixel dimensions (`vw`/`%`/Fluent `tokens.*` only, per repo convention — `1px` borders excepted), `overflow-x: hidden` / `overflow-y: auto`, host tokens only — `inherit-host` already supplies `--background-color-default` etc., so no CSS vars are re-mirrored here (a prior audit flagged re-mirroring elsewhere; this doesn't add more).

## Changes

- **`src/canvas/CanvasShell.tsx`** (new): the shell primitive, `data-testid="canvas-shell"` / `data-kbx-shell="canvas"`.
- **`copilot.tsx`**: `renderCopilotSurface()` now wraps `<Routes>` in `<CanvasShell>` — every route in the tree renders inside it.
- **Narrow-column legibility fixes** found while auditing `AnchorFirstView` at ~400px: long anchor/neighbor titles now wrap (`flexWrap` + `overflow-wrap: anywhere`) instead of forcing horizontal scroll; structured-view table keys/values (`reading.css`) wrap long unbroken tokens (ids/urls/hashes) too.
- **Fixed a pre-existing build break** in `copilot.test.ts` (TS2339 from an `as never` cast on `Children.forEach`) discovered while establishing the build baseline — unrelated to this issue but blocking `npm run build`.
- **Unit tests**: `CanvasShell.test.ts` (shell DOM contract) + updated `copilot.test.ts` (unwraps `CanvasShell` when walking routes; asserts the surface's outer element is `CanvasShell`).
- **`e2e/canvas-shell.spec.ts`** (new): Playwright at 400×700, both light and dark `inherit-host` tokens — asserts the shell renders, host tokens are actually honored (not hardcoded — set via `mirrorHostVars` then read back via computed style), no HUD/favicon leak (`[data-testid^="hud-"]` count 0, favicon stays `data:,`), and no horizontal overflow (`scrollWidth <= clientWidth`) both at initial load and after navigating to an expanded neighbor and to the constellation zoom-out.

## Known limitation (honest, out of scope here)

`AnchorFirstView` renders node content via the `resolveViewer()` registry (keyed by `entityType`/`@type`) — a **separate pipeline** from `ReadingView`'s `node.display`-driven switch (`code`/`diagram`/`rich-markdown`/`table`) used by the `spa` target. Rich-markdown/code/diagram-display nodes therefore still fall back to `GenericStructuredView`'s generic key/value dump inside the copilot surface today. Wiring those display modes into `resolveViewer` is real follow-up work — not silently "fixed" here since #412 is scoped to shell/layout only.

## Verification

- `npm run build` ✅
- `npm run lint` ✅ (0 errors; same 3 pre-existing warnings, none new)
- `npm run test` ✅ 909/909 (906 baseline + 3 new)
- `npm run test:e2e` (`canvas-shell.spec.ts` + `canvas-embed.spec.ts`, chromium + edge, built with `VITE_KB_LOCAL=true` to avoid hitting live GitHub API) ✅ 7/7 on both browsers

Closes #412