### PR TITLE
feat: shim-swap sqlite runtime + inject browser wasm locator (slice 5/5 STEP B)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.4.1",
       "dependencies": {
         "@anokye-labs/kbexplorer-core": "^0.5.1",
-        "@anokye-labs/kbexplorer-engine": "git+https://github.com/anokye-labs/kbexplorer-engine.git#749da622b46abce47b1a856c8b3b74391907cc98",
+        "@anokye-labs/kbexplorer-engine": "git+https://github.com/anokye-labs/kbexplorer-engine.git#27bff04e483e68cdf1d2d5b56a24d7b71130f742",
         "@anokye-labs/kbexplorer-provider-rich-markdown": "^0.1.2",
         "@fluentui/react-components": "^9.74.2",
         "@fluentui/react-icons": "^2.0.323",
@@ -73,8 +73,8 @@
     },
     "node_modules/@anokye-labs/kbexplorer-engine": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/anokye-labs/kbexplorer-engine.git#749da622b46abce47b1a856c8b3b74391907cc98",
-      "integrity": "sha512-o4XfUE5bGr9gitmkbXF5+vyuKX0GN8m4d26eAHcwgfOOHXvotPNkaMcbl1QrmYhh86PBmwKodvWbCtGExmecBw==",
+      "resolved": "git+ssh://git@github.com/anokye-labs/kbexplorer-engine.git#27bff04e483e68cdf1d2d5b56a24d7b71130f742",
+      "integrity": "sha512-1h2IiHD4e3ya8/L5i3pXw+BBdSALMw7W+DcwoHlB9yIRonSbZUIVxUW+yk9EkRfHZ7pzzlFsJfj4a04QUfb77A==",
       "license": "MIT",
       "dependencies": {
         "@anokye-labs/kbexplorer-core": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@anokye-labs/kbexplorer-core": "^0.5.1",
-    "@anokye-labs/kbexplorer-engine": "git+https://github.com/anokye-labs/kbexplorer-engine.git#749da622b46abce47b1a856c8b3b74391907cc98",
+    "@anokye-labs/kbexplorer-engine": "git+https://github.com/anokye-labs/kbexplorer-engine.git#27bff04e483e68cdf1d2d5b56a24d7b71130f742",
     "@anokye-labs/kbexplorer-provider-rich-markdown": "^0.1.2",
     "@fluentui/react-components": "^9.74.2",
     "@fluentui/react-icons": "^2.0.323",

--- a/src/engine/__tests__/boundary.test.ts
+++ b/src/engine/__tests__/boundary.test.ts
@@ -7,8 +7,12 @@ const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..', '
 const ENGINE_ROOT = join(REPO_ROOT, 'src', 'engine');
 const FORBIDDEN_ENGINE_IMPORT_PREFIXES = ['src/representation', 'src/views', 'src/components', 'src/theme'];
 const FORBIDDEN_ENGINE_BARE_SPECIFIERS = ['react', 'react-dom', 'vis-network', 'vis-data'];
-// Allowed until #463 removes the Node-store sqlite wasm shim.
-const ALLOWED_ENGINE_PLATFORM_EXEMPTIONS = ['src/engine/store/sqlite-runtime.ts'];
+// The graph store's sql.js wasm binary must be resolved via a Vite `?url`
+// import somewhere in the app (#472/#473, slice 5/5 STEP B) — this is the one
+// legitimate composition-root exemption, isolated to its own file so the
+// engine-facing `sqlite-runtime.ts` shim and the rest of `src/engine/` stay
+// platform-pure.
+const ALLOWED_ENGINE_PLATFORM_EXEMPTIONS = ['src/engine/store/browser-wasm.ts'];
 const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs']);
 
 const toRepoRelative = (filePath: string): string =>

--- a/src/engine/local-loader.ts
+++ b/src/engine/local-loader.ts
@@ -22,6 +22,7 @@ import { loadKnowledgeBase } from './loader';
 import type { GHTreeItem } from '../api';
 import type { EngineEnv } from './env';
 import type { RepoManifest } from '@anokye-labs/kbexplorer-engine/sources';
+import { browserWasmLocateFile } from './store/browser-wasm';
 
 // ── Manifest Types ─────────────────────────────────────────
 
@@ -288,7 +289,10 @@ export async function buildKnowledgeBaseFromManifest(
     new ManifestSource(manifest, config),
     config,
     env,
-    typeof env?.BASE_URL === 'string' ? { importBaseUrl: env.BASE_URL } : undefined,
+    {
+      ...(typeof env?.BASE_URL === 'string' ? { importBaseUrl: env.BASE_URL } : {}),
+      graphStore: { locateFile: browserWasmLocateFile },
+    },
   );
   return { ...result, themeFileRaw: manifest.themeFileRaw ?? null };
 }

--- a/src/engine/remote-loader.ts
+++ b/src/engine/remote-loader.ts
@@ -16,6 +16,7 @@ import { GitHubApiSource, type ResolutionPreset } from './sources/github-api-sou
 import { loadKnowledgeBase } from './loader'
 import type { EngineEnv } from './env'
 import { localStorageCacheStore } from '../api/github'
+import { browserWasmLocateFile } from './store/browser-wasm'
 
 export type { ResolutionPreset }
 
@@ -40,7 +41,10 @@ export async function loadRemoteKnowledgeBase(
     ghSource,
     config,
     env,
-    typeof env?.BASE_URL === 'string' ? { importBaseUrl: env.BASE_URL } : undefined,
+    {
+      ...(typeof env?.BASE_URL === 'string' ? { importBaseUrl: env.BASE_URL } : {}),
+      graphStore: { locateFile: browserWasmLocateFile },
+    },
   )
   return { ...result, themeFileRaw: themeFileRaw ?? null }
 }

--- a/src/engine/store/browser-wasm.ts
+++ b/src/engine/store/browser-wasm.ts
@@ -1,0 +1,33 @@
+/**
+ * Browser wasm composition root for the graph store's sql.js runtime.
+ *
+ * The engine's `SQLiteGraphStore` (anokye-labs/kbexplorer-template#473,
+ * slice 5/5 STEP B) is Node-compatible and boundary-pure: it accepts an
+ * optional `locateFile` resolver instead of owning a Vite `?url` import
+ * itself. Vite's `?url` suffix only means something inside a Vite build, so
+ * it stays template-side — this is the ONE file in the codebase that imports
+ * it for the graph store. The resolved absolute/dev-server path is then
+ * injected into the engine at the loader call sites (`remote-loader.ts` /
+ * `local-loader.ts`) so `SQLiteGraphStore.create` can find the wasm binary
+ * without the engine ever touching Vite-specific import syntax.
+ */
+import wasmUrl from 'sql.js/dist/sql-wasm.wasm?url';
+
+/**
+ * Moved verbatim from the old `sqlite-runtime.ts` (pre-slice-5). During
+ * `vite dev`, Vite serves `?url` imports for files under `node_modules` as
+ * an absolute dev-server path (e.g. `/node_modules/sql.js/dist/sql-wasm.wasm`)
+ * that isn't resolvable relative to the page origin without the project
+ * root prefix; `initSqlJs`'s `locateFile` callback receives that raw path,
+ * so we prefix it with `process.cwd()` in that dev-server case.
+ */
+function resolveSqlJsWasmPath(url: string): string {
+  const maybeProcess = (globalThis as { process?: { cwd?: () => string } }).process;
+  if (url.startsWith('/node_modules/') && maybeProcess?.cwd) {
+    return `${maybeProcess.cwd()}${url}`;
+  }
+  return url;
+}
+
+/** `locateFile` resolver for the engine's `loadSqlJs`/`SQLiteGraphStore.create`. */
+export const browserWasmLocateFile = (): string => resolveSqlJsWasmPath(wasmUrl);

--- a/src/engine/store/sqlite-runtime.ts
+++ b/src/engine/store/sqlite-runtime.ts
@@ -1,93 +1,13 @@
-import initSqlJs from 'sql.js';
-import type { Database, SqlJsStatic } from 'sql.js';
-import wasmUrl from 'sql.js/dist/sql-wasm.wasm?url';
-
-export interface SqliteByteStore {
-  load(): Promise<Uint8Array | undefined>;
-  save(bytes: Uint8Array): Promise<void>;
-}
-
-const DB_NAME = 'kbexplorer-graph-store';
-const STORE_NAME = 'sqlite';
-const DB_KEY = 'graph-store.sqlite';
-
-let sqlModulePromise: Promise<SqlJsStatic> | undefined;
-
-export async function loadSqlJs(): Promise<SqlJsStatic> {
-  sqlModulePromise ??= initSqlJs({
-    locateFile: () => resolveSqlJsWasmPath(wasmUrl),
-  });
-  return sqlModulePromise;
-}
-
-export async function openPersistedDatabase(
-  byteStore: SqliteByteStore = new IndexedDbSqliteByteStore(),
-): Promise<{ db: Database; persist: () => Promise<void> }> {
-  const SQL = await loadSqlJs();
-  const bytes = await byteStore.load();
-  const db = bytes ? new SQL.Database(bytes) : new SQL.Database();
-  return {
-    db,
-    persist: async () => {
-      await byteStore.save(db.export());
-    },
-  };
-}
-
-export class MemorySqliteByteStore implements SqliteByteStore {
-  private bytes?: Uint8Array;
-
-  async load(): Promise<Uint8Array | undefined> {
-    return this.bytes ? new Uint8Array(this.bytes) : undefined;
-  }
-
-  async save(bytes: Uint8Array): Promise<void> {
-    this.bytes = new Uint8Array(bytes);
-  }
-}
-
-export class IndexedDbSqliteByteStore implements SqliteByteStore {
-  async load(): Promise<Uint8Array | undefined> {
-    const db = await openIndexedDb();
-    return requestToPromise<Uint8Array | undefined>(
-      db.transaction(STORE_NAME, 'readonly').objectStore(STORE_NAME).get(DB_KEY),
-    ).finally(() => db.close());
-  }
-
-  async save(bytes: Uint8Array): Promise<void> {
-    const db = await openIndexedDb();
-    await requestToPromise(
-      db.transaction(STORE_NAME, 'readwrite').objectStore(STORE_NAME).put(bytes, DB_KEY),
-    ).finally(() => db.close());
-  }
-}
-
-function openIndexedDb(): Promise<IDBDatabase> {
-  if (!globalThis.indexedDB) {
-    throw new Error('Graph store SQLite persistence requires IndexedDB support.');
-  }
-
-  return new Promise((resolve, reject) => {
-    const request = globalThis.indexedDB.open(DB_NAME, 1);
-    request.onupgradeneeded = () => {
-      request.result.createObjectStore(STORE_NAME);
-    };
-    request.onsuccess = () => resolve(request.result);
-    request.onerror = () => reject(request.error ?? new Error('Failed to open graph store IndexedDB database.'));
-  });
-}
-
-function requestToPromise<T>(request: IDBRequest<T>): Promise<T> {
-  return new Promise((resolve, reject) => {
-    request.onsuccess = () => resolve(request.result);
-    request.onerror = () => reject(request.error ?? new Error('IndexedDB graph store request failed.'));
-  });
-}
-
-function resolveSqlJsWasmPath(url: string): string {
-  const maybeProcess = (globalThis as { process?: { cwd?: () => string } }).process;
-  if (url.startsWith('/node_modules/') && maybeProcess?.cwd) {
-    return `${maybeProcess.cwd()}${url}`;
-  }
-  return url;
-}
+/**
+ * Shim — re-exports from `@anokye-labs/kbexplorer-engine/store` (moved in
+ * anokye-labs/kbexplorer-template#472/#473, slice 5/5 STEP B). The wasm path
+ * resolution (the one legitimate Vite URL-suffix import) stays template-side
+ * — see `./browser-wasm.ts`.
+ */
+export {
+  IndexedDbSqliteByteStore,
+  MemorySqliteByteStore,
+  loadSqlJs,
+  openPersistedDatabase,
+  type SqliteByteStore,
+} from '@anokye-labs/kbexplorer-engine/store';


### PR DESCRIPTION
Slice 5/5 STEP B — template shim-swap + browser wasm injection, following STEP A's merge of the engine's real `SQLiteGraphStore` + Node-compatible sqlite runtime (`27bff04e483e68cdf1d2d5b56a24d7b71130f742`).

## Changes

1. **Re-pin** `@anokye-labs/kbexplorer-engine` to `27bff04e483e68cdf1d2d5b56a24d7b71130f742` (minimal lockfile delta — engine pin only, 6 lines).
2. **New `src/engine/store/browser-wasm.ts`** — the *only* file in the template that now imports `sql.js/dist/sql-wasm.wasm` with a Vite URL-suffix. Carries the verbatim dev-server path resolution logic moved from the old `sqlite-runtime.ts`, and exports `browserWasmLocateFile()`.
3. **`src/engine/store/sqlite-runtime.ts`** converted to a thin re-export shim from `@anokye-labs/kbexplorer-engine/store` (`loadSqlJs`, `openPersistedDatabase`, `MemorySqliteByteStore`, `IndexedDbSqliteByteStore`, `SqliteByteStore` type) — verified all are exported from the engine's `./store` barrel at the pinned SHA before finalizing.
4. **`src/engine/store/index.ts`** — unchanged; still compiles and exports the same surface since it re-exports from `./sqlite-runtime`.
5. **Loader wiring**: both `remote-loader.ts` and `local-loader.ts` now pass `graphStore: { locateFile: browserWasmLocateFile }` in the `loadKnowledgeBase` options object, alongside the existing `importBaseUrl` conditional (preserved exactly — only present when `env?.BASE_URL` is a string). `loader.ts` itself is untouched (still the pure re-export shim exporting `registerProviders`/`loadKnowledgeBase`).
6. **`src/engine/__tests__/boundary.test.ts`** — moved the Vite-suffix platform exemption from `sqlite-runtime.ts` to `browser-wasm.ts` to match the new composition root (this is the one legitimate exemption; everything else in `src/engine/` stays platform-pure).

## Guardrails honored

- `?url`-suffix import appears in **exactly one file**: `src/engine/store/browser-wasm.ts`.
- `tests/golden/graph-store-parity.test.ts` passes **byte-for-byte unchanged** — it doesn't touch `sqlite-runtime` internals (uses an in-test `MemoryGraphStore`), so it was unaffected, confirmed by running it in isolation before/after.
- No golden re-baselined.

## Verification

- `npx tsc -b` — clean.
- `npm test` — **708/708 green** (incl. `graph-store-parity` golden unchanged, `boundary.test.ts` green after the exemption-path fix).
- `npm run lint` — 0 errors (same 3 pre-existing warnings, unrelated to this change).
- `npm run build` — succeeds; confirmed `dist/assets/sql-wasm-*.wasm` is correctly emitted via the sole `?url` import.

See anokye-labs/kbexplorer-template#473

Holding for independent verify + merge — not self-merged.
