### PR TITLE
feat: wire importBaseUrl through template loaders (F5a)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.4.1",
       "dependencies": {
         "@anokye-labs/kbexplorer-core": "^0.5.1",
-        "@anokye-labs/kbexplorer-engine": "git+https://github.com/anokye-labs/kbexplorer-engine.git#3de83e4149628651397e4335f426ff330b2ce57e",
+        "@anokye-labs/kbexplorer-engine": "github:anokye-labs/kbexplorer-engine#669c2c17",
         "@anokye-labs/kbexplorer-provider-rich-markdown": "^0.1.2",
         "@fluentui/react-components": "^9.74.2",
         "@fluentui/react-icons": "^2.0.323",
@@ -73,8 +73,7 @@
     },
     "node_modules/@anokye-labs/kbexplorer-engine": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/anokye-labs/kbexplorer-engine.git#3de83e4149628651397e4335f426ff330b2ce57e",
-      "integrity": "sha512-+FyBfULRAdH2gfLKaAPPlMNB6fGZpHvaVCOUPYC6YuJImQ9hGvVL2rrI1JPp+7d39JGDr0ftjcIADYlh5I/R0A==",
+      "resolved": "git+ssh://git@github.com/anokye-labs/kbexplorer-engine.git#669c2c17596e6f1f39e042d2a5afc6719c425bad",
       "license": "MIT",
       "dependencies": {
         "@anokye-labs/kbexplorer-core": "^0.5.1",
@@ -2313,14 +2312,14 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.3"
       },
       "funding": {
         "type": "github",
@@ -2605,6 +2604,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2622,6 +2624,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2639,6 +2644,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2656,6 +2664,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2673,6 +2684,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2690,6 +2704,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2793,9 +2810,9 @@
       }
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
-      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -4817,9 +4834,9 @@
       "license": "ISC"
     },
     "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -5284,6 +5301,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5305,6 +5325,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5326,6 +5349,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5347,6 +5373,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5720,21 +5749,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/playwright/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pngjs": {
@@ -6379,6 +6393,21 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/vitest": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@anokye-labs/kbexplorer-core": "^0.5.1",
-    "@anokye-labs/kbexplorer-engine": "git+https://github.com/anokye-labs/kbexplorer-engine.git#3de83e4149628651397e4335f426ff330b2ce57e",
+    "@anokye-labs/kbexplorer-engine": "github:anokye-labs/kbexplorer-engine#669c2c17",
     "@anokye-labs/kbexplorer-provider-rich-markdown": "^0.1.2",
     "@fluentui/react-components": "^9.74.2",
     "@fluentui/react-icons": "^2.0.323",

--- a/src/engine/local-loader.ts
+++ b/src/engine/local-loader.ts
@@ -336,7 +336,12 @@ export async function buildKnowledgeBaseFromManifest(
   config: KBConfig,
   env?: EngineEnv,
 ): Promise<{ graph: KBGraph; config: KBConfig; themeFileRaw: string | null }> {
-  const result = await loadKnowledgeBase(new ManifestSource(manifest, config), config, env);
+  const result = await loadKnowledgeBase(
+    new ManifestSource(manifest, config),
+    config,
+    env,
+    typeof env?.BASE_URL === 'string' ? { importBaseUrl: env.BASE_URL } : undefined,
+  );
   return { ...result, themeFileRaw: manifest.themeFileRaw ?? null };
 }
 

--- a/src/engine/remote-loader.ts
+++ b/src/engine/remote-loader.ts
@@ -32,6 +32,11 @@ export async function loadRemoteKnowledgeBase(
     ghSource.resolveConfig(),
     ghSource.resolveThemeFileRaw(),
   ])
-  const result = await loadKnowledgeBase(ghSource, config, env)
+  const result = await loadKnowledgeBase(
+    ghSource,
+    config,
+    env,
+    typeof env?.BASE_URL === 'string' ? { importBaseUrl: env.BASE_URL } : undefined,
+  )
   return { ...result, themeFileRaw: themeFileRaw ?? null }
 }


### PR DESCRIPTION
## Summary
- pin `@anokye-labs/kbexplorer-engine` to the engine commit that adds the optional `importBaseUrl` passthrough
- pass the existing `env.BASE_URL` through both template loader entry points so `loadKnowledgeBase` receives `importBaseUrl` when available

See anokye-labs/kbexplorer-engine#6
See anokye-labs/kbexplorer-template#472