### PR TITLE
chore: declare engines.node >=22 (kbexplorer-core#66)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.4.1",
   "type": "module",
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "dev": "vite",
     "prebuild": "node scripts/generate-manifest.js",


### PR DESCRIPTION
## Summary
- Add a top-level `engines.node` declaration of `>=22` to `package.json` to align with the rest of the ecosystem.
- References epic anokye-labs/kbexplorer-core#66.
- Refs #66.

## Verification
- `npm run build`
  - Succeeded
  - Vite production build completed successfully
- `npm test`
  - Succeeded
  - 90 test files passed, 955 tests passed
