### PR TITLE
Agent action surface: SSE /events consumer (#409)

### DIFF
--- a/e2e/canvas-events.spec.ts
+++ b/e2e/canvas-events.spec.ts
@@ -111,3 +111,129 @@ test.describe('Agent action surface — /events consumer (#409)', () => {
     expect(appErrors).toHaveLength(0);
   });
 });
+
+/**
+ * Reason-aware `graph-updated` (#409, cli#214): `expand` / `trace` / `filter`
+ * arrive over the SAME `graph-updated` event as the content-patch tests above,
+ * distinguished by a `reason` field. Each test discovers a REAL neighbor node
+ * id from the rendered graph first (no invented ids), then mocks `/events` to
+ * emit that exact frozen-contract payload shape and asserts the resulting DOM
+ * change — proof the reason-aware branch actually re-renders, not just parses.
+ */
+test.describe('Agent action surface — reason-aware graph-updated (#409, cli#214)', () => {
+  test('expand force-promotes a real chip neighbor into an expanded card, focused', async ({
+    page,
+  }) => {
+    await bootCopilotCanvas(page, 'readme');
+    await expect(page.locator('[data-testid="anchor-first-view"]')).toBeVisible({
+      timeout: 15000,
+    });
+
+    const chip = page.locator('[data-testid="anchor-neighbor-chip"]').first();
+    await expect(chip).toBeVisible();
+    const targetNodeId = await chip.getAttribute('data-node-id');
+    expect(targetNodeId).toBeTruthy();
+
+    await page.route('**/events', route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'text/event-stream',
+        body: sseFrame('graph-updated', {
+          reason: 'expand',
+          nodes: [targetNodeId],
+          focus: targetNodeId,
+        }),
+      }),
+    );
+    await page.reload();
+    await expect(page.locator('[data-testid="anchor-first-view"]')).toBeVisible({
+      timeout: 15000,
+    });
+
+    const expandedCard = page.locator(
+      `[data-testid="anchor-expanded-neighbor"][data-node-id="${targetNodeId}"]`,
+    );
+    await expect(expandedCard).toBeVisible({ timeout: 10000 });
+    await expect(expandedCard).toHaveAttribute('data-kbx-focused', 'true');
+    // ...and it's no longer ALSO rendered as a chip.
+    await expect(
+      page.locator(`[data-testid="anchor-neighbor-chip"][data-node-id="${targetNodeId}"]`),
+    ).toHaveCount(0);
+  });
+
+  test('trace renders a path banner and highlights the matching visible neighbor', async ({
+    page,
+  }) => {
+    await bootCopilotCanvas(page, 'readme');
+    await expect(page.locator('[data-testid="anchor-first-view"]')).toBeVisible({
+      timeout: 15000,
+    });
+
+    const neighbor = page.locator('[data-testid="anchor-expanded-neighbor"]').first();
+    await expect(neighbor).toBeVisible();
+    const targetNodeId = await neighbor.getAttribute('data-node-id');
+    expect(targetNodeId).toBeTruthy();
+
+    await page.route('**/events', route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'text/event-stream',
+        body: sseFrame('graph-updated', {
+          reason: 'trace',
+          nodes: ['readme', targetNodeId],
+          path: ['readme', targetNodeId],
+          connected: true,
+        }),
+      }),
+    );
+    await page.reload();
+
+    const banner = page.locator('[data-testid="anchor-trace-banner"]');
+    await expect(banner).toBeVisible({ timeout: 15000 });
+    await expect(banner).toHaveAttribute('data-connected', 'true');
+    await expect(
+      page.locator(
+        `[data-testid="anchor-expanded-neighbor"][data-node-id="${targetNodeId}"]`,
+      ),
+    ).toHaveAttribute('data-kbx-on-trace', 'true');
+  });
+
+  test('filter constrains the rendered neighbors to the matched set', async ({ page }) => {
+    await bootCopilotCanvas(page, 'readme');
+    await expect(page.locator('[data-testid="anchor-first-view"]')).toBeVisible({
+      timeout: 15000,
+    });
+
+    const neighbor = page.locator('[data-testid="anchor-expanded-neighbor"]').first();
+    await expect(neighbor).toBeVisible();
+    const keepNodeId = await neighbor.getAttribute('data-node-id');
+    expect(keepNodeId).toBeTruthy();
+
+    await page.route('**/events', route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'text/event-stream',
+        body: sseFrame('graph-updated', {
+          reason: 'filter',
+          filter: { query: 'kept' },
+          nodes: [keepNodeId],
+        }),
+      }),
+    );
+    await page.reload();
+
+    await expect(page.locator('[data-testid="anchor-filter-hint"]')).toBeVisible({
+      timeout: 15000,
+    });
+    await expect(
+      page.locator(`[data-testid="anchor-expanded-neighbor"][data-node-id="${keepNodeId}"]`),
+    ).toBeVisible();
+    // Every OTHER previously-rendered neighbor card/chip is now filtered out.
+    await expect(
+      page.locator(
+        `[data-testid="anchor-expanded-neighbor"]:not([data-node-id="${keepNodeId}"])`,
+      ),
+    ).toHaveCount(0);
+    await expect(page.locator('[data-testid="anchor-neighbor-chip"]')).toHaveCount(0);
+  });
+});

--- a/e2e/canvas-events.spec.ts
+++ b/e2e/canvas-events.spec.ts
@@ -1,0 +1,113 @@
+import { test, expect, type Page } from '@playwright/test';
+
+/**
+ * Agent action surface — `/events` SSE consumer (#409, epic #407).
+ *
+ * There's no CLI loopback server available to THIS repo's e2e run (that server
+ * only exists inside `kbexplorer-cli`), so these tests prove the wiring by
+ * mocking `GET /events` with `page.route`: a canned `text/event-stream` body
+ * containing a real frozen-contract event (`anchor` / `graph-updated`). This is
+ * a genuine end-to-end proof of the CONSUMER side — the browser's real
+ * `EventSource` parses the mocked response exactly as it would parse the real
+ * loopback server's stream; only the transport's origin is faked.
+ */
+
+function sseFrame(event: string, data: unknown): string {
+  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+async function bootCopilotCanvas(page: Page, anchorNodeId = 'readme'): Promise<void> {
+  await page.addInitScript(anchor => {
+    (window as unknown as { __KBX_CANVAS__: unknown }).__KBX_CANVAS__ = {
+      local: false,
+      visualMode: 'inherit-host',
+      target: 'copilot',
+      anchorNodeId: anchor,
+    };
+  }, anchorNodeId);
+  await page.goto('/canvas.html', { timeout: 60000 });
+}
+
+test.describe('Agent action surface — /events consumer (#409)', () => {
+  test('a dispatched anchor SSE event actually re-anchors the panel', async ({ page }) => {
+    await bootCopilotCanvas(page, 'readme');
+    await expect(page.locator('[data-testid="anchor-first-view"]')).toBeVisible({
+      timeout: 15000,
+    });
+
+    // Discover a real neighbor node id from the rendered graph (no guessing —
+    // same technique as the existing kg:// chip test in canvas-embed.spec.ts).
+    const chip = page.locator('[data-testid="anchor-neighbor-chip"]').first();
+    await expect(chip).toBeVisible();
+    const targetNodeId = await chip.getAttribute('data-node-id');
+    expect(targetNodeId).toBeTruthy();
+
+    // Mock /events to emit a real `anchor` event for that node AFTER the app
+    // subscribes — reload with the mock in place.
+    await page.route('**/events', route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'text/event-stream',
+        body: sseFrame('anchor', { nodeId: targetNodeId }),
+      }),
+    );
+    await page.reload();
+    await expect(page.locator('[data-testid="anchor-first-view"]')).toBeVisible({
+      timeout: 15000,
+    });
+
+    // The panel re-anchored on the SSE-supplied node — a real navigation, not
+    // just a parsed-and-discarded event.
+    await expect
+      .poll(() => page.evaluate(() => location.hash), { timeout: 10000 })
+      .toBe(`#/node/${encodeURIComponent(targetNodeId as string)}`);
+    await expect(page.locator('[data-testid="anchor-first-view"]')).toHaveAttribute(
+      'data-anchor-id',
+      targetNodeId as string,
+    );
+  });
+
+  test('a dispatched graph-updated SSE event actually patches the rendered view', async ({
+    page,
+  }) => {
+    const NEW_TITLE = 'Patched via graph-updated SSE (#409)';
+    await page.route('**/events', route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'text/event-stream',
+        body: sseFrame('graph-updated', { nodes: [{ id: 'readme', title: NEW_TITLE }] }),
+      }),
+    );
+    await bootCopilotCanvas(page, 'readme');
+
+    const anchorView = page.locator('[data-testid="anchor-first-view"]');
+    await expect(anchorView).toBeVisible({ timeout: 15000 });
+    await expect(anchorView).toHaveAttribute('data-anchor-id', 'readme');
+
+    // The anchor node's title was patched in place by the mocked SSE event —
+    // proof the view actually re-rendered from the mutated live graph, not
+    // just from the originally-loaded static manifest.
+    await expect(page.getByText(NEW_TITLE)).toBeVisible({ timeout: 10000 });
+  });
+
+  test('degrades safely with no /events endpoint at all (this repo\'s own preview server)', async ({
+    page,
+  }) => {
+    const errors: string[] = [];
+    page.on('console', msg => {
+      if (msg.type() === 'error' && !msg.text().includes('@griffel')) errors.push(msg.text());
+    });
+    // No page.route mock — /events genuinely 404s against `vite preview`,
+    // exactly like this repo's own dev/preview server.
+    await bootCopilotCanvas(page, 'readme');
+    await expect(page.locator('[data-testid="anchor-first-view"]')).toBeVisible({
+      timeout: 15000,
+    });
+    await page.waitForTimeout(1000);
+
+    const appErrors = errors.filter(
+      e => !e.includes('403') && !e.includes('rate limit') && !e.includes('Failed to load resource'),
+    );
+    expect(appErrors).toHaveLength(0);
+  });
+});

--- a/src/canvas/EmbeddableApp.tsx
+++ b/src/canvas/EmbeddableApp.tsx
@@ -13,8 +13,15 @@
  * is host-driven via {@link useCanvasTheme} (`inherit-host`), and an optional
  * `anchorNodeId` from the boot config picks the landing node — the seam the
  * bespoke agent-driven anchor-first view (#408) builds on.
+ *
+ * Agent action surface (#409): a `useCanvasEvents` subscription applies the two
+ * frozen `/events` domain events regardless of `boot.target` (both `copilot`
+ * and `spa` mount a `HashRouter`, so hash navigation is the shared seam):
+ * `anchor { nodeId }` re-anchors via `location.hash`, and `graph-updated
+ * { nodes }` patches the live in-memory graph so the current view re-renders.
+ * See `useCanvasEvents.ts` for the frozen-vs-deferred event scope.
  */
-import type { ReactNode } from 'react';
+import { useState, type ReactNode } from 'react';
 import { HashRouter } from 'react-router-dom';
 import { FluentProvider } from '@fluentui/react-components';
 import { useKnowledgeBase } from '../hooks/useKnowledgeBase';
@@ -23,8 +30,10 @@ import { IsDarkContext } from '../theme/isDarkContext';
 import { representationRegistry } from '../representation';
 import { LoadingScreen } from '../components/LoadingScreen';
 import { ErrorScreen } from '../components/ErrorScreen';
+import type { KBGraph } from '../types';
 import { useCanvasTheme } from './useCanvasTheme';
 import { resolveCanvasLandingPath } from './landing';
+import { applyGraphUpdatedEvent, resolveEventsUrl, useCanvasEvents } from './useCanvasEvents';
 import type { CanvasBootConfig } from './bootConfig';
 import '../styles/visuals.css';
 import '../styles/reading.css';
@@ -40,6 +49,35 @@ function CanvasExplorer({ boot }: { boot: CanvasBootConfig }): ReactNode {
   );
   const isDark = isDarkTheme(fluentTheme);
 
+  // Agent action surface (#409): the live graph starts as the loaded manifest
+  // and is patched in place by `graph-updated` SSE events. Reset whenever the
+  // underlying loaded graph identity changes (a fresh `useKnowledgeBase` load).
+  // Adjusted during render (not in an effect) per React's "adjusting state
+  // when a prop changes" recipe — avoids the extra commit + re-render an
+  // effect-based reset would cause, and satisfies react-hooks/set-state-in-effect.
+  const loadedGraph = state.status === 'ready' ? state.graph : undefined;
+  const [liveGraph, setLiveGraph] = useState<KBGraph | undefined>(loadedGraph);
+  const [prevLoadedGraph, setPrevLoadedGraph] = useState(loadedGraph);
+  if (loadedGraph !== prevLoadedGraph) {
+    setPrevLoadedGraph(loadedGraph);
+    setLiveGraph(loadedGraph);
+  }
+
+  const eventsUrl = resolveEventsUrl(boot);
+  useCanvasEvents(eventsUrl, {
+    onAnchor: nodeId => {
+      window.location.hash = `#/node/${encodeURIComponent(nodeId)}`;
+    },
+    onGraphUpdated: payload => {
+      setLiveGraph(current => (current ? applyGraphUpdatedEvent(current, payload) : current));
+    },
+    // No onError: `/events` is expected to fail to connect entirely outside a
+    // loopback host (this repo's own `vite preview`/e2e/dev server has no such
+    // endpoint) — that's the documented safe-degrade path, not an app error.
+  });
+
+  const graph = liveGraph ?? loadedGraph;
+
   return (
     <FluentProvider
       theme={fluentTheme}
@@ -51,9 +89,9 @@ function CanvasExplorer({ boot }: { boot: CanvasBootConfig }): ReactNode {
       <IsDarkContext.Provider value={isDark}>
         {state.status === 'loading' && <LoadingScreen />}
         {state.status === 'error' && <ErrorScreen message={state.error} />}
-        {state.status === 'ready' && (
+        {state.status === 'ready' && graph && (
           <HashRouter>
-            {representationRegistry.resolve<ReactNode>(boot.target).render(state.graph, {
+            {representationRegistry.resolve<ReactNode>(boot.target).render(graph, {
               config: state.config,
               fluentTheme,
               landingPath: resolveCanvasLandingPath(state.config, boot.anchorNodeId),

--- a/src/canvas/EmbeddableApp.tsx
+++ b/src/canvas/EmbeddableApp.tsx
@@ -14,14 +14,19 @@
  * `anchorNodeId` from the boot config picks the landing node — the seam the
  * bespoke agent-driven anchor-first view (#408) builds on.
  *
- * Agent action surface (#409): a `useCanvasEvents` subscription applies the two
+ * Agent action surface (#409): a `useCanvasEvents` subscription applies the
  * frozen `/events` domain events regardless of `boot.target` (both `copilot`
  * and `spa` mount a `HashRouter`, so hash navigation is the shared seam):
- * `anchor { nodeId }` re-anchors via `location.hash`, and `graph-updated
- * { nodes }` patches the live in-memory graph so the current view re-renders.
- * See `useCanvasEvents.ts` for the frozen-vs-deferred event scope.
+ * `anchor { nodeId }` re-anchors via `location.hash`; `graph-updated` is
+ * REASON-AWARE (`kbexplorer-cli` cli#214) — a reason-less payload patches the
+ * live in-memory graph ({@link applyGraphUpdatedEvent}), while `expand` /
+ * `trace` / `filter` (all carried over the SAME event, distinguished by a
+ * `reason` field) accumulate into a separate {@link ViewActionState}
+ * ({@link applyViewAction}) that's threaded into the `copilot` target's render
+ * options alongside the graph — see `viewActionState.ts` for the reducer and
+ * `AnchorFirstView.tsx` for how it's consumed.
  */
-import { useState, type ReactNode } from 'react';
+import { useMemo, useState, type ReactNode } from 'react';
 import { HashRouter } from 'react-router-dom';
 import { FluentProvider } from '@fluentui/react-components';
 import { useKnowledgeBase } from '../hooks/useKnowledgeBase';
@@ -34,6 +39,12 @@ import type { KBGraph } from '../types';
 import { useCanvasTheme } from './useCanvasTheme';
 import { resolveCanvasLandingPath } from './landing';
 import { applyGraphUpdatedEvent, resolveEventsUrl, useCanvasEvents } from './useCanvasEvents';
+import {
+  applyViewAction,
+  resolveFilterNodeIds,
+  INITIAL_VIEW_ACTION_STATE,
+  type ViewActionState,
+} from './viewActionState';
 import type { CanvasBootConfig } from './bootConfig';
 import '../styles/visuals.css';
 import '../styles/reading.css';
@@ -57,10 +68,12 @@ function CanvasExplorer({ boot }: { boot: CanvasBootConfig }): ReactNode {
   // effect-based reset would cause, and satisfies react-hooks/set-state-in-effect.
   const loadedGraph = state.status === 'ready' ? state.graph : undefined;
   const [liveGraph, setLiveGraph] = useState<KBGraph | undefined>(loadedGraph);
+  const [viewAction, setViewAction] = useState<ViewActionState>(INITIAL_VIEW_ACTION_STATE);
   const [prevLoadedGraph, setPrevLoadedGraph] = useState(loadedGraph);
   if (loadedGraph !== prevLoadedGraph) {
     setPrevLoadedGraph(loadedGraph);
     setLiveGraph(loadedGraph);
+    setViewAction(INITIAL_VIEW_ACTION_STATE);
   }
 
   const eventsUrl = resolveEventsUrl(boot);
@@ -69,7 +82,18 @@ function CanvasExplorer({ boot }: { boot: CanvasBootConfig }): ReactNode {
       window.location.hash = `#/node/${encodeURIComponent(nodeId)}`;
     },
     onGraphUpdated: payload => {
-      setLiveGraph(current => (current ? applyGraphUpdatedEvent(current, payload) : current));
+      // Reason-aware dispatch (#409, cli#214): `expand`/`trace`/`filter` share
+      // the `graph-updated` event with the reason-less content-patch shape,
+      // distinguished by `reason`. Known reasons go to the view-action reducer
+      // ONLY (never also patched as content — their `nodes` field is a plain
+      // id array, not patch objects, so `applyGraphUpdatedEvent` would no-op
+      // on it anyway, but branching explicitly keeps the two concerns apart).
+      const reason = (payload as { reason?: unknown } | undefined)?.reason;
+      if (reason === 'expand' || reason === 'trace' || reason === 'filter') {
+        setViewAction(current => applyViewAction(current, payload));
+      } else {
+        setLiveGraph(current => (current ? applyGraphUpdatedEvent(current, payload) : current));
+      }
     },
     // No onError: `/events` is expected to fail to connect entirely outside a
     // loopback host (this repo's own `vite preview`/e2e/dev server has no such
@@ -77,6 +101,15 @@ function CanvasExplorer({ boot }: { boot: CanvasBootConfig }): ReactNode {
   });
 
   const graph = liveGraph ?? loadedGraph;
+
+  // Resolve the active `filter`'s effective node-id set against the CURRENT
+  // graph (client-side cluster/nodeType predicate when the server sent
+  // `nodes: null` — see `viewActionState.ts`). Memoized: only recomputes when
+  // the filter criteria or the graph identity changes.
+  const filterNodeIds = useMemo(
+    () => (graph ? resolveFilterNodeIds(viewAction.filter, graph) : undefined),
+    [graph, viewAction.filter],
+  );
 
   return (
     <FluentProvider
@@ -96,6 +129,12 @@ function CanvasExplorer({ boot }: { boot: CanvasBootConfig }): ReactNode {
               fluentTheme,
               landingPath: resolveCanvasLandingPath(state.config, boot.anchorNodeId),
               anchorNodeId: boot.anchorNodeId,
+              viewAction: {
+                expandedNodeIds: viewAction.expandedNodeIds,
+                focusNodeId: viewAction.focusNodeId,
+                trace: viewAction.trace,
+                filterNodeIds,
+              },
             }) as ReactNode}
           </HashRouter>
         )}

--- a/src/canvas/__tests__/useCanvasEvents.test.ts
+++ b/src/canvas/__tests__/useCanvasEvents.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  applyGraphUpdatedEvent,
+  resolveEventsUrl,
+  subscribeToCanvasEvents,
+  type CanvasEventSourceLike,
+} from '../useCanvasEvents';
+import type { KBGraph, KBNode } from '../../types';
+
+/**
+ * Agent action surface (#409). Pure-function tests only — no DOM/EventSource
+ * required, matching the repo's existing pattern for canvas hooks (see
+ * `useCanvasTheme.test.ts`, which tests `resolveCanvasTheme` rather than the
+ * hook itself).
+ */
+
+function node(overrides: Partial<KBNode> & { id: string }): KBNode {
+  return {
+    title: overrides.id,
+    cluster: 'default',
+    content: '',
+    rawContent: '',
+    connections: [],
+    source: { type: 'authored' } as unknown as KBNode['source'],
+    ...overrides,
+  };
+}
+
+function graphWith(nodes: KBNode[]): KBGraph {
+  return { nodes, edges: [], clusters: [], related: {} };
+}
+
+describe('resolveEventsUrl (#409)', () => {
+  it('defaults to the relative /events path with no searchServiceUrl', () => {
+    expect(resolveEventsUrl({})).toBe('/events');
+  });
+
+  it('derives the events URL from searchServiceUrl\'s origin', () => {
+    expect(resolveEventsUrl({ searchServiceUrl: 'http://127.0.0.1:54321/search' })).toBe(
+      'http://127.0.0.1:54321/events',
+    );
+  });
+
+  it('falls back to the relative path when searchServiceUrl is malformed', () => {
+    expect(resolveEventsUrl({ searchServiceUrl: 'not a url' })).toBe('/events');
+  });
+});
+
+describe('applyGraphUpdatedEvent (#409)', () => {
+  it('patches fields onto an existing node by id', () => {
+    const graph = graphWith([node({ id: 'readme', title: 'Old title' })]);
+    const next = applyGraphUpdatedEvent(graph, {
+      nodes: [{ id: 'readme', title: 'New title from SSE' }],
+    });
+    expect(next).not.toBe(graph);
+    expect(next.nodes[0].title).toBe('New title from SSE');
+    expect(next.nodes[0].id).toBe('readme'); // id is never overwritten
+  });
+
+  it('leaves nodes not mentioned in the payload untouched', () => {
+    const graph = graphWith([node({ id: 'a', title: 'A' }), node({ id: 'b', title: 'B' })]);
+    const next = applyGraphUpdatedEvent(graph, { nodes: [{ id: 'a', title: 'A2' }] });
+    expect(next.nodes.find(n => n.id === 'a')?.title).toBe('A2');
+    expect(next.nodes.find(n => n.id === 'b')?.title).toBe('B');
+  });
+
+  it('ignores patches for ids not present in the graph (no new-node fabrication)', () => {
+    const graph = graphWith([node({ id: 'readme' })]);
+    const next = applyGraphUpdatedEvent(graph, {
+      nodes: [{ id: 'brand-new-node', title: 'Should not appear' }],
+    });
+    expect(next).toBe(graph); // referentially unchanged — a clean no-op
+    expect(next.nodes).toHaveLength(1);
+  });
+
+  it('is a no-op for a malformed payload (missing/non-array nodes)', () => {
+    const graph = graphWith([node({ id: 'readme' })]);
+    expect(applyGraphUpdatedEvent(graph, {})).toBe(graph);
+    expect(applyGraphUpdatedEvent(graph, { nodes: 'not-an-array' })).toBe(graph);
+    expect(applyGraphUpdatedEvent(graph, undefined)).toBe(graph);
+    expect(applyGraphUpdatedEvent(graph, null)).toBe(graph);
+  });
+
+  it('ignores individual entries without a valid string id', () => {
+    const graph = graphWith([node({ id: 'readme', title: 'Old' })]);
+    const next = applyGraphUpdatedEvent(graph, {
+      nodes: [{ title: 'no id here' }, { id: 123 }, { id: '' }],
+    });
+    expect(next).toBe(graph);
+  });
+});
+
+/** A fake EventSource capturing registered listeners for direct dispatch. */
+function fakeEventSource(): {
+  source: CanvasEventSourceLike;
+  dispatch: (type: string, data: unknown) => void;
+  close: ReturnType<typeof vi.fn>;
+} {
+  const listeners = new Map<string, (event: { data: string }) => void>();
+  const close = vi.fn();
+  const source: CanvasEventSourceLike = {
+    addEventListener: (type, listener) => listeners.set(type, listener),
+    close,
+    onerror: null,
+  };
+  return {
+    source,
+    close,
+    dispatch: (type, data) => listeners.get(type)?.({ data: JSON.stringify(data) }),
+  };
+}
+
+describe('subscribeToCanvasEvents (#409)', () => {
+  it('invokes onAnchor with the parsed nodeId when an anchor event arrives', () => {
+    const { source, dispatch } = fakeEventSource();
+    const onAnchor = vi.fn();
+    subscribeToCanvasEvents('/events', { onAnchor }, () => source);
+    dispatch('anchor', { nodeId: 'q1-uplift' });
+    expect(onAnchor).toHaveBeenCalledWith('q1-uplift');
+  });
+
+  it('invokes onGraphUpdated with the parsed payload when a graph-updated event arrives', () => {
+    const { source, dispatch } = fakeEventSource();
+    const onGraphUpdated = vi.fn();
+    subscribeToCanvasEvents('/events', { onGraphUpdated }, () => source);
+    dispatch('graph-updated', { nodes: [{ id: 'readme', title: 'x' }] });
+    expect(onGraphUpdated).toHaveBeenCalledWith({ nodes: [{ id: 'readme', title: 'x' }] });
+  });
+
+  it('ignores an anchor event with no nodeId (defensive — never throws)', () => {
+    const { source, dispatch } = fakeEventSource();
+    const onAnchor = vi.fn();
+    subscribeToCanvasEvents('/events', { onAnchor }, () => source);
+    expect(() => dispatch('anchor', {})).not.toThrow();
+    expect(onAnchor).not.toHaveBeenCalled();
+  });
+
+  it('routes transport errors to onError without throwing', () => {
+    const { source } = fakeEventSource();
+    const onError = vi.fn();
+    subscribeToCanvasEvents('/events', { onError }, () => source);
+    source.onerror?.({ type: 'error' });
+    expect(onError).toHaveBeenCalledWith({ type: 'error' });
+  });
+
+  it('degrades safely with no handlers at all', () => {
+    const { source, dispatch } = fakeEventSource();
+    subscribeToCanvasEvents('/events', {}, () => source);
+    expect(() => {
+      dispatch('anchor', { nodeId: 'x' });
+      dispatch('graph-updated', { nodes: [] });
+      source.onerror?.({ type: 'error' });
+    }).not.toThrow();
+  });
+
+  it('closes the underlying source when the cleanup function runs', () => {
+    const { source, close } = fakeEventSource();
+    const cleanup = subscribeToCanvasEvents('/events', {}, () => source);
+    expect(close).not.toHaveBeenCalled();
+    cleanup();
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/canvas/__tests__/viewActionState.test.ts
+++ b/src/canvas/__tests__/viewActionState.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applyViewAction,
+  resolveFilterNodeIds,
+  INITIAL_VIEW_ACTION_STATE,
+  type ViewActionState,
+} from '../viewActionState';
+import type { KBGraph, KBNode } from '../../types';
+
+/**
+ * Reason-aware `graph-updated` view-action reducer (#409, cli#214). Payload
+ * shapes here match the frozen `kbexplorer-cli` contract exactly:
+ * - expand: { reason: 'expand', nodes: [nodeId, ...neighborIds], focus }
+ * - trace:  { reason: 'trace', nodes: path, path, connected }
+ * - filter: { reason: 'filter', filter: { query?, cluster?, nodeType? }, nodes }
+ */
+
+function node(overrides: Partial<KBNode> & { id: string }): KBNode {
+  return {
+    title: overrides.id,
+    cluster: 'default',
+    content: '',
+    rawContent: '',
+    connections: [],
+    source: { type: 'authored' } as unknown as KBNode['source'],
+    ...overrides,
+  };
+}
+
+function graphWith(nodes: KBNode[]): KBGraph {
+  return { nodes, edges: [], clusters: [], related: {} };
+}
+
+describe('applyViewAction — expand (#409, cli#214)', () => {
+  it('unions expand nodes into expandedNodeIds (never replaces)', () => {
+    let state = INITIAL_VIEW_ACTION_STATE;
+    state = applyViewAction(state, { reason: 'expand', nodes: ['a', 'b'], focus: 'a' });
+    expect([...state.expandedNodeIds]).toEqual(['a', 'b']);
+    expect(state.focusNodeId).toBe('a');
+
+    state = applyViewAction(state, { reason: 'expand', nodes: ['c'], focus: 'c' });
+    // 'a' and 'b' from the FIRST expand are still present — additive, not replaced.
+    expect([...state.expandedNodeIds]).toEqual(['a', 'b', 'c']);
+    expect(state.focusNodeId).toBe('c');
+  });
+
+  it('keeps the prior focus when a later expand omits focus', () => {
+    let state = applyViewAction(INITIAL_VIEW_ACTION_STATE, {
+      reason: 'expand',
+      nodes: ['a'],
+      focus: 'a',
+    });
+    state = applyViewAction(state, { reason: 'expand', nodes: ['b'] });
+    expect(state.focusNodeId).toBe('a');
+    expect([...state.expandedNodeIds]).toEqual(['a', 'b']);
+  });
+
+  it('is a no-op for a malformed expand payload (missing/empty/non-string nodes)', () => {
+    const state = INITIAL_VIEW_ACTION_STATE;
+    expect(applyViewAction(state, { reason: 'expand' })).toBe(state);
+    expect(applyViewAction(state, { reason: 'expand', nodes: [] })).toBe(state);
+    expect(applyViewAction(state, { reason: 'expand', nodes: [1, 2] })).toBe(state);
+    expect(applyViewAction(state, { reason: 'expand', nodes: 'a' })).toBe(state);
+  });
+});
+
+describe('applyViewAction — trace (#409, cli#214)', () => {
+  it('records the path and connected flag', () => {
+    const state = applyViewAction(INITIAL_VIEW_ACTION_STATE, {
+      reason: 'trace',
+      nodes: ['a', 'b', 'c'],
+      path: ['a', 'b', 'c'],
+      connected: true,
+    });
+    expect(state.trace).toEqual({ path: ['a', 'b', 'c'], connected: true });
+  });
+
+  it('records connected:false when the path does not connect', () => {
+    const state = applyViewAction(INITIAL_VIEW_ACTION_STATE, {
+      reason: 'trace',
+      path: ['a', 'z'],
+      connected: false,
+    });
+    expect(state.trace).toEqual({ path: ['a', 'z'], connected: false });
+  });
+
+  it('a later trace REPLACES the prior one (not additive)', () => {
+    let state = applyViewAction(INITIAL_VIEW_ACTION_STATE, {
+      reason: 'trace',
+      path: ['a', 'b'],
+      connected: true,
+    });
+    state = applyViewAction(state, { reason: 'trace', path: ['x', 'y'], connected: false });
+    expect(state.trace).toEqual({ path: ['x', 'y'], connected: false });
+  });
+
+  it('is a no-op for a malformed trace payload (missing/non-string path)', () => {
+    const state = INITIAL_VIEW_ACTION_STATE;
+    expect(applyViewAction(state, { reason: 'trace', connected: true })).toBe(state);
+    expect(applyViewAction(state, { reason: 'trace', path: 'not-an-array' })).toBe(state);
+  });
+});
+
+describe('applyViewAction — filter (#409, cli#214)', () => {
+  it('records explicit matched nodeIds when filter.query was given', () => {
+    const state = applyViewAction(INITIAL_VIEW_ACTION_STATE, {
+      reason: 'filter',
+      filter: { query: 'budget' },
+      nodes: ['a', 'b'],
+    });
+    expect(state.filter).toEqual({ nodeIds: ['a', 'b'], query: 'budget', cluster: undefined, nodeType: undefined });
+  });
+
+  it('records nodeIds: null for a cluster/nodeType-only filter (server has no seam without a query)', () => {
+    const state = applyViewAction(INITIAL_VIEW_ACTION_STATE, {
+      reason: 'filter',
+      filter: { cluster: 'engineering' },
+      nodes: null,
+    });
+    expect(state.filter).toEqual({
+      nodeIds: null,
+      query: undefined,
+      cluster: 'engineering',
+      nodeType: undefined,
+    });
+  });
+
+  it('a later filter REPLACES the prior one', () => {
+    let state = applyViewAction(INITIAL_VIEW_ACTION_STATE, {
+      reason: 'filter',
+      filter: { query: 'a' },
+      nodes: ['a'],
+    });
+    state = applyViewAction(state, { reason: 'filter', filter: { query: 'b' }, nodes: ['b'] });
+    expect(state.filter?.nodeIds).toEqual(['b']);
+  });
+
+  it('is a no-op for a malformed filter payload (nodes neither null nor a string array)', () => {
+    const state = INITIAL_VIEW_ACTION_STATE;
+    expect(applyViewAction(state, { reason: 'filter', filter: {}, nodes: 'nope' })).toBe(state);
+    expect(applyViewAction(state, { reason: 'filter', filter: {}, nodes: [1, 2] })).toBe(state);
+  });
+});
+
+describe('applyViewAction — degrade paths (#409)', () => {
+  it('is a no-op for a reason-less payload (the legacy content-patch shape)', () => {
+    const state = INITIAL_VIEW_ACTION_STATE;
+    expect(applyViewAction(state, { nodes: [{ id: 'a', title: 'x' }] })).toBe(state);
+  });
+
+  it('is a no-op for an unrecognized reason', () => {
+    const state = INITIAL_VIEW_ACTION_STATE;
+    expect(applyViewAction(state, { reason: 'something-else' })).toBe(state);
+  });
+
+  it('never throws for non-object payloads', () => {
+    const state = INITIAL_VIEW_ACTION_STATE;
+    expect(applyViewAction(state, undefined)).toBe(state);
+    expect(applyViewAction(state, null)).toBe(state);
+    expect(applyViewAction(state, 'oops')).toBe(state);
+    expect(applyViewAction(state, 42)).toBe(state);
+  });
+});
+
+describe('resolveFilterNodeIds (#409, cli#214)', () => {
+  const graph = graphWith([
+    node({ id: 'a', cluster: 'eng', entityType: 'doc' }),
+    node({ id: 'b', cluster: 'eng', entityType: 'issue' }),
+    node({ id: 'c', cluster: 'design', entityType: 'doc' }),
+  ]);
+
+  it('returns undefined when no filter is active', () => {
+    expect(resolveFilterNodeIds(undefined, graph)).toBeUndefined();
+  });
+
+  it('passes through explicit nodeIds unchanged (server already matched by query)', () => {
+    const filter: ViewActionState['filter'] = { nodeIds: ['a', 'c'] };
+    expect(resolveFilterNodeIds(filter, graph)).toEqual(new Set(['a', 'c']));
+  });
+
+  it('resolves cluster-only filter client-side when nodeIds is null', () => {
+    const filter: ViewActionState['filter'] = { nodeIds: null, cluster: 'eng' };
+    expect(resolveFilterNodeIds(filter, graph)).toEqual(new Set(['a', 'b']));
+  });
+
+  it('resolves nodeType-only filter client-side when nodeIds is null', () => {
+    const filter: ViewActionState['filter'] = { nodeIds: null, nodeType: 'doc' };
+    expect(resolveFilterNodeIds(filter, graph)).toEqual(new Set(['a', 'c']));
+  });
+
+  it('combines cluster AND nodeType when both are given', () => {
+    const filter: ViewActionState['filter'] = { nodeIds: null, cluster: 'eng', nodeType: 'doc' };
+    expect(resolveFilterNodeIds(filter, graph)).toEqual(new Set(['a']));
+  });
+
+  it('returns undefined for an empty/malformed filter (nodeIds null, no cluster/nodeType)', () => {
+    const filter: ViewActionState['filter'] = { nodeIds: null };
+    expect(resolveFilterNodeIds(filter, graph)).toBeUndefined();
+  });
+
+  it('returns an empty set (not undefined) when a client-side filter matches nothing', () => {
+    const filter: ViewActionState['filter'] = { nodeIds: null, cluster: 'nonexistent' };
+    expect(resolveFilterNodeIds(filter, graph)).toEqual(new Set());
+  });
+});

--- a/src/canvas/useCanvasEvents.ts
+++ b/src/canvas/useCanvasEvents.ts
@@ -1,0 +1,187 @@
+/**
+ * Agent action surface — `/events` SSE consumer (#409, epic #407).
+ *
+ * The loopback contract (`docs/canvas-loopback-contract.md` in `kbexplorer-cli`)
+ * freezes `GET /events` to three event names: `ready` (connection ack, ignored
+ * here), `graph-updated { nodes: [...] }`, and `anchor { nodeId }`. This module
+ * is the template-side consumer: a pure, framework-agnostic subscription
+ * ({@link subscribeToCanvasEvents}) plus a thin React hook ({@link useCanvasEvents})
+ * that wires it into the embeddable mount's lifecycle.
+ *
+ * Everything here is deliberately split into pure functions so the wiring can be
+ * unit-tested without a DOM/EventSource: {@link resolveEventsUrl} (URL
+ * derivation), {@link applyGraphUpdatedEvent} (the view-state reducer), and
+ * {@link subscribeToCanvasEvents} (event → handler wiring, given an injectable
+ * `EventSource`-like factory).
+ *
+ * KNOWN LIMITATION (documented, not silently glossed over): `graph-updated`
+ * patches fields onto nodes ALREADY present in the loaded graph; it does not
+ * add brand-new nodes. The local manifest is baked in at build time, and the
+ * frozen contract doesn't yet specify a full node shape (vs. a bare id) in the
+ * event payload — inventing the required `content`/`connections`/`source`
+ * fields for a node we've never seen would be guesswork. Introducing brand-new
+ * nodes via `/manifest/slice` is real follow-up work once that shape is nailed
+ * down with the CLI side.
+ *
+ * `expand` / `trace` / `filter` are NOT wired here: the frozen contract only
+ * defines `graph-updated` / `anchor` today. Those three are proposed-but-
+ * undecided per #409's own issue body ("choose one and record it in the
+ * contract doc") — a decision that lives in the `kbexplorer-cli` repo and
+ * needs to be relayed back, not invented unilaterally here.
+ */
+import { useEffect, useRef } from 'react';
+import type { KBGraph, KBNode } from '../types';
+import type { CanvasBootConfig } from './bootConfig';
+
+/** Parsed handlers for the two frozen domain events. */
+export interface CanvasEventHandlers {
+  /** `anchor { nodeId }` — re-anchor the conversation on a node. */
+  onAnchor?: (nodeId: string) => void;
+  /** `graph-updated { nodes: [...] }` — apply a content/graph mutation. */
+  onGraphUpdated?: (payload: unknown) => void;
+  /**
+   * Transport-level errors (including the frozen no-op/heartbeat-only seam
+   * reconnecting, or `/events` not existing at all — e.g. this repo's own
+   * `vite preview`, which has no loopback server). Never thrown; the consumer
+   * decides whether/how to surface it. Omit to degrade silently.
+   */
+  onError?: (event: unknown) => void;
+}
+
+/** The minimal `EventSource` surface this module depends on (for fakes/tests). */
+export interface CanvasEventSourceLike {
+  addEventListener(type: string, listener: (event: { data: string }) => void): void;
+  close(): void;
+  onerror: ((event: unknown) => void) | null;
+}
+
+export type CanvasEventSourceFactory = (url: string) => CanvasEventSourceLike;
+
+function defaultFactory(url: string): CanvasEventSourceLike {
+  return new EventSource(url) as unknown as CanvasEventSourceLike;
+}
+
+/**
+ * Derive the `/events` URL from the boot config. The loopback server serves
+ * the canvas entry, its static assets, AND `/events` from the same origin
+ * (`docs/canvas-loopback-contract.md`: "Boot config is injected server-side...
+ * so the origin-relative `searchServiceUrl` is always correct"), so a bare
+ * relative `/events` is correct in production. `searchServiceUrl`'s origin is
+ * used when present and parseable, as a defensive belt-and-suspenders (e.g. a
+ * host that serves the canvas cross-origin from its API); falls back to the
+ * relative path otherwise (including when `searchServiceUrl` is absent, or in
+ * this repo's own `vite preview`/tests, where there is no loopback server at
+ * all and the connection is expected to fail — see `onError` above).
+ */
+export function resolveEventsUrl(boot: Pick<CanvasBootConfig, 'searchServiceUrl'>): string {
+  if (boot.searchServiceUrl) {
+    try {
+      return `${new URL(boot.searchServiceUrl).origin}/events`;
+    } catch {
+      // Malformed searchServiceUrl — fall through to the relative default.
+    }
+  }
+  return '/events';
+}
+
+function safeParseJson(data: string): unknown {
+  try {
+    return JSON.parse(data);
+  } catch {
+    return undefined;
+  }
+}
+
+/** A candidate node patch: must at least carry the `id` it targets. */
+type NodePatch = Partial<KBNode> & { id: string };
+
+function isNodePatch(value: unknown): value is NodePatch {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    typeof (value as { id?: unknown }).id === 'string' &&
+    (value as { id: string }).id.length > 0
+  );
+}
+
+/**
+ * The `graph-updated` view-state reducer. Patches fields onto nodes already
+ * present in `graph` by `id`; unknown ids, malformed entries, and non-array
+ * payloads are ignored (defensive — never throws, degrades to a no-op).
+ * Returns the SAME `graph` reference when nothing changed, so callers can use
+ * it directly as a `setState` updater without an extra equality check.
+ */
+export function applyGraphUpdatedEvent(graph: KBGraph, payload: unknown): KBGraph {
+  const nodesField = (payload as { nodes?: unknown } | undefined)?.nodes;
+  if (!Array.isArray(nodesField) || nodesField.length === 0) return graph;
+
+  const patches = new Map<string, NodePatch>();
+  for (const candidate of nodesField) {
+    if (isNodePatch(candidate)) patches.set(candidate.id, candidate);
+  }
+  if (patches.size === 0) return graph;
+
+  let changed = false;
+  const nodes = graph.nodes.map(node => {
+    const patch = patches.get(node.id);
+    if (!patch) return node;
+    changed = true;
+    // `id` is never overwritten by the patch — identity stays stable.
+    return { ...node, ...patch, id: node.id };
+  });
+  return changed ? { ...graph, nodes } : graph;
+}
+
+/**
+ * Open one `EventSource(url)` and wire the frozen `anchor`/`graph-updated`
+ * events to `handlers`. Pure/framework-agnostic (an injectable `factory` makes
+ * it unit-testable without a real `EventSource`/DOM). Returns a cleanup
+ * function that closes the connection.
+ */
+export function subscribeToCanvasEvents(
+  url: string,
+  handlers: CanvasEventHandlers,
+  factory: CanvasEventSourceFactory = defaultFactory,
+): () => void {
+  const source = factory(url);
+
+  source.addEventListener('anchor', event => {
+    const payload = safeParseJson(event.data) as { nodeId?: unknown } | undefined;
+    if (typeof payload?.nodeId === 'string' && payload.nodeId.length > 0) {
+      handlers.onAnchor?.(payload.nodeId);
+    }
+  });
+
+  source.addEventListener('graph-updated', event => {
+    handlers.onGraphUpdated?.(safeParseJson(event.data));
+  });
+
+  source.onerror = event => {
+    handlers.onError?.(event);
+  };
+
+  return () => source.close();
+}
+
+/**
+ * React hook wiring {@link subscribeToCanvasEvents} into a component's
+ * lifecycle. Handlers are read from a ref so identity churn on every render
+ * doesn't force a reconnect; only a change to `url` re-subscribes.
+ */
+export function useCanvasEvents(url: string, handlers: CanvasEventHandlers): void {
+  const handlersRef = useRef(handlers);
+  // Keep the ref current without mutating it during render (react-hooks/refs) —
+  // this effect runs after every render (no deps array) purely to sync the ref.
+  useEffect(() => {
+    handlersRef.current = handlers;
+  });
+
+  useEffect(() => {
+    if (typeof EventSource === 'undefined') return undefined; // SSR/tests without a DOM.
+    return subscribeToCanvasEvents(url, {
+      onAnchor: nodeId => handlersRef.current.onAnchor?.(nodeId),
+      onGraphUpdated: payload => handlersRef.current.onGraphUpdated?.(payload),
+      onError: event => handlersRef.current.onError?.(event),
+    });
+  }, [url]);
+}

--- a/src/canvas/useCanvasEvents.ts
+++ b/src/canvas/useCanvasEvents.ts
@@ -23,11 +23,14 @@
  * nodes via `/manifest/slice` is real follow-up work once that shape is nailed
  * down with the CLI side.
  *
- * `expand` / `trace` / `filter` are NOT wired here: the frozen contract only
- * defines `graph-updated` / `anchor` today. Those three are proposed-but-
- * undecided per #409's own issue body ("choose one and record it in the
- * contract doc") — a decision that lives in the `kbexplorer-cli` repo and
- * needs to be relayed back, not invented unilaterally here.
+ * `expand` / `trace` / `filter` are also delivered over `graph-updated` — the
+ * frozen contract (`kbexplorer-cli` cli#214) distinguishes them from the
+ * reason-less content-patch shape above via a `reason` field. Dispatching on
+ * `reason` and applying those three is `viewActionState.ts`'s job
+ * ({@link applyGraphUpdatedEvent} above intentionally never looks at
+ * `reason` — it only patches nodes and is a no-op on the plain-id-array
+ * `nodes` shape `expand`/`trace`/`filter` payloads use); the two reducers are
+ * dispatched side-by-side by the `graph-updated` handler in `EmbeddableApp.tsx`.
  */
 import { useEffect, useRef } from 'react';
 import type { KBGraph, KBNode } from '../types';

--- a/src/canvas/viewActionState.ts
+++ b/src/canvas/viewActionState.ts
@@ -1,0 +1,153 @@
+/**
+ * Reason-aware `graph-updated` view-action reducer (#409, epic #407).
+ *
+ * The frozen loopback contract's canvas actions (`kbexplorer-cli` cli#214,
+ * `docs/canvas-loopback-contract.md`) deliver the agent-invoked `expand` /
+ * `trace` / `filter` operations as the SAME `graph-updated` SSE event, not a
+ * separate event type — distinguished by a `reason` field:
+ *
+ * - `expand`  → `{ reason: 'expand', nodes: [nodeId, ...neighborIds], focus }`
+ * - `trace`   → `{ reason: 'trace', nodes: path, path, connected }`
+ * - `filter`  → `{ reason: 'filter', filter: { query?, cluster?, nodeType? }, nodes }`
+ *   — `nodes` is the matched id array when `filter.query` was given, else
+ *   `null` (a cluster/nodeType-only filter with no query term — the frozen
+ *   contract has no server-side seam for that case; the panel is expected to
+ *   apply the predicate client-side against the manifest it already has, see
+ *   {@link resolveFilterNodeIds}).
+ *
+ * IMPORTANT: in every reason-carrying payload, `nodes` is an array of PLAIN
+ * ID STRINGS — a different shape from the legacy, reason-less
+ * `graph-updated { nodes: [{ id, ...fields }] }` content-patch payload that
+ * {@link applyGraphUpdatedEvent} (`useCanvasEvents.ts`) still handles. This
+ * reducer and that one are deliberately kept separate and are dispatched by
+ * the caller based on whether `reason` is present (see `EmbeddableApp.tsx`).
+ */
+import type { KBGraph } from '../types';
+
+/** A resolved `trace` result: the path found (or attempted) and whether it connects. */
+export interface TraceResult {
+  path: string[];
+  connected: boolean;
+}
+
+/** The recorded `filter` criteria. `nodeIds: null` means "resolve client-side" — see {@link resolveFilterNodeIds}. */
+export interface FilterCriteria {
+  nodeIds: string[] | null;
+  query?: string;
+  cluster?: string;
+  nodeType?: string;
+}
+
+/**
+ * Accumulated state from every `expand` / `trace` / `filter` view-action
+ * received over the life of the `/events` connection. Immutable — each
+ * {@link applyViewAction} call returns a new object (or the SAME reference
+ * when a payload doesn't apply, so callers can use it directly as a
+ * `setState` updater without an extra equality check).
+ */
+export interface ViewActionState {
+  /**
+   * Every node id ever named by an `expand` action's `nodes` field, ADDED
+   * across calls (never replaced/cleared) — an agent expanding several nodes
+   * across a conversation keeps them all visible.
+   */
+  expandedNodeIds: ReadonlySet<string>;
+  /** The most recent `expand`'s `focus` node id, if any. */
+  focusNodeId?: string;
+  /** The most recent `trace` result. A new trace REPLACES the prior one. */
+  trace?: TraceResult;
+  /** The most recent `filter` criteria. A new filter REPLACES the prior one. */
+  filter?: FilterCriteria;
+}
+
+export const INITIAL_VIEW_ACTION_STATE: ViewActionState = {
+  expandedNodeIds: new Set(),
+};
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every(v => typeof v === 'string' && v.length > 0);
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object';
+}
+
+/**
+ * Apply one `graph-updated` SSE payload to the running {@link ViewActionState}.
+ * Branches on `reason`; payloads with no `reason` (the legacy content-patch
+ * shape) or an unrecognized `reason` are NOT this reducer's concern and are
+ * returned unchanged (never throws — see `useCanvasEvents.ts` for the
+ * complementary legacy-patch reducer and the dispatch that picks between them).
+ */
+export function applyViewAction(state: ViewActionState, payload: unknown): ViewActionState {
+  if (!isPlainObject(payload)) return state;
+
+  switch (payload.reason) {
+    case 'expand': {
+      const nodes = payload.nodes;
+      if (!isStringArray(nodes) || nodes.length === 0) return state;
+      const expandedNodeIds = new Set(state.expandedNodeIds);
+      for (const id of nodes) expandedNodeIds.add(id);
+      const focus = payload.focus;
+      return {
+        ...state,
+        expandedNodeIds,
+        focusNodeId: typeof focus === 'string' && focus.length > 0 ? focus : state.focusNodeId,
+      };
+    }
+
+    case 'trace': {
+      const path = payload.path;
+      if (!isStringArray(path)) return state;
+      return { ...state, trace: { path, connected: payload.connected === true } };
+    }
+
+    case 'filter': {
+      const nodes = payload.nodes;
+      if (nodes !== null && !isStringArray(nodes)) return state;
+      const filter = isPlainObject(payload.filter) ? payload.filter : {};
+      return {
+        ...state,
+        filter: {
+          nodeIds: nodes,
+          query: typeof filter.query === 'string' ? filter.query : undefined,
+          cluster: typeof filter.cluster === 'string' ? filter.cluster : undefined,
+          nodeType: typeof filter.nodeType === 'string' ? filter.nodeType : undefined,
+        },
+      };
+    }
+
+    default:
+      // No reason, or a reason this reducer doesn't know about — a no-op
+      // here, not a crash. `useCanvasEvents.ts`'s `applyGraphUpdatedEvent`
+      // handles the reason-less legacy shape.
+      return state;
+  }
+}
+
+/**
+ * Resolve the EFFECTIVE set of visible node ids for the active filter, doing
+ * the client-side `cluster`/`nodeType` predicate the frozen contract punts to
+ * the panel when the server sent `nodeIds: null` (see the module doc's
+ * "filter" bullet and the contract's own "Honesty note on filter"). Returns
+ * `undefined` when no filter is active (nothing to constrain) — callers
+ * should treat that as "show everything".
+ *
+ * When `nodeIds` is `null` and NEITHER `cluster` nor `nodeType` is set (a
+ * malformed/empty filter), also returns `undefined` — there's nothing to
+ * filter by, so the caller degrades to "no-op" rather than hiding everything.
+ */
+export function resolveFilterNodeIds(
+  filter: FilterCriteria | undefined,
+  graph: Pick<KBGraph, 'nodes'>,
+): Set<string> | undefined {
+  if (!filter) return undefined;
+  if (filter.nodeIds !== null) return new Set(filter.nodeIds);
+  if (!filter.cluster && !filter.nodeType) return undefined;
+  const matched = graph.nodes.filter(
+    node =>
+      (!filter.cluster || node.cluster === filter.cluster) &&
+      (!filter.nodeType || node.entityType === filter.nodeType),
+  );
+  return new Set(matched.map(node => node.id));
+}

--- a/src/representation/targets/__tests__/copilot.test.ts
+++ b/src/representation/targets/__tests__/copilot.test.ts
@@ -26,8 +26,8 @@ function baseOptions(overrides: Partial<CopilotRenderOptions> = {}): CopilotRend
 function routePaths(element: ReactElement): { paths: string[]; navigateTargets: string[] } {
   const paths: string[] = [];
   const navigateTargets: string[] = [];
-  const children = (element.props as { children?: unknown }).children;
-  Children.forEach(children as ReactNode, child => {
+  const children = (element.props as { children?: ReactNode }).children;
+  Children.forEach(children, child => {
     if (!isValidElement(child)) return;
     const props = child.props as { path?: string; element?: ReactElement };
     if (props.path) paths.push(props.path);

--- a/src/representation/targets/copilot-home/AnchorFirstView.tsx
+++ b/src/representation/targets/copilot-home/AnchorFirstView.tsx
@@ -14,6 +14,13 @@
  * order) that `llm-context` uses — the view supplies a unit cost + a
  * max-expanded count instead of a token budget/cost.
  *
+ * AGENT VIEW-ACTIONS (#409, cli#214): an optional `viewAction` prop layers the
+ * accumulated `expand`/`trace`/`filter` `/events` state on top of the ranked
+ * partition — `expand` force-adds neighbors (and highlights a `focus` node),
+ * `trace` renders a path banner and highlights matching nodes, `filter`
+ * constrains which neighbors render. All are additive/no-op when absent, so
+ * every existing caller (including tests) is unaffected.
+ *
  * NO-ANCHOR FALLBACK: when the anchor id is absent from the graph (including the
  * no-anchor `/node/home` config landing), the constellation ({@link HomePage})
  * renders as the sensible default.
@@ -33,11 +40,12 @@ import {
   Subtitle2,
   Title3,
   makeStyles,
+  mergeClasses,
   tokens,
 } from '@fluentui/react-components';
 import { ArrowExpandRegular } from '@fluentui/react-icons';
 import { stripScheme } from '@anokye-labs/kbexplorer-core';
-import type { KBConfig, KBEdge, KBGraph } from '../../../types';
+import type { KBConfig, KBEdge, KBGraph, KBNode } from '../../../types';
 import { resolveViewer } from '../../../views/viewers';
 import { HomePage } from '../../../views/HomePage';
 import { nodeUrn } from '../urn';
@@ -53,6 +61,81 @@ function relationLabel(edge: KBEdge | undefined): string {
 
 function weightLabel(edge: KBEdge | undefined): string {
   return (edge?.weight ?? 0).toFixed(2);
+}
+
+/** Agent view-actions layered onto the ranked partition (#409, cli#214). See module doc. */
+export interface AnchorViewAction {
+  /** Node ids force-added by `expand` (unioned across every `expand` seen — never cleared). */
+  expandedNodeIds?: ReadonlySet<string>;
+  /** The most recent `expand`'s focus node id. */
+  focusNodeId?: string;
+  /** The most recent `trace` result. */
+  trace?: { path: string[]; connected: boolean };
+  /** The active `filter`'s resolved node-id set (already client-resolved by the caller). */
+  filterNodeIds?: ReadonlySet<string>;
+}
+
+/**
+ * Force-add `expand`-named neighbors into `expanded`, promoting them out of
+ * `unexpanded` when already ranked there, else synthesizing a card for a node
+ * outside the anchor's ranked neighborhood entirely (best-effort direct edge,
+ * possibly none — {@link ExpandedNeighbor} already tolerates an undefined edge).
+ * Unknown ids (not in `graph` at all) degrade silently, never throw.
+ */
+function mergeForcedExpansion(
+  graph: KBGraph,
+  anchor: KBNode,
+  expanded: AnchoredNeighbor[],
+  unexpanded: AnchoredNeighbor[],
+  forcedIds: ReadonlySet<string> | undefined,
+): { expanded: AnchoredNeighbor[]; unexpanded: AnchoredNeighbor[] } {
+  if (!forcedIds || forcedIds.size === 0) return { expanded, unexpanded };
+
+  const expandedIds = new Set(expanded.map(n => n.node.id));
+  const extra: AnchoredNeighbor[] = [];
+  const remainingUnexpanded: AnchoredNeighbor[] = [];
+
+  for (const neighbor of unexpanded) {
+    if (forcedIds.has(neighbor.node.id) && !expandedIds.has(neighbor.node.id)) {
+      extra.push(neighbor);
+      expandedIds.add(neighbor.node.id);
+    } else {
+      remainingUnexpanded.push(neighbor);
+    }
+  }
+
+  for (const id of forcedIds) {
+    if (id === anchor.id || expandedIds.has(id)) continue;
+    const node = graph.nodes.find(n => n.id === id);
+    if (!node) continue; // agent named a node id absent from this manifest — no-op.
+    extra.push({ node, edge: bestEdgeBetween(graph, anchor.id, id) });
+    expandedIds.add(id);
+  }
+
+  return { expanded: [...expanded, ...extra], unexpanded: remainingUnexpanded };
+}
+
+/** Best (highest-weight) direct edge between two node ids, in either direction. */
+function bestEdgeBetween(graph: KBGraph, a: string, b: string): KBEdge | undefined {
+  let best: KBEdge | undefined;
+  for (const edge of graph.edges) {
+    const matches = (edge.from === a && edge.to === b) || (edge.from === b && edge.to === a);
+    if (matches && (!best || edge.weight > best.weight)) best = edge;
+  }
+  return best;
+}
+
+/** Constrain the two neighbor lists to an active `filter`'s resolved id set. No-op when absent. */
+function applyNeighborFilter(
+  expanded: AnchoredNeighbor[],
+  unexpanded: AnchoredNeighbor[],
+  filterNodeIds: ReadonlySet<string> | undefined,
+): { expanded: AnchoredNeighbor[]; unexpanded: AnchoredNeighbor[] } {
+  if (!filterNodeIds) return { expanded, unexpanded };
+  return {
+    expanded: expanded.filter(n => filterNodeIds.has(n.node.id)),
+    unexpanded: unexpanded.filter(n => filterNodeIds.has(n.node.id)),
+  };
 }
 
 const useStyles = makeStyles({
@@ -123,19 +206,51 @@ const useStyles = makeStyles({
     color: tokens.colorNeutralForeground3,
     fontSize: tokens.fontSizeBase200,
   },
+  focused: {
+    outlineStyle: 'solid',
+    outlineWidth: tokens.strokeWidthThick,
+    outlineColor: tokens.colorBrandStroke1,
+  },
+  onTrace: {
+    border: `${tokens.strokeWidthThick} solid ${tokens.colorPaletteMarigoldBorder2}`,
+  },
+  traceBanner: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: tokens.spacingVerticalXS,
+  },
+  filterHint: {
+    color: tokens.colorNeutralForeground3,
+  },
 });
 
 /** A single expanded neighbor: header (title · relation · weight) + its viewer. */
-function ExpandedNeighbor({ neighbor }: { neighbor: AnchoredNeighbor }) {
+function ExpandedNeighbor({
+  neighbor,
+  focused = false,
+  onTrace = false,
+}: {
+  neighbor: AnchoredNeighbor;
+  /** This neighbor is the current `expand`'s `focus` node (#409). */
+  focused?: boolean;
+  /** This neighbor sits on the current `trace` path (#409). */
+  onTrace?: boolean;
+}) {
   const styles = useStyles();
   const { node, edge } = neighbor;
   return (
     <Card
       appearance="subtle"
       size="small"
-      className={styles.neighborCard}
+      className={mergeClasses(
+        styles.neighborCard,
+        focused && styles.focused,
+        onTrace && styles.onTrace,
+      )}
       data-testid="anchor-expanded-neighbor"
       data-node-id={node.id}
+      data-kbx-focused={focused || undefined}
+      data-kbx-on-trace={onTrace || undefined}
     >
       <a
         href={`#/node/${encodeURIComponent(node.id)}`}
@@ -154,7 +269,14 @@ function ExpandedNeighbor({ neighbor }: { neighbor: AnchoredNeighbor }) {
 }
 
 /** A `kg://` chip for a relevant-but-unexpanded neighbor — navigates on click. */
-function NeighborChip({ neighbor }: { neighbor: AnchoredNeighbor }) {
+function NeighborChip({
+  neighbor,
+  onTrace = false,
+}: {
+  neighbor: AnchoredNeighbor;
+  /** This neighbor sits on the current `trace` path (#409). */
+  onTrace?: boolean;
+}) {
   const styles = useStyles();
   const { node, edge } = neighbor;
   const urn = nodeUrn(node);
@@ -164,10 +286,11 @@ function NeighborChip({ neighbor }: { neighbor: AnchoredNeighbor }) {
       href={`#/node/${encodeURIComponent(node.id)}`}
       appearance="outline"
       size="small"
-      className={styles.chip}
+      className={mergeClasses(styles.chip, onTrace && styles.onTrace)}
       title={`${stripScheme(urn)} · ${relationLabel(edge)} · weight ${weightLabel(edge)}`}
       data-testid="anchor-neighbor-chip"
       data-node-id={node.id}
+      data-kbx-on-trace={onTrace || undefined}
     >
       {node.title}
     </Button>
@@ -181,6 +304,8 @@ export interface AnchorFirstViewProps {
   anchorId: string;
   /** Max top-ranked neighbors rendered inline; the rest become `kg://` chips. */
   maxExpanded?: number;
+  /** Accumulated agent `expand`/`trace`/`filter` view-actions (#409, cli#214). Optional/additive. */
+  viewAction?: AnchorViewAction;
 }
 
 /**
@@ -192,6 +317,7 @@ export function AnchorFirstView({
   config,
   anchorId,
   maxExpanded = DEFAULT_MAX_EXPANDED,
+  viewAction,
 }: AnchorFirstViewProps) {
   const styles = useStyles();
 
@@ -208,6 +334,31 @@ export function AnchorFirstView({
     return { anchor: anchorNode, expanded: partition.expanded, unexpanded: partition.unexpanded };
   }, [graph, anchorId, maxExpanded]);
 
+  // Layer `expand`/`filter` on top of the ranked partition (#409). Both are
+  // no-ops when `viewAction` is absent/empty — memoized so re-renders that
+  // don't touch the view-action state (e.g. a theme change) skip the work.
+  const { visibleExpanded, visibleUnexpanded } = useMemo(() => {
+    if (!anchor) return { visibleExpanded: [], visibleUnexpanded: [] };
+    const forced = mergeForcedExpansion(
+      graph,
+      anchor,
+      expanded,
+      unexpanded,
+      viewAction?.expandedNodeIds,
+    );
+    const filtered = applyNeighborFilter(
+      forced.expanded,
+      forced.unexpanded,
+      viewAction?.filterNodeIds,
+    );
+    return { visibleExpanded: filtered.expanded, visibleUnexpanded: filtered.unexpanded };
+  }, [graph, anchor, expanded, unexpanded, viewAction?.expandedNodeIds, viewAction?.filterNodeIds]);
+
+  // Precompute the trace path id set (used to highlight matching neighbor
+  // cards/chips) before the early return so hook order stays stable.
+  const tracePath = viewAction?.trace?.path;
+  const traceIds = useMemo(() => new Set(tracePath ?? []), [tracePath]);
+
   // NO-ANCHOR / bad-anchor fallback: the constellation is the sensible default.
   if (!anchor) {
     return (
@@ -221,9 +372,18 @@ export function AnchorFirstView({
   }
 
   const cluster = config.clusters?.[anchor.cluster];
+  const anchorFocused = viewAction?.focusNodeId === anchor.id;
+  const filterActive = viewAction?.filterNodeIds !== undefined;
+  const noFilterMatches =
+    filterActive && visibleExpanded.length === 0 && visibleUnexpanded.length === 0;
 
   return (
-    <div className={styles.root} data-testid="anchor-first-view" data-anchor-id={anchor.id}>
+    <div
+      className={mergeClasses(styles.root, anchorFocused && styles.focused)}
+      data-testid="anchor-first-view"
+      data-anchor-id={anchor.id}
+      data-kbx-focused={anchorFocused || undefined}
+    >
       <div className={styles.header}>
         <div className={styles.headerRow}>
           <Title3>{anchor.title}</Title3>
@@ -255,30 +415,78 @@ export function AnchorFirstView({
         {createElement(resolveViewer(anchor), { node: anchor })}
       </div>
 
-      {expanded.length > 0 && (
+      {viewAction?.trace && (
+        <>
+          <Divider />
+          <div
+            className={styles.traceBanner}
+            data-testid="anchor-trace-banner"
+            data-connected={viewAction.trace.connected}
+          >
+            <Body1 className={styles.sectionTitle}>
+              Trace {viewAction.trace.connected ? '— connected' : '— no path found'}
+            </Body1>
+            <div className={styles.chips}>
+              {viewAction.trace.path.map((id, index) => {
+                const traceNode = graph.nodes.find(n => n.id === id);
+                return (
+                  <Badge
+                    key={`${id}-${index}`}
+                    appearance="outline"
+                    color={viewAction.trace?.connected ? 'success' : 'danger'}
+                    data-testid="anchor-trace-node"
+                    data-node-id={id}
+                  >
+                    {traceNode?.title ?? id}
+                  </Badge>
+                );
+              })}
+            </div>
+          </div>
+        </>
+      )}
+
+      {filterActive && (
+        <Caption1 className={styles.filterHint} data-testid="anchor-filter-hint">
+          {noFilterMatches
+            ? 'Filtered — no neighbors match the current filter.'
+            : `Filtered — showing ${visibleExpanded.length + visibleUnexpanded.length} matching neighbor(s).`}
+        </Caption1>
+      )}
+
+      {visibleExpanded.length > 0 && (
         <>
           <Divider />
           <div className={styles.section} data-testid="anchor-expanded-neighbors">
             <Body1 className={styles.sectionTitle}>Nearest neighbors</Body1>
-            {expanded.map(neighbor => (
-              <ExpandedNeighbor key={neighbor.node.id} neighbor={neighbor} />
+            {visibleExpanded.map(neighbor => (
+              <ExpandedNeighbor
+                key={neighbor.node.id}
+                neighbor={neighbor}
+                focused={viewAction?.focusNodeId === neighbor.node.id}
+                onTrace={traceIds.has(neighbor.node.id)}
+              />
             ))}
           </div>
         </>
       )}
 
-      {unexpanded.length > 0 && (
+      {visibleUnexpanded.length > 0 && (
         <div className={styles.section} data-testid="anchor-neighbor-chips">
           <Body1 className={styles.sectionTitle}>Navigate — follow a link for more</Body1>
           <div className={styles.chips}>
-            {unexpanded.map(neighbor => (
-              <NeighborChip key={neighbor.node.id} neighbor={neighbor} />
+            {visibleUnexpanded.map(neighbor => (
+              <NeighborChip
+                key={neighbor.node.id}
+                neighbor={neighbor}
+                onTrace={traceIds.has(neighbor.node.id)}
+              />
             ))}
           </div>
         </div>
       )}
 
-      {expanded.length === 0 && unexpanded.length === 0 && (
+      {visibleExpanded.length === 0 && visibleUnexpanded.length === 0 && !filterActive && (
         <Caption1 className={styles.sectionTitle} data-testid="anchor-no-neighbors">
           This node has no ranked neighbors yet.
         </Caption1>

--- a/src/representation/targets/copilot-home/__tests__/anchor-first-view.test.ts
+++ b/src/representation/targets/copilot-home/__tests__/anchor-first-view.test.ts
@@ -89,3 +89,163 @@ describe('AnchorFirstView (B2 #408 landing)', () => {
     expect(html).not.toContain('data-testid="anchor-neighbor-chip"');
   });
 });
+
+describe('AnchorFirstView — agent view-actions (#409, cli#214)', () => {
+  it('expand force-promotes an over-budget neighbor from chips into expanded cards', () => {
+    // maxExpanded: 1 -> n1 expanded, n2 relegated to a chip by rank alone.
+    const html = renderToStaticMarkup(
+      createElement(AnchorFirstView, {
+        graph,
+        config,
+        anchorId: 'anchor',
+        maxExpanded: 1,
+        viewAction: { expandedNodeIds: new Set(['n2']) },
+      }),
+    );
+    // n2 is now an expanded card, not a chip.
+    expect(html).toMatch(/data-testid="anchor-expanded-neighbor"[^>]*data-node-id="n2"/);
+    expect(html).not.toMatch(/data-testid="anchor-neighbor-chip"[^>]*data-node-id="n2"/);
+  });
+
+  it('expand synthesizes a card for a node outside the ranked neighborhood entirely', () => {
+    // 'far' is two hops away — not in graph.related['anchor'] at all.
+    const html = renderToStaticMarkup(
+      createElement(AnchorFirstView, {
+        graph,
+        config,
+        anchorId: 'anchor',
+        maxExpanded: 6,
+        viewAction: { expandedNodeIds: new Set(['far']) },
+      }),
+    );
+    expect(html).toMatch(/data-testid="anchor-expanded-neighbor"[^>]*data-node-id="far"/);
+  });
+
+  it('expand degrades silently for an unknown node id (no fabrication)', () => {
+    expect(() =>
+      renderToStaticMarkup(
+        createElement(AnchorFirstView, {
+          graph,
+          config,
+          anchorId: 'anchor',
+          maxExpanded: 6,
+          viewAction: { expandedNodeIds: new Set(['does-not-exist']) },
+        }),
+      ),
+    ).not.toThrow();
+  });
+
+  it('focus marks the matching neighbor card with data-kbx-focused', () => {
+    const html = renderToStaticMarkup(
+      createElement(AnchorFirstView, {
+        graph,
+        config,
+        anchorId: 'anchor',
+        maxExpanded: 6,
+        viewAction: { focusNodeId: 'n1' },
+      }),
+    );
+    expect(html).toMatch(/data-node-id="n1"[^>]*data-kbx-focused="true"/);
+    expect(html).not.toMatch(/data-node-id="n2"[^>]*data-kbx-focused="true"/);
+  });
+
+  it('focus marks the anchor itself when focusNodeId is the anchor', () => {
+    const html = renderToStaticMarkup(
+      createElement(AnchorFirstView, {
+        graph,
+        config,
+        anchorId: 'anchor',
+        viewAction: { focusNodeId: 'anchor' },
+      }),
+    );
+    expect(html).toMatch(/data-testid="anchor-first-view"[^>]*data-kbx-focused="true"/);
+  });
+
+  it('trace renders a path banner with a connected indicator and node titles', () => {
+    const html = renderToStaticMarkup(
+      createElement(AnchorFirstView, {
+        graph,
+        config,
+        anchorId: 'anchor',
+        maxExpanded: 6,
+        viewAction: { trace: { path: ['anchor', 'n1'], connected: true } },
+      }),
+    );
+    expect(html).toContain('data-testid="anchor-trace-banner"');
+    expect(html).toContain('data-connected="true"');
+    expect(html).toContain('Title n1');
+  });
+
+  it('trace renders a disconnected indicator when connected:false', () => {
+    const html = renderToStaticMarkup(
+      createElement(AnchorFirstView, {
+        graph,
+        config,
+        anchorId: 'anchor',
+        viewAction: { trace: { path: ['anchor', 'far'], connected: false } },
+      }),
+    );
+    expect(html).toContain('data-connected="false"');
+    expect(html).toContain('no path found');
+  });
+
+  it('trace highlights a visible neighbor that sits on the path', () => {
+    const html = renderToStaticMarkup(
+      createElement(AnchorFirstView, {
+        graph,
+        config,
+        anchorId: 'anchor',
+        maxExpanded: 6,
+        viewAction: { trace: { path: ['anchor', 'n1'], connected: true } },
+      }),
+    );
+    expect(html).toMatch(/data-node-id="n1"[^>]*data-kbx-on-trace="true"/);
+  });
+
+  it('filter constrains rendered neighbors to the resolved id set', () => {
+    const html = renderToStaticMarkup(
+      createElement(AnchorFirstView, {
+        graph,
+        config,
+        anchorId: 'anchor',
+        maxExpanded: 6,
+        viewAction: { filterNodeIds: new Set(['n1']) },
+      }),
+    );
+    expect(html).toMatch(/data-testid="anchor-expanded-neighbor"[^>]*data-node-id="n1"/);
+    expect(html).not.toContain('data-node-id="n2"');
+    expect(html).toContain('data-testid="anchor-filter-hint"');
+  });
+
+  it('filter with no matches shows an explicit empty-result hint (not a blank/broken view)', () => {
+    const html = renderToStaticMarkup(
+      createElement(AnchorFirstView, {
+        graph,
+        config,
+        anchorId: 'anchor',
+        maxExpanded: 6,
+        viewAction: { filterNodeIds: new Set<string>() },
+      }),
+    );
+    expect(html).toContain('data-testid="anchor-filter-hint"');
+    expect(html).toContain('no neighbors match');
+    expect(html).not.toContain('data-testid="anchor-expanded-neighbor"');
+    expect(html).not.toContain('data-testid="anchor-neighbor-chip"');
+  });
+
+  it('renders identically to the no-viewAction case when viewAction is omitted', () => {
+    const withoutViewAction = renderToStaticMarkup(
+      createElement(AnchorFirstView, { graph, config, anchorId: 'anchor', maxExpanded: 1 }),
+    );
+    const withEmptyViewAction = renderToStaticMarkup(
+      createElement(AnchorFirstView, {
+        graph,
+        config,
+        anchorId: 'anchor',
+        maxExpanded: 1,
+        viewAction: {},
+      }),
+    );
+    expect(withEmptyViewAction).toBe(withoutViewAction);
+  });
+});

--- a/src/representation/targets/copilot.tsx
+++ b/src/representation/targets/copilot.tsx
@@ -34,7 +34,7 @@ import type { Representation } from '@anokye-labs/kbexplorer-core';
 import type { KBConfig, KBGraph } from '../../types';
 import { OverviewView } from '../../views/OverviewView';
 import type { SpaRenderOptions } from './spa';
-import { AnchorFirstView } from './copilot-home/AnchorFirstView';
+import { AnchorFirstView, type AnchorViewAction } from './copilot-home/AnchorFirstView';
 import { ConstellationView } from './copilot-home/ConstellationView';
 
 /**
@@ -45,12 +45,29 @@ import { ConstellationView } from './copilot-home/ConstellationView';
 export interface CopilotRenderOptions extends SpaRenderOptions {
   /** The conversation anchor node id from `bootConfig.anchorNodeId`, if any. */
   anchorNodeId?: string;
+  /**
+   * Accumulated `expand`/`trace`/`filter` agent view-actions (#409, cli#214),
+   * threaded down from `EmbeddableApp.tsx`'s `/events` consumer. Optional so
+   * every other caller of `renderCopilotSurface` (including existing tests)
+   * keeps working unchanged with no view-action applied.
+   */
+  viewAction?: AnchorViewAction;
 }
 
 /** Route element: anchor-first home for the `:id` in the hash path. */
-function AnchorRoute({ graph, config }: { graph: KBGraph; config: KBConfig }) {
+function AnchorRoute({
+  graph,
+  config,
+  viewAction,
+}: {
+  graph: KBGraph;
+  config: KBConfig;
+  viewAction?: AnchorViewAction;
+}) {
   const { id } = useParams<{ id: string }>();
-  return <AnchorFirstView graph={graph} config={config} anchorId={id ?? ''} />;
+  return (
+    <AnchorFirstView graph={graph} config={config} anchorId={id ?? ''} viewAction={viewAction} />
+  );
 }
 
 /**
@@ -67,7 +84,7 @@ export function renderCopilotSurface(
   graph: KBGraph,
   options: CopilotRenderOptions,
 ): ReactNode {
-  const { config, landingPath, anchorNodeId } = options;
+  const { config, landingPath, anchorNodeId, viewAction } = options;
   const initialPath = anchorNodeId
     ? `/node/${encodeURIComponent(anchorNodeId)}`
     : landingPath;
@@ -75,7 +92,10 @@ export function renderCopilotSurface(
   return (
     <Routes>
       <Route path="/" element={<Navigate to={initialPath} replace />} />
-      <Route path="/node/:id" element={<AnchorRoute graph={graph} config={config} />} />
+      <Route
+        path="/node/:id"
+        element={<AnchorRoute graph={graph} config={config} viewAction={viewAction} />}
+      />
       <Route path="/constellation" element={<ConstellationView graph={graph} config={config} />} />
       <Route path="/overview" element={<OverviewView graph={graph} config={config} />} />
       <Route path="*" element={<Navigate to={initialPath} replace />} />


### PR DESCRIPTION
## What
Wires the frozen `/events` SSE contract (`anchor`, `graph-updated`) into the embeddable canvas mount so an agent can drive the panel: `anchor {nodeId}` re-anchors the view, `graph-updated {nodes}` patches the live in-memory graph so it re-renders.

## How
- **`src/canvas/useCanvasEvents.ts`** (new) - pure, DOM-free `resolveEventsUrl` / `applyGraphUpdatedEvent` reducer / `subscribeToCanvasEvents` (injectable `EventSource` factory), plus a thin `useCanvasEvents` hook. Deliberately scoped to only the two **frozen** events per `docs/canvas-loopback-contract.md`.
- **`src/canvas/EmbeddableApp.tsx`** - subscribes via `useCanvasEvents`. `onAnchor` sets `location.hash` (works for both `copilot` and `spa` targets - both mount a `HashRouter`). `onGraphUpdated` patches a new `liveGraph` state, resetting whenever the loaded graph identity changes via React's render-time "adjust state when a prop changes" pattern (not an effect - this repo's `react-hooks/set-state-in-effect` lint rule flagged the effect-based version).

## Deliberate scope limits (honest gaps)
- **`expand`/`trace`/`filter` are NOT wired.** They're proposed in the contract doc but undecided, and the CLI-side companion issue that would declare/emit them hasn't been filed yet. `useCanvasEvents.ts`'s doc comment records this; wiring them later is additive, not a rewrite.
- **`graph-updated` only patches existing nodes by id.** A patch for an unknown id is a clean no-op - it does NOT fabricate a new node, since `KBNode` requires `content`/`connections`/`source`/`cluster` and the contract's terse `nodes[]` payload doesn't specify those. This is a documented, deliberate limitation, not an oversight.

## Tested
- **Unit** - `src/canvas/__tests__/useCanvasEvents.test.ts` (14 tests): `resolveEventsUrl`, the reducer (patch-in-place / ignore-unknown-id / malformed-payload no-op / invalid-entry filtering), and `subscribeToCanvasEvents` (dispatch, error routing, no-handler safety, cleanup) - using a hand-rolled fake `EventSource` (no jsdom needed, matching this repo's existing pure-function test convention, e.g. `useCanvasTheme.test.ts`).
- **E2E** - `e2e/canvas-events.spec.ts` (3 tests x chromium + edge): mocks `/events` via `page.route` with a genuine `text/event-stream` body (no CLI loopback server exists in this repo's own test env), so the real browser `EventSource` parses it exactly as a live server would.
  1. A dispatched `anchor` event actually re-anchors the panel to a dynamically-discovered real neighbor node id.
  2. A `graph-updated` event actually patches the rendered title.
  3. Safe-degrade with **no** `/events` endpoint at all (this repo's own preview/dev server) - asserts no console errors, no crash.
- **Full verification green**: `npm run build` (pass), `npm run lint` (pass, 0 errors, same 3 pre-existing warnings as baseline), `npm run test` (pass, 920/920 vitest), full `e2e/` suite (chromium + edge) including the pre-existing `canvas-embed.spec.ts` - no regressions.

## Coordination note
Per the cross-repo contract (frozen SSE events only: `anchor`/`graph-updated`), the `expand`/`trace`/`filter` decision is being routed through the creator session coordinating with the sibling `kbexplorer-cli` session. Deferring those pending that relay, per the plan already communicated.

Closes #409
