### PR TITLE
Warn + verify graceful degrade for unknown expand/trace node ids (#409 precision fix)

### DIFF
--- a/src/representation/targets/copilot-home/AnchorFirstView.tsx
+++ b/src/representation/targets/copilot-home/AnchorFirstView.tsx
@@ -21,6 +21,15 @@
  * constrains which neighbors render. All are additive/no-op when absent, so
  * every existing caller (including tests) is unaffected.
  *
+ * ID RESOLUTION: `expand`'s `nodes` and `trace`'s `path` are bare node-id
+ * strings from the server (`cli#214`/`cli#216`) — this view is the client-side
+ * seam that resolves each one against the SAME node map `buildGraph` produced
+ * from the loaded manifest (`graph.nodes`). An id absent from that map (a
+ * real, tracked, non-blocking server<->client id-space gap, `kbexplorer-cli#216`)
+ * is never fabricated: `expand` skips it entirely (logging one dev-console
+ * warning), `trace` still renders its badge but with the raw id as the label
+ * instead of a resolved title.
+ *
  * NO-ANCHOR FALLBACK: when the anchor id is absent from the graph (including the
  * no-anchor `/node/home` config landing), the constellation ({@link HomePage})
  * renders as the sensible default.
@@ -82,7 +91,10 @@ export interface AnchorViewAction {
  * `unexpanded` when already ranked there, else synthesizing a card for a node
  * outside the anchor's ranked neighborhood entirely (best-effort direct edge,
  * possibly none — {@link ExpandedNeighbor} already tolerates an undefined edge).
- * Unknown ids (not in `graph` at all) degrade silently, never throw.
+ * Unknown ids (not in `graph` at all — the server<->client id-space seam
+ * tracked as `kbexplorer-cli#216`, non-blocking) are skipped and never
+ * rendered/fabricated; each one logs a single dev-console warning so the gap
+ * is visible without throwing or breaking the rest of the expand batch.
  */
 function mergeForcedExpansion(
   graph: KBGraph,
@@ -109,7 +121,15 @@ function mergeForcedExpansion(
   for (const id of forcedIds) {
     if (id === anchor.id || expandedIds.has(id)) continue;
     const node = graph.nodes.find(n => n.id === id);
-    if (!node) continue; // agent named a node id absent from this manifest — no-op.
+    if (!node) {
+      // agent (or the server-resolved expand payload) named a node id absent
+      // from this manifest — skip it, never fabricate a card, but surface the
+      // gap so it's debuggable (see kbexplorer-cli#216).
+      console.warn(
+        `[AnchorFirstView] expand named node id "${id}" not found in the loaded manifest — skipping.`,
+      );
+      continue;
+    }
     extra.push({ node, edge: bestEdgeBetween(graph, anchor.id, id) });
     expandedIds.add(id);
   }
@@ -384,9 +404,22 @@ export function AnchorFirstView({
   }, [graph, anchor, expanded, unexpanded, viewAction?.expandedNodeIds, viewAction?.filterNodeIds]);
 
   // Precompute the trace path id set (used to highlight matching neighbor
-  // cards/chips) before the early return so hook order stays stable.
+  // cards/chips) before the early return so hook order stays stable. Trace
+  // path ids are looked up against the SAME client node map as expand (see
+  // `mergeForcedExpansion`) — an id absent from this manifest still renders
+  // (as a badge showing the raw id, see the trace banner below) rather than
+  // breaking the path, but is warned once per path so the gap stays visible.
   const tracePath = viewAction?.trace?.path;
-  const traceIds = useMemo(() => new Set(tracePath ?? []), [tracePath]);
+  const traceIds = useMemo(() => {
+    for (const id of tracePath ?? []) {
+      if (!graph.nodes.some(n => n.id === id)) {
+        console.warn(
+          `[AnchorFirstView] trace path node id "${id}" not found in the loaded manifest — showing the raw id.`,
+        );
+      }
+    }
+    return new Set(tracePath ?? []);
+  }, [graph, tracePath]);
 
   // NO-ANCHOR / bad-anchor fallback: the constellation is the sensible default.
   if (!anchor) {

--- a/src/representation/targets/copilot-home/AnchorFirstView.tsx
+++ b/src/representation/targets/copilot-home/AnchorFirstView.tsx
@@ -408,7 +408,8 @@ export function AnchorFirstView({
   // path ids are looked up against the SAME client node map as expand (see
   // `mergeForcedExpansion`) — an id absent from this manifest still renders
   // (as a badge showing the raw id, see the trace banner below) rather than
-  // breaking the path, but is warned once per path so the gap stays visible.
+  // breaking the path; each missing id in the path logs its own warning (not
+  // deduped to one-per-path) so every gap stays individually visible.
   const tracePath = viewAction?.trace?.path;
   const traceIds = useMemo(() => {
     for (const id of tracePath ?? []) {

--- a/src/representation/targets/copilot-home/__tests__/anchor-first-view.test.ts
+++ b/src/representation/targets/copilot-home/__tests__/anchor-first-view.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import type { KBConfig, KBGraph, KBNode } from '../../../../types';
@@ -135,6 +135,31 @@ describe('AnchorFirstView — agent view-actions (#409, cli#214)', () => {
     ).not.toThrow();
   });
 
+  it('expand skips an unknown id (with a dev warning) while still rendering the known ids in the same batch', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const html = renderToStaticMarkup(
+        createElement(AnchorFirstView, {
+          graph,
+          config,
+          anchorId: 'anchor',
+          maxExpanded: 6,
+          // 'far' is a real node id; 'does-not-exist' is not in `graph` at all
+          // (the kbexplorer-cli#216 server<->client id-space seam) — the known
+          // id must still render even though the batch also names an unknown one.
+          viewAction: { expandedNodeIds: new Set(['far', 'does-not-exist']) },
+        }),
+      );
+      expect(html).toMatch(/data-testid="anchor-expanded-neighbor"[^>]*data-node-id="far"/);
+      expect(html).not.toContain('does-not-exist');
+      expect(warn).toHaveBeenCalledExactlyOnceWith(
+        expect.stringContaining('"does-not-exist" not found in the loaded manifest'),
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
   it('focus marks the matching neighbor card with data-kbx-focused', () => {
     const html = renderToStaticMarkup(
       createElement(AnchorFirstView, {
@@ -187,6 +212,30 @@ describe('AnchorFirstView — agent view-actions (#409, cli#214)', () => {
     );
     expect(html).toContain('data-connected="false"');
     expect(html).toContain('no path found');
+  });
+
+  it('trace falls back to the raw id (with a dev warning) for a path hop absent from the manifest', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const html = renderToStaticMarkup(
+        createElement(AnchorFirstView, {
+          graph,
+          config,
+          anchorId: 'anchor',
+          // 'does-not-exist' is not in `graph` at all (kbexplorer-cli#216) —
+          // the path still renders in full, with the raw id as that hop's label.
+          viewAction: { trace: { path: ['anchor', 'does-not-exist'], connected: true } },
+        }),
+      );
+      expect(html).toContain('data-testid="anchor-trace-banner"');
+      expect(html).toMatch(/data-testid="anchor-trace-node"[^>]*data-node-id="does-not-exist"/);
+      expect(html).toContain('does-not-exist');
+      expect(warn).toHaveBeenCalledExactlyOnceWith(
+        expect.stringContaining('"does-not-exist" not found in the loaded manifest'),
+      );
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it('trace highlights a visible neighbor that sits on the path', () => {

--- a/src/representation/targets/copilot-home/__tests__/anchor-first-view.test.ts
+++ b/src/representation/targets/copilot-home/__tests__/anchor-first-view.test.ts
@@ -152,7 +152,8 @@ describe('AnchorFirstView — agent view-actions (#409, cli#214)', () => {
       );
       expect(html).toMatch(/data-testid="anchor-expanded-neighbor"[^>]*data-node-id="far"/);
       expect(html).not.toContain('does-not-exist');
-      expect(warn).toHaveBeenCalledExactlyOnceWith(
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn).toHaveBeenCalledWith(
         expect.stringContaining('"does-not-exist" not found in the loaded manifest'),
       );
     } finally {
@@ -230,7 +231,8 @@ describe('AnchorFirstView — agent view-actions (#409, cli#214)', () => {
       expect(html).toContain('data-testid="anchor-trace-banner"');
       expect(html).toMatch(/data-testid="anchor-trace-node"[^>]*data-node-id="does-not-exist"/);
       expect(html).toContain('does-not-exist');
-      expect(warn).toHaveBeenCalledExactlyOnceWith(
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn).toHaveBeenCalledWith(
         expect.stringContaining('"does-not-exist" not found in the loaded manifest'),
       );
     } finally {


### PR DESCRIPTION
## Precision fix following creator's cli#214 payload-shape correction (#409)

The creator verified the merged CLI payload shape directly: `graph-updated{reason:'expand'}`'s `nodes` field is an array of **bare node-id strings** (`[focusId, ...neighborIds]`), not node objects with title/cluster. This PR confirms and hardens the client-side resolution path that already existed for this.

### What was already correct

`mergeForcedExpansion` (in `AnchorFirstView.tsx`) already resolves each server-sent id against the client's own node map — `graph.nodes`, the same map `buildGraph` (`src/engine/graph.ts`) produces from the loaded manifest — and already had a silent `continue` for an id not found there. Same for `trace`'s path: each hop is looked up against `graph.nodes` for its title.

### What this PR adds

1. **`expand`**: an unknown id (the tracked, non-blocking `kbexplorer-cli#216` server↔client id-space seam) now logs **one dev-console warning** before being skipped, instead of a silent no-op — so the gap is visible without breaking anything. The rest of the batch's known ids still render.
2. **`trace`**: an unknown path-hop id also now logs a warning; it still renders its badge with the raw id as a fallback label (can't just drop a hop from a path without misrepresenting connectivity).
3. Two new tests:
   - `expand skips an unknown id (with a dev warning) while still rendering the known ids in the same batch` — asserts a known id (`far`) renders as an expanded card while an unknown id (`does-not-exist`) is both warned-on and never appears in the output.
   - `trace falls back to the raw id (with a dev warning) for a path hop absent from the manifest` — asserts the trace banner renders in full with the raw id as that hop's label, and the warning fires.
4. Doc comments (module-level + `mergeForcedExpansion`) updated to describe the id-resolution contract explicitly.

### Verification

- `npx tsc -b` — clean
- `npx eslint .` — 0 errors (3 pre-existing warnings only)
- `npx vitest run` — 1051/1051 unit tests pass (1049 + 2 new)
- `VITE_KB_LOCAL=true npx vite build` + `npx playwright test --project=chromium` — 93/93 e2e pass, including `no console errors on key pages` (the new warnings only fire on genuinely-unknown ids, which don't occur in the app's normal e2e flows)

Refs #409. No behavior change for the happy path — every id currently reaching this view resolves — this only makes the already-existing skip/fallback behavior debuggable and adds regression coverage for it.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anokye-labs/kbexplorer-template/pull/462" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->