### PR TITLE
Fix NodeIntentBar reset: lint-clean, race-free redesign (follow-up to #410)

### DIFF
--- a/src/representation/targets/copilot-home/NodeIntentBar.tsx
+++ b/src/representation/targets/copilot-home/NodeIntentBar.tsx
@@ -15,7 +15,7 @@
  * or a non-2xx, e.g. a 404 from a CLI that predates `kbexplorer-cli#195`)
  * surfaces a small persistent hint instead of throwing or silently no-oping.
  */
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 import { Button, Caption1, makeStyles, tokens } from '@fluentui/react-components';
 import {
   DEFAULT_NODE_INTENT_ACTIONS,
@@ -26,6 +26,13 @@ import {
 } from '../../../canvas/chatIntent';
 
 type IntentState = 'idle' | 'pending' | 'ok' | 'unavailable';
+
+/** A per-action entry, tagged with the node id the request was issued for. */
+interface IntentEntry {
+  status: IntentState;
+  /** The `nodeId` this entry's request targeted — see the staleness guard below. */
+  nodeId: string;
+}
 
 const useStyles = makeStyles({
   root: {
@@ -62,21 +69,23 @@ export function NodeIntentBar({
   fetchImpl,
 }: NodeIntentBarProps) {
   const styles = useStyles();
-  const [states, setStates] = useState<Record<string, IntentState>>({});
+  const [states, setStates] = useState<Record<string, IntentEntry>>({});
 
   // This bar is reused in place for the anchor node across `/node/:id`
   // navigations (React Router re-renders the same instance with a new
   // `nodeId`, it does not remount it). Reset the per-action outcomes whenever
   // the target node changes so a previous node's `ok`/`unavailable` badge can
-  // never persist onto a different node's bar. `nodeIdRef` additionally lets a
-  // resolving `postChatIntent` promise detect that the node changed while it
-  // was in flight and drop its now-stale outcome instead of painting it onto
-  // the new node.
-  const nodeIdRef = useRef(nodeId);
-  useEffect(() => {
-    nodeIdRef.current = nodeId;
+  // never persist onto a different node's bar. Adjusted DURING RENDER (React's
+  // "adjusting state when a prop changes" recipe, matching the
+  // `prevLoadedGraph` pattern in `EmbeddableApp.tsx`) rather than in a
+  // `useEffect`, to avoid the extra commit + re-render an effect-based
+  // `setState` would cause (and the `react-hooks/set-state-in-effect` lint it
+  // trips).
+  const [prevNodeId, setPrevNodeId] = useState(nodeId);
+  if (nodeId !== prevNodeId) {
+    setPrevNodeId(nodeId);
     setStates({});
-  }, [nodeId]);
+  }
 
   if (actions.length === 0) {
     return null;
@@ -84,23 +93,30 @@ export function NodeIntentBar({
 
   const handleClick = (action: NodeIntentAction) => {
     const issuedFor = nodeId;
-    setStates(prev => ({ ...prev, [action.id]: 'pending' }));
+    setStates(prev => ({ ...prev, [action.id]: { status: 'pending', nodeId: issuedFor } }));
     const request: ChatIntentRequest = { intent: action.id, nodeId, prompt: action.prompt };
     void postChatIntent(chatIntentUrl, request, fetchImpl).then(outcome => {
-      if (nodeIdRef.current !== issuedFor) {
-        return;
-      }
-      setStates(prev => ({ ...prev, [action.id]: outcome.status }));
+      // Drop the outcome if this action's entry no longer belongs to the node
+      // the request was issued for — e.g. a `nodeId` prop change (the render-
+      // time reset above) cleared it, or a NEWER click for the same action id
+      // already superseded it. Reading `prev` — the functional updater's
+      // guaranteed-current state — makes this check race-free without a ref
+      // or an effect (`prev`, unlike a closed-over prop, is never stale).
+      setStates(prev =>
+        prev[action.id]?.nodeId === issuedFor
+          ? { ...prev, [action.id]: { status: outcome.status, nodeId: issuedFor } }
+          : prev,
+      );
     });
   };
 
-  const anyUnavailable = Object.values(states).some(s => s === 'unavailable');
+  const anyUnavailable = Object.values(states).some(entry => entry.status === 'unavailable');
 
   return (
     <div className={styles.root} data-testid="node-intent-bar" data-node-id={nodeId}>
       <div className={styles.row}>
         {actions.map(action => {
-          const state = states[action.id] ?? 'idle';
+          const state = states[action.id]?.status ?? 'idle';
           return (
             <Button
               key={action.id}


### PR DESCRIPTION
## Follow-up to #410 / #459

`kbexplorer-template#459` merged to `main` before a lint issue in its review-thread fix could be addressed on that branch (the branch was deleted at merge). This PR fixes it as a follow-up against `main`.

### The bug this replaces

The version merged in #459 fixed `NodeIntentBar`'s stale per-node state (Devin thread) by resetting state inside a `useEffect`:

```tsx
useEffect(() => {
  nodeIdRef.current = nodeId;
  setStates({});
}, [nodeId]);
```

This is **functionally correct** (verified: e2e regression test passes) but trips this repo's `react-hooks/set-state-in-effect` ESLint rule (verified directly: `npx eslint src/representation/targets/copilot-home/NodeIntentBar.tsx` → 1 error). Note: **lint is not part of CI in this repo** (no lint step in any workflow), which is why the PR merged green despite the error — `npx eslint .` only surfaces it locally.

### The fix

Moved the reset to render time (matching the `EmbeddableApp.tsx` `prevLoadedGraph` idiom already used elsewhere in this codebase), which resolves the lint error. That in turn ruled out the ref-based staleness guard (`nodeIdRef.current !== issuedFor`), because writing a ref's `.current` during render trips a *second* lint rule (`react-hooks/refs`, "Cannot access refs during render"). Splitting the ref update into its own effect avoids both rules but reopens a real (if narrow) race: the ref-update effect commits *after* paint, so a stale async response landing in the gap between the render-time reset and the effect flush could pass the staleness check and repaint an already-reset (idle) entry with no further correction.

Final design needs no ref or effect for the guard at all: each per-action state entry is tagged with the `nodeId` it was issued for (`Record<string, {status, nodeId}>`). The staleness check moves into the `postChatIntent(...).then()` callback's own **functional** `setStates` updater, comparing `prev[action.id]?.nodeId` against the `nodeId` captured at click time. React guarantees `prev` is never stale in a functional updater, so this is provably race-free without a ref. The render-time `nodeId` change still does `setStates({})` to clear all entries, which naturally invalidates any in-flight request for the old node (`prev[action.id]` becomes `undefined` post-reset, so the `nodeId` comparison always fails).

### Verification

- `npx tsc -b` — clean
- `npx eslint .` — **0 errors** (3 pre-existing warnings only, unrelated to this file)
- `npx vitest run` — 1049/1049 unit tests pass
- `VITE_KB_LOCAL=true npx vite build` + `npx playwright test --project=chromium` — **93/93 e2e pass**, including the existing `e2e/node-intent-bar.spec.ts` "per-node intent state resets when the panel re-anchors" regression test (unmodified, still on `main` from #459)
- **Adversarial check**: `git stash`'d this fix to temporarily restore the merged (buggy-lint) version, re-ran `npx eslint` directly on it to confirm the error is real (it is), then restored the fix

Refs #410. No functional/behavioral change from what shipped in #459 — same states, same UI, same test coverage passes — this only replaces the internal reset mechanism to be lint-clean and remove the narrow ref/effect race window.