### PR TITLE
feat: wire app BASE_URL into loader importBaseUrl (F5a)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.4.1",
       "dependencies": {
         "@anokye-labs/kbexplorer-core": "^0.5.1",
-        "@anokye-labs/kbexplorer-engine": "git+https://github.com/anokye-labs/kbexplorer-engine.git#3de83e4149628651397e4335f426ff330b2ce57e",
+        "@anokye-labs/kbexplorer-engine": "git+https://github.com/anokye-labs/kbexplorer-engine.git#669c2c17596e6f1f39e042d2a5afc6719c425bad",
         "@anokye-labs/kbexplorer-provider-rich-markdown": "^0.1.2",
         "@fluentui/react-components": "^9.74.2",
         "@fluentui/react-icons": "^2.0.323",
@@ -73,8 +73,8 @@
     },
     "node_modules/@anokye-labs/kbexplorer-engine": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/anokye-labs/kbexplorer-engine.git#3de83e4149628651397e4335f426ff330b2ce57e",
-      "integrity": "sha512-+FyBfULRAdH2gfLKaAPPlMNB6fGZpHvaVCOUPYC6YuJImQ9hGvVL2rrI1JPp+7d39JGDr0ftjcIADYlh5I/R0A==",
+      "resolved": "git+ssh://git@github.com/anokye-labs/kbexplorer-engine.git#669c2c17596e6f1f39e042d2a5afc6719c425bad",
+      "integrity": "sha512-4myoi+GCWbDU1hUPNOcPPdL2uITRDos8MW85f4NR9Yzd1ABP2osl8puhbfxu9ev0HqDl7QZIqyDKArMhzgfctw==",
       "license": "MIT",
       "dependencies": {
         "@anokye-labs/kbexplorer-core": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@anokye-labs/kbexplorer-core": "^0.5.1",
-    "@anokye-labs/kbexplorer-engine": "git+https://github.com/anokye-labs/kbexplorer-engine.git#3de83e4149628651397e4335f426ff330b2ce57e",
+    "@anokye-labs/kbexplorer-engine": "git+https://github.com/anokye-labs/kbexplorer-engine.git#669c2c17596e6f1f39e042d2a5afc6719c425bad",
     "@anokye-labs/kbexplorer-provider-rich-markdown": "^0.1.2",
     "@fluentui/react-components": "^9.74.2",
     "@fluentui/react-icons": "^2.0.323",

--- a/src/engine/local-loader.ts
+++ b/src/engine/local-loader.ts
@@ -336,7 +336,12 @@ export async function buildKnowledgeBaseFromManifest(
   config: KBConfig,
   env?: EngineEnv,
 ): Promise<{ graph: KBGraph; config: KBConfig; themeFileRaw: string | null }> {
-  const result = await loadKnowledgeBase(new ManifestSource(manifest, config), config, env);
+  const result = await loadKnowledgeBase(
+    new ManifestSource(manifest, config),
+    config,
+    env,
+    typeof env?.BASE_URL === 'string' ? { importBaseUrl: env.BASE_URL } : undefined,
+  );
   return { ...result, themeFileRaw: manifest.themeFileRaw ?? null };
 }
 

--- a/src/engine/remote-loader.ts
+++ b/src/engine/remote-loader.ts
@@ -32,6 +32,11 @@ export async function loadRemoteKnowledgeBase(
     ghSource.resolveConfig(),
     ghSource.resolveThemeFileRaw(),
   ])
-  const result = await loadKnowledgeBase(ghSource, config, env)
+  const result = await loadKnowledgeBase(
+    ghSource,
+    config,
+    env,
+    typeof env?.BASE_URL === 'string' ? { importBaseUrl: env.BASE_URL } : undefined,
+  )
   return { ...result, themeFileRaw: themeFileRaw ?? null }
 }


### PR DESCRIPTION
See #472
See anokye-labs/kbexplorer-engine#6

## Summary

Completes the F5a follow-up deferred in #505 (slice-3 template shim-swap). Re-pins the engine git-dep to `669c2c17` (engine PR#10's merge SHA, which added an additive `importBaseUrl` passthrough param to `loadKnowledgeBase`/`loader.ts`) and wires the app's `BASE_URL` through to it at both template call sites.

## Changes

- `package.json` / `package-lock.json`: bump `@anokye-labs/kbexplorer-engine` git-dep pin `3de83e41` -> `669c2c17`.
- `src/engine/local-loader.ts` (`buildKnowledgeBaseFromManifest`) and `src/engine/remote-loader.ts` (`loadRemoteKnowledgeBase`): both now pass a 4th arg to `loadKnowledgeBase`:
  ```ts
  typeof env?.BASE_URL === 'string' ? { importBaseUrl: env.BASE_URL } : undefined
  ```

## Boundary rule respected

Both call sites already receive `env` (`import.meta.env`, threaded down from `useKnowledgeBase.ts`) - this change reads the existing `env.BASE_URL` field rather than adding any *new* `import.meta.env` access, so `boundary.test.ts`'s "no fresh `import.meta.env` reads outside the designated wrapper" rule stays intact and green. The `typeof === 'string'` guard is required both for `exactOptionalPropertyTypes` correctness and because `EngineEnv` is a `[key: string]: string | boolean | undefined` index signature (no direct type-level guarantee that `BASE_URL` is a string).

## Verification

- `npx tsc -b`: clean.
- `npm test`: 67/67 files, 710/710 tests green, including `boundary.test.ts` (no react/vis-network/DOM/fresh `import.meta.env` leaks).
- `npm run lint`: 0 errors (3 pre-existing, unrelated warnings).
- `npm run build`: succeeds.

This is the last piece before `anokye-labs/kbexplorer-engine#6` can be closed. Left open for independent review/merge, per process - not self-merging.
