### PR TITLE
Fix: /constellation renders a full-viewport interactive graph, not the decorative hero

### DIFF
--- a/e2e/canvas-embed.spec.ts
+++ b/e2e/canvas-embed.spec.ts
@@ -12,6 +12,12 @@ import { test, expect } from '@playwright/test';
  * conversation anchor node + its weight-ranked neighbors, with `kg://` chips for
  * the unexpanded remainder and the constellation demoted to an optional
  * zoom-out. The `spa` target remains as an escape hatch (route tree + viewers).
+ *
+ * #453: the zoom-out (`/constellation`) now renders {@link ConstellationView}
+ * — a full-viewport, interactive force-directed graph (drag-pan, scroll-zoom,
+ * click-to-re-anchor) — instead of the SPA's decorative, non-interactive
+ * `HomePage` hero. Covered below: the canvas fills the panel (not a fixed
+ * ~280px/35vh band) and clicking a node navigates to `/node/<id>`.
  */
 
 const HOST_BG = 'rgb(13, 17, 23)'; // #0d1117 — GitHub dark canvas
@@ -156,10 +162,91 @@ test.describe('Embeddable canvas mount (#406 / #440 / #408)', () => {
       chipNodeId as string,
     );
 
-    // The constellation zoom-out is reachable from the anchor-first home.
+    // The constellation zoom-out is reachable from the anchor-first home —
+    // and (#453) renders the real interactive graph, not the decorative hero.
     await page.locator('[data-testid="constellation-zoom-out"]').click();
     await expect.poll(() => page.evaluate(() => location.hash)).toBe('#/constellation');
-    await expect(page.getByText('Knowledge Clusters')).toBeVisible({ timeout: 15000 });
+    await expect(page.locator('[data-testid="constellation-view"]')).toBeVisible({ timeout: 15000 });
+    await expect(page.locator('[data-testid="constellation-view"] canvas')).toBeVisible({ timeout: 15000 });
+
+    await page.waitForTimeout(500);
+    expect(appErrors(errors)).toHaveLength(0);
+  });
+
+  test('copilot: /constellation renders a full-viewport interactive graph; clicking a node re-anchors (#453)', async ({
+    page,
+  }) => {
+    const errors = collectErrors(page);
+
+    await page.addInitScript(() => {
+      (window as unknown as { __KBX_CANVAS__: unknown }).__KBX_CANVAS__ = {
+        local: false,
+        visualMode: 'inherit-host',
+        anchorNodeId: 'readme',
+      };
+    });
+    // Deep-link straight to the zoom-out — bypasses the anchor-first landing
+    // (deep links always win, same as the full-page app's landing config).
+    await page.goto('/canvas.html#/constellation', { timeout: 60000 });
+
+    const view = page.locator('[data-testid="constellation-view"]');
+    await expect(view).toBeVisible({ timeout: 15000 });
+
+    // The live network registers under its audit slot once mounted (#435's
+    // `window.__kbeNetworks` hook — the same one `scripts/audit-visual.mjs` uses).
+    await page.waitForFunction(() => {
+      const w = window as unknown as { __kbeNetworks?: Record<string, unknown> };
+      return !!w.__kbeNetworks?.['copilotConstellation'];
+    }, { timeout: 15000 });
+    await page.waitForTimeout(2000); // let forceAtlas2 stabilization settle (fitOnStabilize)
+
+    // Full-viewport canvas — NOT the old hero's fixed 35vh/~280px band.
+    const canvas = view.locator('canvas');
+    await expect(canvas).toBeVisible();
+    const canvasBox = await canvas.boundingBox();
+    expect(canvasBox).toBeTruthy();
+    expect(canvasBox!.height).toBeGreaterThan(400);
+
+    // Live node/edge counts render in the header, not a hardcoded placeholder.
+    await expect(page.locator('[data-testid="constellation-stats"]')).toContainText(
+      /\d+ nodes · \d+ links/,
+    );
+
+    // Clicking a node re-anchors the panel to /node/<id>. vis-network draws to
+    // a single <canvas> (no per-node DOM elements), so locate a rendered
+    // node's on-screen position via the live network's own coordinate mapping
+    // — the same canvasToDOM technique `scripts/audit-visual.mjs` uses to
+    // probe rendered nodes.
+    const clickTarget = await page.evaluate(() => {
+      type NetworkLike = {
+        body?: { data?: { nodes?: { getIds?: () => string[] } } };
+        getPositions: () => Record<string, { x: number; y: number }>;
+        canvasToDOM: (pos: { x: number; y: number }) => { x: number; y: number };
+      };
+      const w = window as unknown as {
+        __kbeNetworks?: Record<string, { network: NetworkLike; container: HTMLElement }>;
+      };
+      const reg = w.__kbeNetworks?.['copilotConstellation'];
+      if (!reg) return null;
+      const ids = reg.network.body?.data?.nodes?.getIds?.() ?? [];
+      const positions = reg.network.getPositions();
+      const rect = reg.container.getBoundingClientRect();
+      for (const id of ids) {
+        const p = positions[id];
+        if (!p) continue;
+        const dom = reg.network.canvasToDOM({ x: p.x, y: p.y });
+        if (dom.x >= 0 && dom.x <= rect.width && dom.y >= 0 && dom.y <= rect.height) {
+          return { id, x: rect.left + dom.x, y: rect.top + dom.y };
+        }
+      }
+      return null;
+    });
+    expect(clickTarget).toBeTruthy();
+
+    await page.mouse.click(clickTarget!.x, clickTarget!.y);
+    await expect
+      .poll(() => page.evaluate(() => location.hash))
+      .toBe(`#/node/${encodeURIComponent(clickTarget!.id)}`);
 
     await page.waitForTimeout(500);
     expect(appErrors(errors)).toHaveLength(0);

--- a/e2e/canvas-embed.spec.ts
+++ b/e2e/canvas-embed.spec.ts
@@ -216,10 +216,11 @@ test.describe('Embeddable canvas mount (#406 / #440 / #408)', () => {
     // a single <canvas> (no per-node DOM elements), so locate a rendered
     // node's on-screen position via the live network's own coordinate mapping
     // — the same canvasToDOM technique `scripts/audit-visual.mjs` uses to
-    // probe rendered nodes.
+    // probe rendered nodes. Node IDs come from the public `getPositions()`
+    // map (its keys) rather than the private `network.body.data.nodes`
+    // internals, so this doesn't rely on vis-network's non-public structure.
     const clickTarget = await page.evaluate(() => {
       type NetworkLike = {
-        body?: { data?: { nodes?: { getIds?: () => string[] } } };
         getPositions: () => Record<string, { x: number; y: number }>;
         canvasToDOM: (pos: { x: number; y: number }) => { x: number; y: number };
       };
@@ -228,10 +229,9 @@ test.describe('Embeddable canvas mount (#406 / #440 / #408)', () => {
       };
       const reg = w.__kbeNetworks?.['copilotConstellation'];
       if (!reg) return null;
-      const ids = reg.network.body?.data?.nodes?.getIds?.() ?? [];
       const positions = reg.network.getPositions();
       const rect = reg.container.getBoundingClientRect();
-      for (const id of ids) {
+      for (const id of Object.keys(positions)) {
         const p = positions[id];
         if (!p) continue;
         const dom = reg.network.canvasToDOM({ x: p.x, y: p.y });

--- a/src/representation/targets/copilot-home/ConstellationView.tsx
+++ b/src/representation/targets/copilot-home/ConstellationView.tsx
@@ -1,0 +1,98 @@
+/**
+ * ConstellationView — full-viewport, interactive force-directed graph for the
+ * `copilot` target's `/constellation` route (#453, epic #407 / #401).
+ *
+ * `AnchorFirstView` (#408) demotes the constellation to an optional zoom-out
+ * reached via its "Constellation" button (`data-testid="constellation-zoom-out"`,
+ * `href="#/constellation"`). Before this component existed, that route rendered
+ * `HomePage` — the SPA's decorative landing hero, whose only graph visual
+ * (`ConstellationHero`) is a translucent, non-interactive band fixed at
+ * `height: '35vh'` (physics disabled after a single `fit()`, no
+ * `interactive: true`). Clicking a node did nothing; the only affordances were
+ * CTA buttons that linked to a fixed node.
+ *
+ * #453 fixes this: `/constellation` now mounts the SAME `createGraphNetwork`
+ * engine helper `HUD`'s expanded-map overlay uses — `interactive: true` for
+ * drag-pan + scroll-zoom, `fitOnStabilize: true`, and node clicks re-anchor
+ * the panel (`navigate('/node/<id>')`) instead of doing nothing — mounted
+ * full-bleed instead of a fixed-height decoration.
+ *
+ * ADDITIVE: `HomePage`/`ConstellationHero` are untouched — still used by the
+ * full-page SPA landing (`App`/`main.tsx`) and the `homepage` display mode
+ * (`ReadingView`). This is purely a new route target inside the `copilot`
+ * target's own narrow `<Routes>` (`copilot.tsx`).
+ */
+import { useEffect, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Button, Caption1, makeStyles, tokens } from '@fluentui/react-components';
+import { ArrowLeftRegular } from '@fluentui/react-icons';
+import type { KBConfig, KBGraph } from '../../../types';
+import { useIsDark } from '../../../theme/isDarkContext';
+import { mountConstellationNetwork } from './mountConstellationNetwork';
+
+const useStyles = makeStyles({
+  root: {
+    position: 'absolute',
+    inset: 0,
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  header: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: tokens.spacingHorizontalS,
+    padding: `${tokens.spacingVerticalS} ${tokens.spacingHorizontalM}`,
+    borderBottom: `1px solid ${tokens.colorNeutralStroke2}`,
+    flexShrink: 0,
+  },
+  stats: {
+    color: tokens.colorNeutralForeground3,
+    whiteSpace: 'nowrap',
+  },
+  canvas: {
+    position: 'relative',
+    flex: 1,
+    minHeight: 0,
+  },
+});
+
+export interface ConstellationViewProps {
+  graph: KBGraph;
+  config: KBConfig;
+}
+
+/**
+ * Full-viewport zoom-out: the real explorable constellation (drag-pan,
+ * scroll-zoom, click-to-select) — not the fixed-height decorative hero.
+ */
+export function ConstellationView({ graph, config }: ConstellationViewProps) {
+  const styles = useStyles();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const isDark = useIsDark();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+    return mountConstellationNetwork(containerRef.current, graph, isDark, navigate);
+  }, [graph, isDark, navigate]);
+
+  return (
+    <div className={styles.root} data-testid="constellation-view">
+      <div className={styles.header}>
+        <Button appearance="subtle" icon={<ArrowLeftRegular />} as="a" href="#/">
+          Back
+        </Button>
+        <Caption1 className={styles.stats} data-testid="constellation-stats">
+          {graph.nodes.length} nodes · {graph.edges.length} links · click a node to open it
+        </Caption1>
+      </div>
+      <div
+        ref={containerRef}
+        className={styles.canvas}
+        data-testid="constellation-canvas"
+        aria-label={`${config.title} — interactive knowledge constellation`}
+      />
+    </div>
+  );
+}

--- a/src/representation/targets/copilot-home/__tests__/constellation-view.test.ts
+++ b/src/representation/targets/copilot-home/__tests__/constellation-view.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { MemoryRouter } from 'react-router-dom';
+import type { KBConfig, KBEdge, KBGraph, KBNode } from '../../../../types';
+import { ConstellationView } from '../ConstellationView';
+
+/** A small graph with `nodeCount` nodes wired into a cycle of `edgeCount` edges. */
+function graphWith(nodeCount: number, edgeCount: number): KBGraph {
+  const nodes: KBNode[] = Array.from({ length: nodeCount }, (_, i): KBNode => ({
+    id: `n${i}`,
+    title: `Node ${i}`,
+    cluster: 'default',
+    content: '',
+    rawContent: '',
+    connections: [],
+    source: { type: 'file', path: '' },
+  }));
+  const edges: KBEdge[] = Array.from({ length: edgeCount }, (_, i): KBEdge => ({
+    from: `n${i % Math.max(nodeCount, 1)}`,
+    to: `n${(i + 1) % Math.max(nodeCount, 1)}`,
+    type: 'references',
+    relation: 'related',
+    description: '',
+    source: 'inline',
+    weight: 1,
+  }));
+  return { nodes, edges, clusters: [], related: {} };
+}
+
+const CONFIG = { title: 'Test Repo', clusters: {} } as unknown as KBConfig;
+
+describe('ConstellationView (#453 static chrome)', () => {
+  it('renders a back affordance, live node/edge counts, and the full-viewport canvas container', () => {
+    const graph = graphWith(172, 640);
+    const html = renderToStaticMarkup(
+      createElement(MemoryRouter, null, createElement(ConstellationView, { graph, config: CONFIG })),
+    );
+
+    expect(html).toContain('data-testid="constellation-view"');
+    expect(html).toContain('data-testid="constellation-canvas"');
+    expect(html).toContain('data-testid="constellation-stats"');
+    // Back affordance re-anchors to the copilot target's own root redirect
+    // (`/` → the conversation anchor or configured landing path).
+    expect(html).toContain('href="#/"');
+    // Live counts sourced from the graph, not a hardcoded placeholder.
+    expect(html).toContain('172 nodes');
+    expect(html).toContain('640 links');
+  });
+
+  it('reflects the actual graph size in the stats text, not a fixed/stale count', () => {
+    const html = renderToStaticMarkup(
+      createElement(MemoryRouter, null, createElement(ConstellationView, { graph: graphWith(5, 3), config: CONFIG })),
+    );
+    expect(html).toContain('5 nodes');
+    expect(html).toContain('3 links');
+  });
+});

--- a/src/representation/targets/copilot-home/__tests__/mount-constellation-network.test.ts
+++ b/src/representation/targets/copilot-home/__tests__/mount-constellation-network.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { KBEdge, KBGraph, KBNode } from '../../../../types';
+import type { GraphNetworkResult } from '../../../../engine/createGraphNetwork';
+import { mountConstellationNetwork } from '../mountConstellationNetwork';
+
+/** A small graph with `nodeCount` nodes wired into a cycle of `edgeCount` edges. */
+function graphWith(nodeCount: number, edgeCount: number): KBGraph {
+  const nodes: KBNode[] = Array.from({ length: nodeCount }, (_, i): KBNode => ({
+    id: `n${i}`,
+    title: `Node ${i}`,
+    cluster: 'default',
+    content: '',
+    rawContent: '',
+    connections: [],
+    source: { type: 'file', path: '' },
+  }));
+  const edges: KBEdge[] = Array.from({ length: edgeCount }, (_, i): KBEdge => ({
+    from: `n${i % Math.max(nodeCount, 1)}`,
+    to: `n${(i + 1) % Math.max(nodeCount, 1)}`,
+    type: 'references',
+    relation: 'related',
+    description: '',
+    source: 'inline',
+    weight: 1,
+  }));
+  return { nodes, edges, clusters: [], related: {} };
+}
+
+/** A fake `GraphNetworkResult` — `destroy` is a spy so cleanup is assertable. */
+function fakeNetworkResult() {
+  const destroy = vi.fn();
+  const result: GraphNetworkResult = {
+    network: { destroy } as unknown as GraphNetworkResult['network'],
+    nodes: {} as GraphNetworkResult['nodes'],
+    edges: {} as GraphNetworkResult['edges'],
+    setEmphasis: vi.fn(),
+  };
+  return { result, destroy };
+}
+
+describe('mountConstellationNetwork (#453 — real interactive graph, not the decorative hero)', () => {
+  it('calls createGraphNetwork with the container ref, the graph, isDark, interactive:true and fitOnStabilize:true', () => {
+    const graph = graphWith(3, 2);
+    const fakeContainer = { tagName: 'DIV' } as unknown as HTMLElement;
+    const { result } = fakeNetworkResult();
+    const createGraphNetworkFn = vi.fn().mockReturnValue(result);
+    const navigate = vi.fn();
+
+    mountConstellationNetwork(fakeContainer, graph, true, navigate, createGraphNetworkFn);
+
+    expect(createGraphNetworkFn).toHaveBeenCalledTimes(1);
+    const options = createGraphNetworkFn.mock.calls[0][0];
+    // The exact container ref flows through untouched — not a copy/wrapper.
+    expect(options.container).toBe(fakeContainer);
+    expect(options.graph).toBe(graph);
+    expect(options.isDark).toBe(true);
+    expect(options.interactive).toBe(true);
+    expect(options.fitOnStabilize).toBe(true);
+    expect(options.auditSlot).toBe('copilotConstellation');
+  });
+
+  it('re-anchors the panel on node click: onNodeClick navigates to /node/<encoded id>', () => {
+    const graph = graphWith(2, 1);
+    const { result } = fakeNetworkResult();
+    const createGraphNetworkFn = vi.fn().mockReturnValue(result);
+    const navigate = vi.fn();
+
+    mountConstellationNetwork({} as HTMLElement, graph, false, navigate, createGraphNetworkFn);
+
+    const options = createGraphNetworkFn.mock.calls[0][0];
+    expect(typeof options.onNodeClick).toBe('function');
+    options.onNodeClick?.('kb://mission/x');
+    expect(navigate).toHaveBeenCalledTimes(1);
+    expect(navigate).toHaveBeenCalledWith('/node/kb%3A%2F%2Fmission%2Fx');
+  });
+
+  it('destroys the network when the returned cleanup runs (unmount)', () => {
+    const graph = graphWith(1, 0);
+    const { result, destroy } = fakeNetworkResult();
+    const createGraphNetworkFn = vi.fn().mockReturnValue(result);
+
+    const cleanup = mountConstellationNetwork({} as HTMLElement, graph, true, vi.fn(), createGraphNetworkFn);
+    expect(destroy).not.toHaveBeenCalled();
+
+    cleanup();
+    expect(destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('swallows an already-torn-down network error from destroy() without throwing', () => {
+    const graph = graphWith(1, 0);
+    const createGraphNetworkFn = vi.fn().mockReturnValue({
+      network: {
+        destroy: () => { throw new Error('already destroyed'); },
+      } as unknown as GraphNetworkResult['network'],
+      nodes: {} as GraphNetworkResult['nodes'],
+      edges: {} as GraphNetworkResult['edges'],
+      setEmphasis: vi.fn(),
+    });
+
+    const cleanup = mountConstellationNetwork({} as HTMLElement, graph, true, vi.fn(), createGraphNetworkFn);
+    expect(() => cleanup()).not.toThrow();
+  });
+});

--- a/src/representation/targets/copilot-home/mountConstellationNetwork.ts
+++ b/src/representation/targets/copilot-home/mountConstellationNetwork.ts
@@ -1,0 +1,44 @@
+/**
+ * mountConstellationNetwork — mounting logic for {@link ConstellationView}
+ * (#453), split into its own module (not a component file) so:
+ *
+ *  1. `react-refresh/only-export-components` stays happy — component files
+ *     should only export components, and this is a plain function.
+ *  2. It's directly unit-testable by injecting a fake `createGraphNetworkFn` +
+ *     `navigate`, without needing a real DOM/vis-network instance (this
+ *     repo's unit tests run under Node, not jsdom). The actual live-canvas
+ *     mount — full-viewport sizing, drag-pan/scroll-zoom, and the real
+ *     click-to-navigate interaction — is verified by the
+ *     `e2e/canvas-embed.spec.ts` Playwright spec.
+ */
+import type { KBGraph } from '../../../types';
+import {
+  createGraphNetwork as createGraphNetworkImpl,
+  type GraphNetworkOptions,
+  type GraphNetworkResult,
+} from '../../../engine/createGraphNetwork';
+
+/**
+ * Mount a live {@link createGraphNetworkImpl} instance into `container` and
+ * return its cleanup (`network.destroy()`).
+ */
+export function mountConstellationNetwork(
+  container: HTMLElement,
+  graph: KBGraph,
+  isDark: boolean,
+  navigate: (path: string) => void,
+  createGraphNetworkFn: (options: GraphNetworkOptions) => GraphNetworkResult = createGraphNetworkImpl,
+): () => void {
+  const { network } = createGraphNetworkFn({
+    container,
+    graph,
+    isDark,
+    interactive: true,
+    fitOnStabilize: true,
+    onNodeClick: nodeId => navigate(`/node/${encodeURIComponent(nodeId)}`),
+    auditSlot: 'copilotConstellation',
+  });
+  return () => {
+    try { network.destroy(); } catch { /* already torn down */ }
+  };
+}

--- a/src/representation/targets/copilot.tsx
+++ b/src/representation/targets/copilot.tsx
@@ -15,6 +15,11 @@
  * `kg://` chips), with the constellation demoted to an optional zoom-out. The
  * registration/wiring #440 put in place is unchanged; only the render body is.
  *
+ * #453 replaces the zoom-out's render target: `/constellation` now renders
+ * {@link ConstellationView} — a full-viewport, interactive force-directed
+ * graph (drag-pan, scroll-zoom, click-to-re-anchor) — instead of `HomePage`,
+ * the SPA's decorative, non-interactive landing hero.
+ *
  * ADDITIVE: the `spa` target and the full-page `App`/`main.tsx` path are
  * untouched — this owns its OWN narrow `<Routes>` inside the mount's HashRouter.
  */
@@ -27,10 +32,10 @@ import type { ReactNode } from 'react';
 import { Routes, Route, Navigate, useParams } from 'react-router-dom';
 import type { Representation } from '@anokye-labs/kbexplorer-core';
 import type { KBConfig, KBGraph } from '../../types';
-import { HomePage } from '../../views/HomePage';
 import { OverviewView } from '../../views/OverviewView';
 import type { SpaRenderOptions } from './spa';
 import { AnchorFirstView } from './copilot-home/AnchorFirstView';
+import { ConstellationView } from './copilot-home/ConstellationView';
 
 /**
  * Runtime context the copilot view needs beyond the pure graph. Widens
@@ -56,7 +61,7 @@ function AnchorRoute({ graph, config }: { graph: KBGraph; config: KBConfig }) {
  * fallback — {@link AnchorFirstView} degrades an unknown landing node, e.g.
  * `/node/home`, to the constellation). Every `/node/:id` re-anchors the view, so
  * clicking a `kg://` neighbor chip re-centers the panel. `/constellation` is the
- * optional zoom-out (the force-directed {@link HomePage}).
+ * optional zoom-out (the full-viewport, interactive {@link ConstellationView}).
  */
 export function renderCopilotSurface(
   graph: KBGraph,
@@ -71,7 +76,7 @@ export function renderCopilotSurface(
     <Routes>
       <Route path="/" element={<Navigate to={initialPath} replace />} />
       <Route path="/node/:id" element={<AnchorRoute graph={graph} config={config} />} />
-      <Route path="/constellation" element={<HomePage graph={graph} config={config} />} />
+      <Route path="/constellation" element={<ConstellationView graph={graph} config={config} />} />
       <Route path="/overview" element={<OverviewView graph={graph} config={config} />} />
       <Route path="*" element={<Navigate to={initialPath} replace />} />
     </Routes>


### PR DESCRIPTION
## Before / after

**Before:** the `copilot` target's `/constellation` route rendered `HomePage` — the SPA's decorative landing hero. Its only graph visual (`ConstellationHero`) is a translucent, non-interactive band fixed at `height: '35vh'`, physics disabled after a single `fit()`, no `interactive: true`. Clicking a node did nothing; the only affordances were CTA buttons linking to a fixed node (`#/node/readme`). There was no route in the `copilot` target that rendered an actual explorable constellation.

**After:** `/constellation` renders a new `ConstellationView` — a full-viewport, **interactive** force-directed graph, reusing the same `createGraphNetwork` engine helper `HUD`'s expanded-map overlay uses: `interactive: true` (drag-pan, scroll-zoom), `fitOnStabilize: true`, and node clicks re-anchor the panel (`navigate('/node/<id>')`) instead of doing nothing. A thin header (← Back + live node/edge counts) matches the anchor-first view's chrome.

## Scope

Purely additive — only the `/constellation` route element inside `copilot.tsx`'s own `<Routes>` changed. `HomePage.tsx` / `ConstellationHero.tsx` are byte-identical to `main` (still used by the full-page SPA landing and the `homepage` display mode).

## Changes

- **New** `src/representation/targets/copilot-home/ConstellationView.tsx` — the component (header chrome + full-bleed canvas mount).
- **New** `src/representation/targets/copilot-home/mountConstellationNetwork.ts` — the `createGraphNetwork` mounting logic, extracted into its own module so it's directly unit-testable (inject a fake `createGraphNetworkFn` + `navigate`) and so the component file only exports components (`react-refresh/only-export-components`).
- **`copilot.tsx`** — swaps the `/constellation` route element from `HomePage` to `ConstellationView`; removes the now-unused `HomePage` import.
- **`e2e/canvas-embed.spec.ts`** — fixes the now-stale `"Knowledge Clusters"` assertion in the existing #408 zoom-out test, and adds a new spec asserting the canvas fills the panel (not a fixed ~280px/35vh band) and that clicking a node navigates to `/node/<id>`.

## Verification (all green)

- **Unit tests:** 916/916 pass (`npx vitest run`), including 8 new tests covering `mountConstellationNetwork`'s options/click-wiring/cleanup and `ConstellationView`'s static chrome.
- **eslint:** 0 errors. (3 pre-existing warnings remain, all in files untouched by this PR — 2 in `scripts/*.mjs`, 1 in `HUD.tsx`.)
- **vite build:** succeeds for both entries (`index.html` and `canvas.html`).
- **Playwright (`e2e/canvas-embed.spec.ts`, headless, chromium):** 4/4 pass, including the new `#453` spec (full-viewport canvas + click-to-navigate) and the fixed `#408` spec.
- **`git diff`:** confirms `HomePage.tsx` / `ConstellationHero.tsx` are untouched.

### Known pre-existing, unrelated issue
`npx tsc -b` has **one** pre-existing failure in `src/representation/targets/__tests__/copilot.test.ts:32` (`Property 'props' does not exist on type 'never'`) that reproduces identically on a clean `main` checkout (verified via `git stash`) — it is not introduced by this change and no file in this PR touches that test. Flagging so it isn't mistaken for a regression from this PR.

Closes #453