### PR TITLE
Refactor viewer registration for #467

### DIFF
--- a/src/engine/__tests__/derived-artifact-render.test.ts
+++ b/src/engine/__tests__/derived-artifact-render.test.ts
@@ -21,7 +21,7 @@ import { fileURLToPath } from 'node:url';
 import type { KBNode, Cluster } from '../../types';
 import { buildGraph } from '../graph';
 import { resolveType, resetNodeTypeRegistry } from '../node-types';
-import { resolveViewer, resetViewerRegistry } from '../../views/viewers';
+import { registerBuiltinViewers, resolveViewer, resetViewerRegistry } from '../../views/viewers';
 import { registerContentModelTypes } from '../content-model';
 import { PersonView } from '../../views/viewers/PersonView';
 import { SquadView } from '../../views/viewers/SquadView';
@@ -42,6 +42,7 @@ const CLUSTERS: Cluster[] = [{ id: 'org', name: 'Organization', color: '#c0a3ff'
 describe('derived-artifact render proof (cross-repo, F8 gap)', () => {
   beforeAll(() => {
     // Registering the content-model spine binds person→PersonView, squad→SquadView.
+    registerBuiltinViewers();
     registerContentModelTypes();
   });
   afterAll(() => {

--- a/src/engine/__tests__/providers/content-model-provider.test.ts
+++ b/src/engine/__tests__/providers/content-model-provider.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { ContentModelProvider } from '../../providers/content-model-provider';
 import { resolveType } from '../../node-types';
-import { resolveViewer } from '../../../views/viewers';
+import { registerBuiltinViewers, resolveViewer } from '../../../views/viewers';
 import { SquadView } from '../../../views/viewers/SquadView';
 import { PersonView } from '../../../views/viewers/PersonView';
 import type { KBConfig } from '../../../types';
@@ -31,6 +31,7 @@ describe('ContentModelProvider (T2.4 / #163)', () => {
   });
 
   it('registers spine node types + bespoke viewers on resolve', async () => {
+    registerBuiltinViewers();
     const provider = new ContentModelProvider(loadFixtureSource());
     const { nodes } = await provider.resolve(config, []);
     expect(resolveType('squad')?.layer).toBe('work');

--- a/src/engine/__tests__/providers/structural-provider.test.ts
+++ b/src/engine/__tests__/providers/structural-provider.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { StructuralProvider, parseCodeowners, buildStructuralFileNode } from '../../providers/structural-provider';
 import { resetNodeTypeRegistry, resolveType } from '../../node-types';
-import { resetViewerRegistry, resolveViewer } from '../../../views/viewers';
+import { registerBuiltinViewers, resetViewerRegistry, resolveViewer } from '../../../views/viewers';
 import { WorkflowView } from '../../../views/viewers/WorkflowView';
 import { ActionView } from '../../../views/viewers/ActionView';
 import { SkillView } from '../../../views/viewers/SkillView';
@@ -84,6 +84,7 @@ describe('StructuralProvider', () => {
   beforeEach(() => {
     resetNodeTypeRegistry();
     resetViewerRegistry();
+    registerBuiltinViewers();
   });
 
   it('is a safe no-op when there are no structural files', async () => {

--- a/src/engine/content-model/__tests__/vocabulary.test.ts
+++ b/src/engine/content-model/__tests__/vocabulary.test.ts
@@ -14,7 +14,7 @@ import { readContentModelSchema, canonicalKind, urnLocalId } from '../schema-rea
 import type { ContentModelSource, Vocabulary } from '../types';
 import { loadFixtureSource } from './fixtures';
 import { registerContentModelTypes } from '../register';
-import { resolveViewer } from '../../../views/viewers/registry';
+import { registerBuiltinViewers, resolveViewer } from '../../../views/viewers';
 import { SquadView } from '../../../views/viewers/SquadView';
 import { GenericStructuredView } from '../../../views/viewers/GenericStructuredView';
 import type { KBNode } from '../../../types';
@@ -87,6 +87,7 @@ describe('cross-repo vocabulary — alias canonicalization (#153)', () => {
   });
 
   it('routes the aliased node to the canonical kind\'s bespoke viewer (SquadView)', () => {
+    registerBuiltinViewers();
     registerContentModelTypes();
     const cell = nodeOf(graph, CELL);
     expect(resolveViewer(cell)).toBe(SquadView);

--- a/src/engine/content-model/register.ts
+++ b/src/engine/content-model/register.ts
@@ -10,46 +10,34 @@
  */
 import type { NodeLayer } from '../../types';
 import { registerType } from '../node-types';
-import { registerViewer, type ViewerComponent } from '../../views/viewers';
-import { PersonView } from '../../views/viewers/PersonView';
-import { SquadView } from '../../views/viewers/SquadView';
-import { WorkstreamView } from '../../views/viewers/WorkstreamView';
-import { MissionView } from '../../views/viewers/MissionView';
-import { PriorityView } from '../../views/viewers/PriorityView';
-import { CycleView } from '../../views/viewers/CycleView';
-import { OrgView } from '../../views/viewers/OrgView';
-import { TeamView } from '../../views/viewers/TeamView';
-import { SystemOfRecordView } from '../../views/viewers/SystemOfRecordView';
-import { ServiceView } from '../../views/viewers/ServiceView';
-import { DecisionView } from '../../views/viewers/DecisionView';
 
 interface SpineKind {
   id: string;
   label: string;
   layer: NodeLayer;
   relations: string[];
-  view: ViewerComponent;
+  viewer: string;
   description: string;
 }
 
 /** The content-model spine kinds and the viewer each resolves to. */
 export const CONTENT_MODEL_KINDS: SpineKind[] = [
-  { id: 'person', label: 'Person', layer: 'work', relations: ['reports-to'], view: PersonView, description: 'An individual in the org.' },
-  { id: 'squad', label: 'Squad', layer: 'work', relations: ['leads', 'staffs', 'structural', 'deprecated'], view: SquadView, description: 'A squad that staffs people, is led by a DRI, and delivers a workstream.' },
-  { id: 'workstream', label: 'Workstream', layer: 'work', relations: ['structural'], view: WorkstreamView, description: 'A stream of work aligned to a priority.' },
-  { id: 'mission', label: 'Mission', layer: 'work', relations: ['structural'], view: MissionView, description: 'A time-boxed mission assigned to a cycle + squad.' },
-  { id: 'priority', label: 'Priority', layer: 'work', relations: [], view: PriorityView, description: 'A ranked organizational priority.' },
-  { id: 'cycle', label: 'Cycle', layer: 'work', relations: [], view: CycleView, description: 'A planning cycle (time box).' },
-  { id: 'org', label: 'Org', layer: 'work', relations: [], view: OrgView, description: 'An organization with a charter.' },
+  { id: 'person', label: 'Person', layer: 'work', relations: ['reports-to'], viewer: 'person', description: 'An individual in the org.' },
+  { id: 'squad', label: 'Squad', layer: 'work', relations: ['leads', 'staffs', 'structural', 'deprecated'], viewer: 'squad', description: 'A squad that staffs people, is led by a DRI, and delivers a workstream.' },
+  { id: 'workstream', label: 'Workstream', layer: 'work', relations: ['structural'], viewer: 'workstream', description: 'A stream of work aligned to a priority.' },
+  { id: 'mission', label: 'Mission', layer: 'work', relations: ['structural'], viewer: 'mission', description: 'A time-boxed mission assigned to a cycle + squad.' },
+  { id: 'priority', label: 'Priority', layer: 'work', relations: [], viewer: 'priority', description: 'A ranked organizational priority.' },
+  { id: 'cycle', label: 'Cycle', layer: 'work', relations: [], viewer: 'cycle', description: 'A planning cycle (time box).' },
+  { id: 'org', label: 'Org', layer: 'work', relations: [], viewer: 'org', description: 'An organization with a charter.' },
   // Work-graph organizational-layer descriptor kinds (#233)
-  { id: 'team', label: 'Team', layer: 'work', relations: ['leads', 'staffs', 'owns'], view: TeamView, description: 'A team that leads people and owns workstreams.' },
-  { id: 'system-of-record', label: 'System of Record', layer: 'work', relations: ['tracked-in'], view: SystemOfRecordView, description: 'An external system that tracks a workstream (e.g. an ADO board or GitHub repo).' },
+  { id: 'team', label: 'Team', layer: 'work', relations: ['leads', 'staffs', 'owns'], viewer: 'team', description: 'A team that leads people and owns workstreams.' },
+  { id: 'system-of-record', label: 'System of Record', layer: 'work', relations: ['tracked-in'], viewer: 'system-of-record', description: 'An external system that tracks a workstream (e.g. an ADO board or GitHub repo).' },
   // Services-monorepo core kinds (#275)
-  { id: 'service', label: 'Service', layer: 'work', relations: ['owned-by', 'tracked-in'], view: ServiceView, description: 'A deployable service owned by a team, with a ServiceTree id and catalog-info path.' },
-  { id: 'decision', label: 'Decision', layer: 'work', relations: ['decided-by', 'affects'], view: DecisionView, description: 'An architecture decision record (ADR) — deciders, status, context, and the work it affects.' },
+  { id: 'service', label: 'Service', layer: 'work', relations: ['owned-by', 'tracked-in'], viewer: 'service', description: 'A deployable service owned by a team, with a ServiceTree id and catalog-info path.' },
+  { id: 'decision', label: 'Decision', layer: 'work', relations: ['decided-by', 'affects'], viewer: 'decision', description: 'An architecture decision record (ADR) — deciders, status, context, and the work it affects.' },
 ];
 
-/** Register every spine node type + its bespoke viewer. Idempotent. */
+/** Register every spine node type + its bespoke viewer name. Idempotent. */
 export function registerContentModelTypes(): void {
   for (const k of CONTENT_MODEL_KINDS) {
     registerType({
@@ -58,9 +46,8 @@ export function registerContentModelTypes(): void {
       layer: k.layer,
       cluster: k.id,
       relations: k.relations,
-      viewer: k.id,
+      viewer: k.viewer,
       description: k.description,
     });
-    registerViewer(k.id, k.view);
   }
 }

--- a/src/engine/demo-entities.ts
+++ b/src/engine/demo-entities.ts
@@ -12,10 +12,7 @@
 import type { KBGraph, KBNode, KBEdge, Cluster } from '../types';
 import { buildJsonLd } from '../types';
 import { registerType } from './node-types';
-import { registerViewer } from '../views/viewers';
-import { PersonView } from '../views/viewers/PersonView';
-import { SquadView } from '../views/viewers/SquadView';
-import { buildSampleRichMarkdownNode } from '../views/rich-markdown/sample-document';
+import { buildSampleRichMarkdownNode } from './demo-rich-markdown';
 
 const DEMO_CLUSTER: Cluster = { id: 'org', name: 'Organization', color: '#c0a3ff' };
 
@@ -78,8 +75,6 @@ export function registerDemoEntityTypes(): void {
     relations: [],
     description: 'A team charter document (demo kind with no bespoke viewer).',
   });
-  registerViewer('person', PersonView);
-  registerViewer('squad', SquadView);
 }
 
 /**

--- a/src/engine/demo-rich-markdown.ts
+++ b/src/engine/demo-rich-markdown.ts
@@ -1,0 +1,86 @@
+import { renderSafeMarkdown } from './safe-markdown';
+import type { KBNode } from '../types';
+
+const SAMPLE_FRONTMATTER: Record<string, unknown> = {
+  title: 'Release Pipeline',
+  status: 'active',
+  owner: 'Team Atlas',
+  updated: '2026-06-30',
+  tags: ['release', 'ci', 'pipeline'],
+};
+
+const MERMAID_SOURCE = `flowchart LR
+  A[Build] --> B[Test]
+  B --> C[Deploy]`;
+
+const DOT_SOURCE = `digraph G {
+  build -> test;
+  test -> deploy;
+}`;
+
+const ICS_SOURCE = `BEGIN:VEVENT
+SUMMARY:Sprint Review
+DTSTART:20260701T160000Z
+END:VEVENT`;
+
+const CANVAS_SOURCE = `{ "shapes": [ { "rect": [0, 0, 128, 80] }, { "circle": [80, 48, 26] } ] }`;
+
+const SAMPLE_DOT_SVG = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 80"><rect width="200" height="80" rx="8" fill="#0f172a"/><text x="16" y="44" fill="#f8fafc" font-size="18">Dependency graph</text></svg>';
+const SAMPLE_ICS_SVG = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 80"><rect width="200" height="80" rx="8" fill="#1d4ed8"/><text x="16" y="44" fill="#eff6ff" font-size="18">Sprint Review</text></svg>';
+const SAMPLE_CANVAS_SVG = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 80"><rect x="20" y="18" width="128" height="44" rx="8" fill="#f59e0b"/><circle cx="152" cy="40" r="24" fill="#ef4444"/></svg>';
+
+const SAMPLE_RICH_MARKDOWN_RAW = `# Release Pipeline
+
+This document describes the **release pipeline** and embeds several block kinds —
+a live diagram plus three blocks that render from a pre-built SVG.
+
+## Flow (live Mermaid)
+
+\`\`\`mermaid
+${MERMAID_SOURCE}
+\`\`\`
+
+## Dependency graph (Graphviz DOT)
+
+\`\`\`dot
+${DOT_SOURCE}
+\`\`\`
+
+## Schedule (iCalendar)
+
+\`\`\`ics
+${ICS_SOURCE}
+\`\`\`
+
+## Whiteboard (canvas)
+
+\`\`\`canvas
+${CANVAS_SOURCE}
+\`\`\`
+`;
+
+function buildSampleBlocks() {
+  return [
+    { kind: 'mermaid', source: MERMAID_SOURCE, title: 'Release flow' },
+    { kind: 'dot', source: DOT_SOURCE, svg: SAMPLE_DOT_SVG, title: 'Build dependency graph' },
+    { kind: 'ics', source: ICS_SOURCE, svg: SAMPLE_ICS_SVG, title: 'Sprint Review' },
+    { kind: 'canvas', source: CANVAS_SOURCE, svg: SAMPLE_CANVAS_SVG, title: 'Whiteboard sketch' },
+  ];
+}
+
+export function buildSampleRichMarkdownNode(id = 'demo-richmd-doc'): KBNode {
+  const content = renderSafeMarkdown(SAMPLE_RICH_MARKDOWN_RAW);
+  return {
+    id,
+    title: 'Release Pipeline',
+    cluster: 'docs',
+    content,
+    rawContent: SAMPLE_RICH_MARKDOWN_RAW,
+    emoji: 'DocumentRegular',
+    display: 'rich-markdown',
+    connections: [],
+    source: { type: 'derived', generator: 'rich-markdown-demo' },
+    provider: 'demo-richmd',
+    data: { richMarkdown: { frontmatter: SAMPLE_FRONTMATTER, blocks: buildSampleBlocks() } },
+  };
+}

--- a/src/engine/providers/authored-rich-markdown-provider.ts
+++ b/src/engine/providers/authored-rich-markdown-provider.ts
@@ -33,11 +33,17 @@ import {
 } from '@anokye-labs/kbexplorer-provider-rich-markdown/lib';
 import type { GraphProvider, ProviderResult } from '../providers';
 import type { KBConfig, KBNode, KBEdge } from '../../types';
-import type { RichMarkdownBlock } from '../../views/rich-markdown';
 import { assignIdentity } from '../identity';
 import { isRichAuthoredMarkdown } from './rich-markdown/detect';
 
 const PROVIDER_ID = 'authored-rich-markdown';
+
+interface RichMarkdownBlock {
+  kind: string;
+  source: string;
+  hash?: string;
+  range?: { start: number; end: number };
+}
 
 /** Leading YAML frontmatter block (`---\n…\n---`), tolerant of a BOM + CRLF. */
 const LEADING_FRONTMATTER_RE = /^\uFEFF?---\r?\n[\s\S]*?\r?\n---\r?\n?/;

--- a/src/engine/providers/structural-provider.ts
+++ b/src/engine/providers/structural-provider.ts
@@ -20,10 +20,6 @@ import type { KBConfig, KBNode, NodeSource, Connection } from '../../types';
 import { buildJsonLd } from '../../types';
 import { registerType } from '../node-types';
 import { urnIdentity } from '../identity';
-import { registerViewer } from '../../views/viewers';
-import { WorkflowView } from '../../views/viewers/WorkflowView';
-import { ActionView } from '../../views/viewers/ActionView';
-import { SkillView } from '../../views/viewers/SkillView';
 import {
   applyStructuredNodeMap,
   parseStructuredNodeMap,
@@ -58,10 +54,6 @@ export function registerStructuralTypes(): void {
   registerType({ id: 'funding-config', label: 'Funding', layer: 'work', cluster: STRUCTURAL_CLUSTER, relations: ['structural'], description: 'Repository funding links.' });
   registerType({ id: 'github-config', label: 'Repo Config', layer: 'work', cluster: STRUCTURAL_CLUSTER, relations: ['structural'], description: 'Generic repository configuration file.' });
   registerType({ id: 'structured-config', label: 'Config', layer: 'work', cluster: STRUCTURAL_CLUSTER, relations: ['structural'], description: 'Heuristically-typed structured config.' });
-
-  registerViewer('workflow', WorkflowView);
-  registerViewer('github-action', ActionView);
-  registerViewer('skill', SkillView);
 }
 
 // ── Path classification ────────────────────────────────────

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,9 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { registerBuiltinViewers } from './views/viewers/builtin-map'
+
+registerBuiltinViewers()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/views/viewers/__tests__/spine-viewers.test.ts
+++ b/src/views/viewers/__tests__/spine-viewers.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach } from 'vitest';
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import type { KBNode } from '../../../types';
-import { resolveViewer, resetViewerRegistry, type ViewerComponent } from '../index';
+import { registerBuiltinViewers, resolveViewer, resetViewerRegistry, type ViewerComponent } from '../index';
 import { resetNodeTypeRegistry } from '../../../engine/node-types';
 import { registerContentModelTypes, CONTENT_MODEL_KINDS } from '../../../engine/content-model';
 import { SquadView } from '../SquadView';
@@ -208,6 +208,7 @@ describe('spine viewers — rendering (T2.5 + T2.6 / #164, #165)', () => {
 
 describe('spine viewers — registration + resolution (#164, #165)', () => {
   it('registers a viewer for every spine kind and resolves each to its bespoke view', () => {
+    registerBuiltinViewers();
     registerContentModelTypes();
     const expected: Record<string, ViewerComponent> = {
       squad: SquadView, workstream: WorkstreamView, mission: MissionView,

--- a/src/views/viewers/builtin-map.ts
+++ b/src/views/viewers/builtin-map.ts
@@ -1,0 +1,33 @@
+import { registerViewer } from './registry';
+import { ActionView } from './ActionView';
+import { CycleView } from './CycleView';
+import { DecisionView } from './DecisionView';
+import { MissionView } from './MissionView';
+import { OrgView } from './OrgView';
+import { PersonView } from './PersonView';
+import { PriorityView } from './PriorityView';
+import { ServiceView } from './ServiceView';
+import { SquadView } from './SquadView';
+import { SystemOfRecordView } from './SystemOfRecordView';
+import { TeamView } from './TeamView';
+import { WorkstreamView } from './WorkstreamView';
+import { WorkflowView } from './WorkflowView';
+import { SkillView } from './SkillView';
+
+export function registerBuiltinViewers(): void {
+  registerViewer('workflow', WorkflowView);
+  registerViewer('action', ActionView);
+  registerViewer('github-action', ActionView);
+  registerViewer('skill', SkillView);
+  registerViewer('person', PersonView);
+  registerViewer('squad', SquadView);
+  registerViewer('workstream', WorkstreamView);
+  registerViewer('mission', MissionView);
+  registerViewer('priority', PriorityView);
+  registerViewer('cycle', CycleView);
+  registerViewer('org', OrgView);
+  registerViewer('team', TeamView);
+  registerViewer('system-of-record', SystemOfRecordView);
+  registerViewer('service', ServiceView);
+  registerViewer('decision', DecisionView);
+}

--- a/src/views/viewers/index.ts
+++ b/src/views/viewers/index.ts
@@ -25,6 +25,8 @@ export {
   type ViewerProps,
 } from './GenericStructuredView';
 
+export { registerBuiltinViewers } from './builtin-map';
+
 // Services-monorepo bespoke viewers (#275).
 export { ServiceView } from './ServiceView';
 export { DecisionView } from './DecisionView';

--- a/src/views/viewers/registry.ts
+++ b/src/views/viewers/registry.ts
@@ -43,10 +43,11 @@ export function resetViewerRegistry(): void {
 
 /**
  * Resolve a viewer for a node. Resolution precedence:
- * 1. `node.entityType`
- * 2. JSON-LD `@type` — when it is an array each entry is tried in order and the
+ * 1. `resolveType(entityType)?.viewer` when the node has an `entityType`.
+ * 2. `node.entityType` (or the direct string argument when a string is passed).
+ * 3. JSON-LD `@type` — when it is an array each entry is tried in order and the
  *    first entry with a registered viewer wins.
- * 3. {@link GenericStructuredView} fallback.
+ * 4. {@link GenericStructuredView} fallback.
  */
 export function resolveViewer(node: Pick<KBNode, 'entityType' | 'jsonld'> | string | undefined | null): ViewerComponent {
   const candidates: string[] = [];

--- a/src/views/viewers/registry.ts
+++ b/src/views/viewers/registry.ts
@@ -1,4 +1,5 @@
 import type { KBNode } from '../../types';
+import { resolveType } from '../../engine/node-types';
 import { GenericStructuredView, type ViewerComponent } from './GenericStructuredView';
 
 /**
@@ -47,12 +48,21 @@ export function resetViewerRegistry(): void {
  *    first entry with a registered viewer wins.
  * 3. {@link GenericStructuredView} fallback.
  */
-export function resolveViewer(node: Pick<KBNode, 'entityType' | 'jsonld'>): ViewerComponent {
+export function resolveViewer(node: Pick<KBNode, 'entityType' | 'jsonld'> | string | undefined | null): ViewerComponent {
   const candidates: string[] = [];
-  if (node.entityType) candidates.push(node.entityType);
-  const ldType = node.jsonld?.['@type'];
-  if (Array.isArray(ldType)) candidates.push(...ldType);
-  else if (ldType) candidates.push(ldType);
+  if (typeof node === 'string') {
+    candidates.push(node);
+  } else if (node) {
+    const entityType = node.entityType;
+    if (entityType) {
+      const typeDef = resolveType(entityType);
+      if (typeDef?.viewer) candidates.push(typeDef.viewer);
+      candidates.push(entityType);
+    }
+    const ldType = node.jsonld?.['@type'];
+    if (Array.isArray(ldType)) candidates.push(...ldType);
+    else if (ldType) candidates.push(ldType);
+  }
 
   for (const candidate of candidates) {
     const viewer = registry.get(normalizeKey(candidate));

--- a/src/views/viewers/registry.ts
+++ b/src/views/viewers/registry.ts
@@ -42,9 +42,11 @@ export function resetViewerRegistry(): void {
 }
 
 /**
- * Resolve a viewer for a node. Resolution precedence:
- * 1. `resolveType(entityType)?.viewer` when the node has an `entityType`.
- * 2. `node.entityType` (or the direct string argument when a string is passed).
+ * Resolve a viewer for a node or a direct viewer-name string. Resolution precedence:
+ * 1. `resolveType(entityType)?.viewer` when the input is node-like and has an
+ *    `entityType`.
+ * 2. `node.entityType` for node-like input, or the direct string argument when a
+ *    string is passed.
  * 3. JSON-LD `@type` — when it is an array each entry is tried in order and the
  *    first entry with a registered viewer wins.
  * 4. {@link GenericStructuredView} fallback.


### PR DESCRIPTION
Fixes #467

## Summary
- Moved built-in viewer registration out of engine modules and into a single app-owned registration entrypoint.
- Updated node-type registration to carry viewer-name metadata instead of importing view components directly from the engine.
- Decoupled the demo-rich-markdown data path from the view layer so engine code no longer depends on `src/views`.
- Adjusted viewer tests to register built-in viewers explicitly in non-app contexts.

## Verification
```text
$ npm test
> kbexplorer-template@0.4.1 test
> vitest run --config vitest.config.ts

Test Files  96 passed (96)
Tests  1051 passed (1051)
```

```text
$ npx tsc -b
# completed successfully
```

```text
$ npm run lint
> kbexplorer-template@0.4.1 lint
> eslint .

✖ 3 problems (0 errors, 3 warnings)
```

```text
$ Select-String-based checks
No matches for views/ in src/engine
No matches for registerViewer in src/engine
```
