### PR TITLE
Add bidirectional click-to-chat intent bar (#410)

### DIFF
--- a/e2e/node-intent-bar.spec.ts
+++ b/e2e/node-intent-bar.spec.ts
@@ -166,4 +166,47 @@ test.describe('Bidirectional click → chat — /chat-intent consumer (#410)', (
 
     expect(affordanceHits).toBe(0);
   });
+
+  test('per-node intent state resets when the panel re-anchors (no stale badge carries across navigation)', async ({
+    page,
+  }) => {
+    await page.route('**/chat-intent', route =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: '{"ok":true}' }),
+    );
+
+    await bootCopilotCanvas(page, 'readme');
+    const anchorView = page.locator('[data-testid="anchor-first-view"]');
+    await expect(anchorView).toBeVisible({ timeout: 15000 });
+    await expect(anchorView).toHaveAttribute('data-anchor-id', 'readme');
+
+    // A real neighbor to re-anchor onto — discovered from the rendered graph,
+    // not hardcoded (same technique as the round-trip test above).
+    const neighborCard = page.locator('[data-testid="anchor-expanded-neighbor"]').first();
+    await expect(neighborCard).toBeVisible();
+    const neighborId = await neighborCard.getAttribute('data-node-id');
+    expect(neighborId).toBeTruthy();
+    expect(neighborId).not.toBe('readme');
+
+    // Drive the ANCHOR node's "derives" intent to a terminal (`ok`) state.
+    const anchorDerives = anchorView.locator('[data-testid="node-intent-derives"]').first();
+    await expect(anchorDerives).toHaveAttribute('data-intent-state', 'idle');
+    await anchorDerives.click();
+    await expect(anchorDerives).toHaveAttribute('data-intent-state', 'ok', { timeout: 10000 });
+
+    // Re-anchor onto the neighbor through the hash router. This re-renders the
+    // SAME AnchorFirstView — and its single anchor-level NodeIntentBar instance
+    // — with a new `nodeId`; it is NOT remounted. That reuse is exactly the path
+    // that used to leak the previous node's `ok` badge onto the new node's bar.
+    await page.evaluate(id => {
+      location.hash = `#/node/${encodeURIComponent(id)}`;
+    }, neighborId as string);
+    await expect(anchorView).toHaveAttribute('data-anchor-id', neighborId as string, {
+      timeout: 10000,
+    });
+
+    // The freshly-anchored node's bar must be back to `idle`, never the previous
+    // node's `ok`.
+    const newAnchorDerives = anchorView.locator('[data-testid="node-intent-derives"]').first();
+    await expect(newAnchorDerives).toHaveAttribute('data-intent-state', 'idle');
+  });
 });

--- a/e2e/node-intent-bar.spec.ts
+++ b/e2e/node-intent-bar.spec.ts
@@ -1,0 +1,169 @@
+import { test, expect, type Page } from '@playwright/test';
+
+/**
+ * Bidirectional click → chat: the `/chat-intent` consumer (#410, epic #407).
+ *
+ * There's no CLI loopback server available to THIS repo's e2e run (that
+ * server + the agent chat turn it triggers only exist inside `kbexplorer-cli`,
+ * and `kbexplorer-cli#195` — the seam that turns a posted intent into a real
+ * chat turn — is still open as of this PR). These tests prove the TEMPLATE
+ * side of the contract the same way canvas-events.spec.ts proved #409's
+ * consumer side: mock `POST /chat-intent` with `page.route` and assert the
+ * real click → real `fetch` → real DOM state transition, then (reusing #409's
+ * already-proven `/events` mechanism) show that an agent's follow-up `anchor`
+ * event completes the round trip the click kicked off. What's simulated here
+ * is the AGENT'S reply (no live agent exists in this test env); what's real
+ * is every hop the template code owns: the click handler, the intent POST
+ * body, the pending → acknowledged UI, and the SSE-driven re-anchor.
+ */
+
+function sseFrame(event: string, data: unknown): string {
+  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+async function bootCopilotCanvas(page: Page, anchorNodeId = 'readme'): Promise<void> {
+  await page.addInitScript(anchor => {
+    (window as unknown as { __KBX_CANVAS__: unknown }).__KBX_CANVAS__ = {
+      local: false,
+      visualMode: 'inherit-host',
+      target: 'copilot',
+      anchorNodeId: anchor,
+    };
+  }, anchorNodeId);
+  await page.goto('/canvas.html', { timeout: 60000 });
+}
+
+test.describe('Bidirectional click → chat — /chat-intent consumer (#410)', () => {
+  test('clicking "What derives from this?" POSTs the exact intent and shows pending → acknowledged', async ({
+    page,
+  }) => {
+    const requests: unknown[] = [];
+    await page.route('**/chat-intent', route => {
+      requests.push(route.request().postDataJSON());
+      return route.fulfill({ status: 200, contentType: 'application/json', body: '{"ok":true}' });
+    });
+
+    await bootCopilotCanvas(page, 'readme');
+    const anchorView = page.locator('[data-testid="anchor-first-view"]');
+    await expect(anchorView).toBeVisible({ timeout: 15000 });
+
+    const derivesButton = anchorView.locator('[data-testid="node-intent-derives"]').first();
+    await expect(derivesButton).toBeVisible();
+    await expect(derivesButton).toHaveAttribute('data-intent-state', 'idle');
+
+    await derivesButton.click();
+    await expect(derivesButton).toHaveAttribute('data-intent-state', 'ok', { timeout: 10000 });
+
+    expect(requests).toEqual([
+      { intent: 'derives', nodeId: 'readme', prompt: 'What derives from this node?' },
+    ]);
+  });
+
+  test('"Pin as anchor" on a neighbor posts the intent, then the agent\'s anchor event re-anchors the panel', async ({
+    page,
+  }) => {
+    await bootCopilotCanvas(page, 'readme');
+    const anchorView = page.locator('[data-testid="anchor-first-view"]');
+    await expect(anchorView).toBeVisible({ timeout: 15000 });
+
+    // A real expanded neighbor's own "Pin as anchor" button — discovered from
+    // the rendered graph, not hardcoded (same technique as #409's tests).
+    const neighborCard = page.locator('[data-testid="anchor-expanded-neighbor"]').first();
+    await expect(neighborCard).toBeVisible();
+    const targetNodeId = await neighborCard.getAttribute('data-node-id');
+    expect(targetNodeId).toBeTruthy();
+
+    const requests: unknown[] = [];
+    await page.route('**/chat-intent', route => {
+      requests.push(route.request().postDataJSON());
+      return route.fulfill({ status: 200, contentType: 'application/json', body: '{"ok":true}' });
+    });
+    // The agent's reply is simulated (no live agent in this test env): once
+    // the click has posted the intent, an `anchor` SSE event for the SAME
+    // node — #409's already-proven consumer — completes the round trip.
+    await page.route('**/events', route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'text/event-stream',
+        body: sseFrame('anchor', { nodeId: targetNodeId }),
+      }),
+    );
+
+    const pinButton = neighborCard.locator('[data-testid="node-intent-pin"]');
+    await expect(pinButton).toBeVisible();
+    await pinButton.click();
+    await expect(pinButton).toHaveAttribute('data-intent-state', 'ok', { timeout: 10000 });
+
+    expect(requests).toEqual([{ intent: 'pin', nodeId: targetNodeId }]);
+
+    // Reload so the mocked /events stream (registered above) is consumed on
+    // connect — mirrors canvas-events.spec.ts's anchor round-trip test.
+    await page.reload();
+    await expect(page.locator('[data-testid="anchor-first-view"]')).toBeVisible({
+      timeout: 15000,
+    });
+    await expect
+      .poll(() => page.evaluate(() => location.hash), { timeout: 10000 })
+      .toBe(`#/node/${encodeURIComponent(targetNodeId as string)}`);
+    await expect(page.locator('[data-testid="anchor-first-view"]')).toHaveAttribute(
+      'data-anchor-id',
+      targetNodeId as string,
+    );
+  });
+
+  test('degrades gracefully with a visible hint when /chat-intent is absent (older CLI)', async ({
+    page,
+  }) => {
+    const errors: string[] = [];
+    page.on('console', msg => {
+      if (msg.type() === 'error' && !msg.text().includes('@griffel')) errors.push(msg.text());
+    });
+    await page.route('**/chat-intent', route => route.fulfill({ status: 404, body: 'not found' }));
+
+    await bootCopilotCanvas(page, 'readme');
+    const anchorView = page.locator('[data-testid="anchor-first-view"]');
+    await expect(anchorView).toBeVisible({ timeout: 15000 });
+
+    const affectedButton = anchorView.locator('[data-testid="node-intent-affected"]').first();
+    await affectedButton.click();
+    await expect(affectedButton).toHaveAttribute('data-intent-state', 'unavailable', {
+      timeout: 10000,
+    });
+    await expect(
+      anchorView.locator('[data-testid="node-intent-unavailable-hint"]').first(),
+    ).toBeVisible();
+
+    const appErrors = errors.filter(
+      e => !e.includes('403') && !e.includes('rate limit') && !e.includes('Failed to load resource'),
+    );
+    expect(appErrors).toHaveLength(0);
+  });
+
+  test('no node-intent click ever issues a direct mutating /affordance/:name request', async ({
+    page,
+  }) => {
+    let affordanceHits = 0;
+    await page.route('**/affordance/**', route => {
+      affordanceHits += 1;
+      return route.fulfill({ status: 200, contentType: 'application/json', body: '{"ok":true}' });
+    });
+    await page.route('**/chat-intent', route =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: '{"ok":true}' }),
+    );
+
+    await bootCopilotCanvas(page, 'readme');
+    const anchorView = page.locator('[data-testid="anchor-first-view"]');
+    await expect(anchorView).toBeVisible({ timeout: 15000 });
+
+    // Click every default intent action on the anchor — none of them, read-
+    // only-sounding ("What derives from this?") or explicitly mutating
+    // ("Pin as anchor"), may ever hit /affordance/:name directly.
+    for (const id of ['pin', 'derives', 'affected']) {
+      const button = anchorView.locator(`[data-testid="node-intent-${id}"]`).first();
+      await button.click();
+      await expect(button).toHaveAttribute('data-intent-state', 'ok', { timeout: 10000 });
+    }
+
+    expect(affordanceHits).toBe(0);
+  });
+});

--- a/src/canvas/EmbeddableApp.tsx
+++ b/src/canvas/EmbeddableApp.tsx
@@ -45,6 +45,7 @@ import {
   INITIAL_VIEW_ACTION_STATE,
   type ViewActionState,
 } from './viewActionState';
+import { resolveChatIntentUrl } from './chatIntent';
 import type { CanvasBootConfig } from './bootConfig';
 import '../styles/visuals.css';
 import '../styles/reading.css';
@@ -77,6 +78,7 @@ function CanvasExplorer({ boot }: { boot: CanvasBootConfig }): ReactNode {
   }
 
   const eventsUrl = resolveEventsUrl(boot);
+  const chatIntentUrl = resolveChatIntentUrl(boot);
   useCanvasEvents(eventsUrl, {
     onAnchor: nodeId => {
       window.location.hash = `#/node/${encodeURIComponent(nodeId)}`;
@@ -135,6 +137,7 @@ function CanvasExplorer({ boot }: { boot: CanvasBootConfig }): ReactNode {
                 trace: viewAction.trace,
                 filterNodeIds,
               },
+              chatIntentUrl,
             }) as ReactNode}
           </HashRouter>
         )}

--- a/src/canvas/__tests__/chatIntent.test.ts
+++ b/src/canvas/__tests__/chatIntent.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_NODE_INTENT_ACTIONS,
+  postChatIntent,
+  resolveChatIntentUrl,
+  type FetchLike,
+} from '../chatIntent';
+
+describe('resolveChatIntentUrl', () => {
+  it('defaults to a same-origin-relative /chat-intent', () => {
+    expect(resolveChatIntentUrl({})).toBe('/chat-intent');
+  });
+
+  it('uses the searchServiceUrl origin when present and parseable', () => {
+    expect(resolveChatIntentUrl({ searchServiceUrl: 'http://localhost:5555/search' })).toBe(
+      'http://localhost:5555/chat-intent',
+    );
+  });
+
+  it('falls back to the relative default for a malformed searchServiceUrl', () => {
+    expect(resolveChatIntentUrl({ searchServiceUrl: 'not a url' })).toBe('/chat-intent');
+  });
+});
+
+describe('DEFAULT_NODE_INTENT_ACTIONS', () => {
+  it("names the three intents from #410's issue body", () => {
+    const ids = DEFAULT_NODE_INTENT_ACTIONS.map(a => a.id);
+    expect(ids).toEqual(['pin', 'derives', 'affected']);
+  });
+
+  it('is an open catalog (a plain array), not a fixed enum', () => {
+    // Callers can spread/extend it — no readonly-tuple-of-exactly-3 trap.
+    const extended = [...DEFAULT_NODE_INTENT_ACTIONS, { id: 'custom', label: 'Custom' }];
+    expect(extended).toHaveLength(4);
+  });
+});
+
+describe('postChatIntent', () => {
+  const request = { intent: 'pin', nodeId: 'readme' };
+
+  it('resolves ok on a 2xx response and POSTs the exact intent body', async () => {
+    const fetchImpl = vi.fn<FetchLike>().mockResolvedValue({ ok: true, status: 200 });
+    const outcome = await postChatIntent('/chat-intent', request, fetchImpl);
+    expect(outcome).toEqual({ status: 'ok' });
+    expect(fetchImpl).toHaveBeenCalledWith('/chat-intent', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(request),
+    });
+  });
+
+  it('resolves unavailable on a 404 (older CLI without #195)', async () => {
+    const fetchImpl = vi.fn<FetchLike>().mockResolvedValue({ ok: false, status: 404 });
+    const outcome = await postChatIntent('/chat-intent', request, fetchImpl);
+    expect(outcome).toEqual({ status: 'unavailable' });
+  });
+
+  it('resolves unavailable on a network rejection, never throws', async () => {
+    const fetchImpl = vi.fn<FetchLike>().mockRejectedValue(new TypeError('Failed to fetch'));
+    await expect(postChatIntent('/chat-intent', request, fetchImpl)).resolves.toEqual({
+      status: 'unavailable',
+    });
+  });
+
+  it('forwards an optional prompt when supplied', async () => {
+    const fetchImpl = vi.fn<FetchLike>().mockResolvedValue({ ok: true, status: 200 });
+    const withPrompt = { intent: 'derives', nodeId: 'readme', prompt: 'What derives from this?' };
+    await postChatIntent('/chat-intent', withPrompt, fetchImpl);
+    expect(fetchImpl).toHaveBeenCalledWith(
+      '/chat-intent',
+      expect.objectContaining({ body: JSON.stringify(withPrompt) }),
+    );
+  });
+});

--- a/src/canvas/chatIntent.ts
+++ b/src/canvas/chatIntent.ts
@@ -1,0 +1,102 @@
+/**
+ * Bidirectional click → chat: the `/chat-intent` client (#410, epic #407).
+ *
+ * The reverse direction of #409 (agent → panel). A click in the canvas becomes
+ * the next chat turn: the client POSTs a small intent envelope to a loopback
+ * endpoint the CLI exposes (`anokye-labs/kbexplorer-cli#195`, "Click→chat seam
+ * (Lane B)" — open as of this PR, 0 comments), which translates it into an
+ * agent chat turn / tool call. This module owns ONLY the client call + the
+ * intent catalog; it never talks to `/affordance/:name` or any other mutating
+ * endpoint — that is the whole point of the consent-routing rule in #410's
+ * issue body ("mutating intents MUST route through the agent chat turn, never
+ * a direct mutating POST from the iframe"). Because this is the ONLY function
+ * in this module that performs a network write, and it only ever targets
+ * `/chat-intent`, there is no code path here that could issue a direct
+ * mutating `/affordance` POST.
+ *
+ * `#195` has not landed yet (verified via `gh issue view` before writing this),
+ * so `postChatIntent` is deliberately defensive: any non-2xx response, a
+ * network failure, or a malformed response body all resolve to `{ status:
+ * 'unavailable' }` rather than throwing — the acceptance criterion "graceful
+ * no-op + a visible hint when the endpoint is absent (older CLI)" from #410.
+ */
+import type { CanvasBootConfig } from './bootConfig';
+
+/** A single clickable intent — deliberately an open catalog, not a fixed enum. */
+export interface NodeIntentAction {
+  /** Stable id sent as `intent` in the request body (e.g. `'pin'`). */
+  id: string;
+  /** Human-readable button label. */
+  label: string;
+  /** Optional free-text prompt hint forwarded to the agent alongside the id. */
+  prompt?: string;
+}
+
+/**
+ * The three intents named in #410's issue body. Extensible, not exhaustive —
+ * callers may pass their own {@link NodeIntentAction} list; this default is a
+ * convenience, not a hardcoded ceiling.
+ */
+export const DEFAULT_NODE_INTENT_ACTIONS: readonly NodeIntentAction[] = [
+  { id: 'pin', label: 'Pin as anchor' },
+  { id: 'derives', label: 'What derives from this?', prompt: 'What derives from this node?' },
+  { id: 'affected', label: 'Show affected', prompt: 'What would be affected by a change here?' },
+];
+
+/** Request body for `POST /chat-intent`, per #410's proposed contract. */
+export interface ChatIntentRequest {
+  intent: string;
+  nodeId: string;
+  prompt?: string;
+}
+
+export type ChatIntentOutcome =
+  | { status: 'ok' }
+  | { status: 'unavailable' };
+
+/**
+ * Derive the `/chat-intent` URL from the boot config — same-origin-relative
+ * reasoning as `useCanvasEvents.ts`'s `resolveEventsUrl` (the loopback server
+ * serves the canvas entry, its assets, and its API endpoints from one origin).
+ */
+export function resolveChatIntentUrl(
+  boot: Pick<CanvasBootConfig, 'searchServiceUrl'>,
+): string {
+  if (boot.searchServiceUrl) {
+    try {
+      return `${new URL(boot.searchServiceUrl).origin}/chat-intent`;
+    } catch {
+      // Malformed searchServiceUrl — fall through to the relative default.
+    }
+  }
+  return '/chat-intent';
+}
+
+/** The minimal `fetch`-like surface this module depends on (for tests). */
+export type FetchLike = (
+  url: string,
+  init: { method: string; headers: Record<string, string>; body: string },
+) => Promise<{ ok: boolean; status: number }>;
+
+/**
+ * POST an intent to `/chat-intent`. Never throws: a network failure, a
+ * non-2xx response (including a 404 from an older CLI that predates #195), or
+ * any other rejection all resolve to `{ status: 'unavailable' }` so the caller
+ * can show a graceful hint instead of an app-level error.
+ */
+export async function postChatIntent(
+  url: string,
+  request: ChatIntentRequest,
+  fetchImpl: FetchLike = fetch,
+): Promise<ChatIntentOutcome> {
+  try {
+    const res = await fetchImpl(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(request),
+    });
+    return res.ok ? { status: 'ok' } : { status: 'unavailable' };
+  } catch {
+    return { status: 'unavailable' };
+  }
+}

--- a/src/canvas/chatIntent.ts
+++ b/src/canvas/chatIntent.ts
@@ -15,10 +15,12 @@
  * mutating `/affordance` POST.
  *
  * `#195` has not landed yet (verified via `gh issue view` before writing this),
- * so `postChatIntent` is deliberately defensive: any non-2xx response, a
- * network failure, or a malformed response body all resolve to `{ status:
- * 'unavailable' }` rather than throwing — the acceptance criterion "graceful
- * no-op + a visible hint when the endpoint is absent (older CLI)" from #410.
+ * so `postChatIntent` is deliberately defensive: any non-2xx response or a
+ * network failure resolves to `{ status: 'unavailable' }` rather than throwing
+ * — the acceptance criterion "graceful no-op + a visible hint when the endpoint
+ * is absent (older CLI)" from #410. A 2xx is treated as success on its status
+ * code alone; the response body is intentionally never parsed (the CLI's status
+ * is the whole contract), so there is no body-shape this client can choke on.
  */
 import type { CanvasBootConfig } from './bootConfig';
 
@@ -87,7 +89,14 @@ export type FetchLike = (
 export async function postChatIntent(
   url: string,
   request: ChatIntentRequest,
-  fetchImpl: FetchLike = fetch,
+  // Wrap rather than pass `fetch` directly so the global is resolved when the
+  // call is made (inside the try below), not when this default binds. In a
+  // runtime with no `fetch` binding at all a bare `fetch` default would throw a
+  // ReferenceError before the try — the one way this function could break its
+  // "never throws" contract. Through the wrapper that reference happens inside
+  // the try instead, so a missing `fetch` degrades to `unavailable` like any
+  // other failure.
+  fetchImpl: FetchLike = (fetchUrl, init) => fetch(fetchUrl, init),
 ): Promise<ChatIntentOutcome> {
   try {
     const res = await fetchImpl(url, {

--- a/src/representation/targets/copilot-home/AnchorFirstView.tsx
+++ b/src/representation/targets/copilot-home/AnchorFirstView.tsx
@@ -50,6 +50,8 @@ import { resolveViewer } from '../../../views/viewers';
 import { HomePage } from '../../../views/HomePage';
 import { nodeUrn } from '../urn';
 import { expandAnchoredNeighborhood, type AnchoredNeighbor } from '../llm-context';
+import { resolveChatIntentUrl } from '../../../canvas/chatIntent';
+import { NodeIntentBar } from './NodeIntentBar';
 
 /** Default number of top-ranked neighbors rendered inline (rest → chips). */
 export const DEFAULT_MAX_EXPANDED = 6;
@@ -244,12 +246,14 @@ function ExpandedNeighbor({
   neighbor,
   focused = false,
   onTrace = false,
+  chatIntentUrl,
 }: {
   neighbor: AnchoredNeighbor;
   /** This neighbor is the current `expand`'s `focus` node (#409). */
   focused?: boolean;
   /** This neighbor sits on the current `trace` path (#409). */
   onTrace?: boolean;
+  chatIntentUrl: string;
 }) {
   const styles = useStyles();
   const { node, edge } = neighbor;
@@ -279,6 +283,7 @@ function ExpandedNeighbor({
         </div>
       </a>
       {createElement(resolveViewer(node), { node })}
+      <NodeIntentBar nodeId={node.id} chatIntentUrl={chatIntentUrl} />
     </Card>
   );
 }
@@ -321,6 +326,13 @@ export interface AnchorFirstViewProps {
   maxExpanded?: number;
   /** Accumulated agent `expand`/`trace`/`filter` view-actions (#409, cli#214). Optional/additive. */
   viewAction?: AnchorViewAction;
+  /**
+   * Resolved `/chat-intent` URL for #410's per-node action bar. Defaults to
+   * the same-origin-relative `/chat-intent` (via `resolveChatIntentUrl({})`)
+   * when the caller doesn't supply one — e.g. ad-hoc test rendering that
+   * doesn't thread a boot config through.
+   */
+  chatIntentUrl?: string;
 }
 
 /**
@@ -333,8 +345,10 @@ export function AnchorFirstView({
   anchorId,
   maxExpanded = DEFAULT_MAX_EXPANDED,
   viewAction,
+  chatIntentUrl,
 }: AnchorFirstViewProps) {
   const styles = useStyles();
+  const resolvedChatIntentUrl = chatIntentUrl ?? resolveChatIntentUrl({});
 
   // Memoize the anchor lookup + shared greedy partition (llm-context) so theme
   // changes / parent re-renders don't re-run the O(n) walk. Unit cost + a count
@@ -469,6 +483,8 @@ export function AnchorFirstView({
         </Caption1>
       )}
 
+      <NodeIntentBar nodeId={anchor.id} chatIntentUrl={resolvedChatIntentUrl} />
+
       {visibleExpanded.length > 0 && (
         <>
           <Divider />
@@ -480,6 +496,7 @@ export function AnchorFirstView({
                 neighbor={neighbor}
                 focused={viewAction?.focusNodeId === neighbor.node.id}
                 onTrace={traceIds.has(neighbor.node.id)}
+                chatIntentUrl={resolvedChatIntentUrl}
               />
             ))}
           </div>

--- a/src/representation/targets/copilot-home/NodeIntentBar.tsx
+++ b/src/representation/targets/copilot-home/NodeIntentBar.tsx
@@ -1,0 +1,110 @@
+/**
+ * Per-node intent action bar (#410, epic #407).
+ *
+ * An extensible row of buttons for a single node — "Pin as anchor", "What
+ * derives from this?", "Show affected" by default, but callers may pass any
+ * {@link NodeIntentAction} list (never hardcoded to exactly three). Each click
+ * POSTs to `/chat-intent` via {@link postChatIntent} — the ONLY network call
+ * this component makes — so there is no code path here that could issue a
+ * direct mutating `/affordance/:name` request: every intent, read-only or
+ * mutating, becomes a chat turn the agent decides how to act on (#410's
+ * consent-routing rule).
+ *
+ * States are per-action (`idle` → `pending` → `ok` | `unavailable`) so one
+ * slow/failed intent doesn't block the others. `unavailable` (network failure
+ * or a non-2xx, e.g. a 404 from a CLI that predates `kbexplorer-cli#195`)
+ * surfaces a small persistent hint instead of throwing or silently no-oping.
+ */
+import { useState } from 'react';
+import { Button, Caption1, makeStyles, tokens } from '@fluentui/react-components';
+import {
+  DEFAULT_NODE_INTENT_ACTIONS,
+  postChatIntent,
+  type ChatIntentRequest,
+  type FetchLike,
+  type NodeIntentAction,
+} from '../../../canvas/chatIntent';
+
+type IntentState = 'idle' | 'pending' | 'ok' | 'unavailable';
+
+const useStyles = makeStyles({
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: tokens.spacingVerticalXXS,
+  },
+  row: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: tokens.spacingHorizontalXS,
+  },
+  hint: {
+    color: tokens.colorNeutralForeground3,
+  },
+});
+
+export interface NodeIntentBarProps {
+  /** The node these actions target (`ChatIntentRequest.nodeId`). */
+  nodeId: string;
+  /** Resolved `/chat-intent` URL (see `resolveChatIntentUrl`). */
+  chatIntentUrl: string;
+  /** Open, extensible action catalog — defaults to the three from #410. */
+  actions?: readonly NodeIntentAction[];
+  /** Injectable for tests; defaults to the global `fetch`. */
+  fetchImpl?: FetchLike;
+}
+
+/** Renders nothing when there are no actions — an empty bar is a no-op. */
+export function NodeIntentBar({
+  nodeId,
+  chatIntentUrl,
+  actions = DEFAULT_NODE_INTENT_ACTIONS,
+  fetchImpl,
+}: NodeIntentBarProps) {
+  const styles = useStyles();
+  const [states, setStates] = useState<Record<string, IntentState>>({});
+
+  if (actions.length === 0) {
+    return null;
+  }
+
+  const handleClick = (action: NodeIntentAction) => {
+    setStates(prev => ({ ...prev, [action.id]: 'pending' }));
+    const request: ChatIntentRequest = { intent: action.id, nodeId, prompt: action.prompt };
+    void postChatIntent(chatIntentUrl, request, fetchImpl).then(outcome => {
+      setStates(prev => ({ ...prev, [action.id]: outcome.status }));
+    });
+  };
+
+  const anyUnavailable = Object.values(states).some(s => s === 'unavailable');
+
+  return (
+    <div className={styles.root} data-testid="node-intent-bar" data-node-id={nodeId}>
+      <div className={styles.row}>
+        {actions.map(action => {
+          const state = states[action.id] ?? 'idle';
+          return (
+            <Button
+              key={action.id}
+              appearance="outline"
+              size="small"
+              disabled={state === 'pending'}
+              onClick={() => handleClick(action)}
+              data-testid={`node-intent-${action.id}`}
+              data-node-id={nodeId}
+              data-intent-state={state}
+            >
+              {state === 'pending' ? 'Sending…' : action.label}
+            </Button>
+          );
+        })}
+      </div>
+      {anyUnavailable && (
+        <Caption1 className={styles.hint} data-testid="node-intent-unavailable-hint">
+          Chat isn&apos;t connected — this canvas isn&apos;t running behind the Copilot CLI
+          loopback yet.
+        </Caption1>
+      )}
+    </div>
+  );
+}

--- a/src/representation/targets/copilot-home/NodeIntentBar.tsx
+++ b/src/representation/targets/copilot-home/NodeIntentBar.tsx
@@ -15,7 +15,7 @@
  * or a non-2xx, e.g. a 404 from a CLI that predates `kbexplorer-cli#195`)
  * surfaces a small persistent hint instead of throwing or silently no-oping.
  */
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Button, Caption1, makeStyles, tokens } from '@fluentui/react-components';
 import {
   DEFAULT_NODE_INTENT_ACTIONS,
@@ -64,14 +64,32 @@ export function NodeIntentBar({
   const styles = useStyles();
   const [states, setStates] = useState<Record<string, IntentState>>({});
 
+  // This bar is reused in place for the anchor node across `/node/:id`
+  // navigations (React Router re-renders the same instance with a new
+  // `nodeId`, it does not remount it). Reset the per-action outcomes whenever
+  // the target node changes so a previous node's `ok`/`unavailable` badge can
+  // never persist onto a different node's bar. `nodeIdRef` additionally lets a
+  // resolving `postChatIntent` promise detect that the node changed while it
+  // was in flight and drop its now-stale outcome instead of painting it onto
+  // the new node.
+  const nodeIdRef = useRef(nodeId);
+  useEffect(() => {
+    nodeIdRef.current = nodeId;
+    setStates({});
+  }, [nodeId]);
+
   if (actions.length === 0) {
     return null;
   }
 
   const handleClick = (action: NodeIntentAction) => {
+    const issuedFor = nodeId;
     setStates(prev => ({ ...prev, [action.id]: 'pending' }));
     const request: ChatIntentRequest = { intent: action.id, nodeId, prompt: action.prompt };
     void postChatIntent(chatIntentUrl, request, fetchImpl).then(outcome => {
+      if (nodeIdRef.current !== issuedFor) {
+        return;
+      }
       setStates(prev => ({ ...prev, [action.id]: outcome.status }));
     });
   };

--- a/src/representation/targets/copilot-home/__tests__/NodeIntentBar.test.ts
+++ b/src/representation/targets/copilot-home/__tests__/NodeIntentBar.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { NodeIntentBar } from '../NodeIntentBar';
+
+/**
+ * NodeIntentBar (#410) — structural/DOM-contract assertions only. Static
+ * markup can't exercise clicks/state transitions (no jsdom in this repo's
+ * vitest setup, consistent with CanvasShell.test.ts); the interactive
+ * pending → ok/unavailable behavior and the "no direct /affordance POST" and
+ * "hint on unavailable" acceptance criteria are covered by
+ * e2e/node-intent-bar.spec.ts in a real browser.
+ */
+describe('NodeIntentBar (#410)', () => {
+  it('renders exactly the three default intents from the #410 issue body', () => {
+    const html = renderToStaticMarkup(
+      createElement(NodeIntentBar, { nodeId: 'readme', chatIntentUrl: '/chat-intent' }),
+    );
+    expect(html).toContain('data-testid="node-intent-bar"');
+    expect(html).toContain('data-node-id="readme"');
+    expect(html).toContain('data-testid="node-intent-pin"');
+    expect(html).toContain('data-testid="node-intent-derives"');
+    expect(html).toContain('data-testid="node-intent-affected"');
+    expect(html).toContain('Pin as anchor');
+    expect(html).toContain('What derives from this?');
+    expect(html).toContain('Show affected');
+  });
+
+  it('renders nothing for an empty action list (an empty bar is a no-op)', () => {
+    const html = renderToStaticMarkup(
+      createElement(NodeIntentBar, { nodeId: 'readme', chatIntentUrl: '/chat-intent', actions: [] }),
+    );
+    expect(html).toBe('');
+  });
+
+  it('honors an extensible custom action list, not a hardcoded set of three', () => {
+    const html = renderToStaticMarkup(
+      createElement(NodeIntentBar, {
+        nodeId: 'readme',
+        chatIntentUrl: '/chat-intent',
+        actions: [{ id: 'custom', label: 'Custom action' }],
+      }),
+    );
+    expect(html).toContain('data-testid="node-intent-custom"');
+    expect(html).toContain('Custom action');
+    expect(html).not.toContain('Pin as anchor');
+  });
+
+  it('does not render the unavailable hint before any click has happened', () => {
+    const html = renderToStaticMarkup(
+      createElement(NodeIntentBar, { nodeId: 'readme', chatIntentUrl: '/chat-intent' }),
+    );
+    expect(html).not.toContain('node-intent-unavailable-hint');
+  });
+});

--- a/src/representation/targets/copilot.tsx
+++ b/src/representation/targets/copilot.tsx
@@ -53,6 +53,12 @@ export interface CopilotRenderOptions extends SpaRenderOptions {
    * keeps working unchanged with no view-action applied.
    */
   viewAction?: AnchorViewAction;
+  /**
+   * Resolved `/chat-intent` URL (#410, `resolveChatIntentUrl` in
+   * `canvas/chatIntent.ts`) — threaded down to {@link AnchorFirstView}'s
+   * per-node intent action bar.
+   */
+  chatIntentUrl?: string;
 }
 
 /** Route element: anchor-first home for the `:id` in the hash path. */
@@ -60,14 +66,22 @@ function AnchorRoute({
   graph,
   config,
   viewAction,
+  chatIntentUrl,
 }: {
   graph: KBGraph;
   config: KBConfig;
   viewAction?: AnchorViewAction;
+  chatIntentUrl?: string;
 }) {
   const { id } = useParams<{ id: string }>();
   return (
-    <AnchorFirstView graph={graph} config={config} anchorId={id ?? ''} viewAction={viewAction} />
+    <AnchorFirstView
+      graph={graph}
+      config={config}
+      anchorId={id ?? ''}
+      viewAction={viewAction}
+      chatIntentUrl={chatIntentUrl}
+    />
   );
 }
 
@@ -90,7 +104,7 @@ export function renderCopilotSurface(
   graph: KBGraph,
   options: CopilotRenderOptions,
 ): ReactNode {
-  const { config, landingPath, anchorNodeId, viewAction } = options;
+  const { config, landingPath, anchorNodeId, viewAction, chatIntentUrl } = options;
   const initialPath = anchorNodeId
     ? `/node/${encodeURIComponent(anchorNodeId)}`
     : landingPath;
@@ -101,7 +115,14 @@ export function renderCopilotSurface(
         <Route path="/" element={<Navigate to={initialPath} replace />} />
         <Route
           path="/node/:id"
-          element={<AnchorRoute graph={graph} config={config} viewAction={viewAction} />}
+          element={
+            <AnchorRoute
+              graph={graph}
+              config={config}
+              viewAction={viewAction}
+              chatIntentUrl={chatIntentUrl}
+            />
+          }
         />
         <Route path="/constellation" element={<ConstellationView graph={graph} config={config} />} />
         <Route path="/overview" element={<OverviewView graph={graph} config={config} />} />


### PR DESCRIPTION
## Summary

Closes #410 — bidirectional click→chat: a click in the canvas becomes the next chat turn via `POST /chat-intent`.

**Stacked on #409** (base branch `hoopsomuah-agent-actions-409`, not `main`): #410's acceptance criteria require demonstrating the round trip through #409's `useCanvasEvents`/`/events` consumer, which isn't on `main` yet. GitHub will auto-retarget this PR to `main` once #458 merges.

## What's wired + tested (this repo's scope)

- **`src/canvas/chatIntent.ts`** — `resolveChatIntentUrl` (mirrors #409's `resolveEventsUrl` origin-derivation) + `postChatIntent`, a defensive client: any non-2xx response or network failure resolves to `{ status: 'unavailable' }`, never throws. This module's **only** network call targets `/chat-intent` — there is no code path here that could issue a direct mutating `/affordance/:name` request, satisfying the consent-routing rule ("mutating intents never issue a direct mutating `/affordance` POST from the iframe") **by construction**, and asserted by e2e test #4 below.
- **`src/representation/targets/copilot-home/NodeIntentBar.tsx`** — an extensible action bar (`DEFAULT_NODE_INTENT_ACTIONS`: `pin` / `derives` / `affected` — a plain array, not a hardcoded ceiling of exactly three) with per-action `idle → pending → ok/unavailable` state and a visible hint when unavailable.
- Wired into `AnchorFirstView.tsx`: one bar under the anchor's own viewer, one per expanded neighbor card. `chatIntentUrl` threaded through `copilot.tsx`'s `CopilotRenderOptions`/`AnchorRoute`, computed in `EmbeddableApp.tsx` alongside #409's `eventsUrl`.
- **Unit tests**: `chatIntent.test.ts` (9 cases — URL resolution incl. malformed `searchServiceUrl`, ok/404/network-rejection outcomes, exact POST body incl. optional prompt) and `NodeIntentBar.test.ts` (4 static-markup structural cases via `renderToStaticMarkup`, matching `CanvasShell.test.ts`'s no-jsdom convention).
- **`e2e/node-intent-bar.spec.ts`** (4 cases, chromium + edge, all green):
  1. Clicking "What derives from this?" POSTs the exact intent body and flips `pending → ok`.
  2. "Pin as anchor" on a neighbor posts the intent, then — via a mocked `/events` `anchor` event reusing #409's already-proven consumer — the panel actually re-anchors on that node.
  3. `/chat-intent` returning 404 (older CLI) shows the unavailable hint, zero console errors.
  4. Clicking every default action never hits `/affordance/:name`.

## Honest scope note

`anokye-labs/kbexplorer-cli#195` ("click→chat seam / Lane B") is still **open, unimplemented** as of this PR — I checked before writing this. "A real chat turn" per the issue's acceptance criteria can't be verified from this repo alone; there's no live CLI/agent in this test environment. What's proven here is the full template-side contract: the click, the exact POST body, graceful degradation when the endpoint is absent, and the round trip back through #409's SSE consumer once an agent (simulated via mocked `/events`) acts. Once the CLI session lands #195 with a concrete `/chat-intent` request/response shape, this client may need a small follow-up if the shape differs from the proposed `{ intent, nodeId, prompt? } → { ok: true }` contract in #410's issue body.

## Verification

- `npm run build` (default) ✅
- `npm run build:local` (e2e's manifest-mode build) ✅
- `npm run lint` ✅ 0 errors, 3 pre-existing warnings (unrelated)
- `npm run test` ✅ 933/933 (920 baseline + 13 new)
- Full e2e suite (chromium + edge) ✅ 166/166, including the 4 new tests

## Out of scope (per #410's issue body)

- Declaring `actions[]` (#409, done).
- The CLI SDK message seam (`kbexplorer-cli#195`) — not yet implemented upstream.
- Rendering the affordance catalog (#411 — blocked on `#456`, not attempted in this PR per direct instruction from the epic coordinator).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anokye-labs/kbexplorer-template/pull/459" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->