### PR TITLE
feat(view-kit): publish @anokye-labs/kbexplorer-view-kit render contract (refs #503)

### DIFF
--- a/.github/workflows/publish-view-kit.yml
+++ b/.github/workflows/publish-view-kit.yml
@@ -1,0 +1,67 @@
+name: Publish view-kit to npm
+
+# Publishes the `@anokye-labs/kbexplorer-view-kit` workspace subpackage on its own
+# tag namespace, INDEPENDENTLY of any template release/version tag. The template
+# app package itself is private and never published; only view-kit is.
+#
+# Cut a release by pushing a tag shaped `view-kit-v<semver>` (e.g.
+# `view-kit-v0.1.0`) whose version matches packages/view-kit/package.json.
+on:
+  push:
+    tags: ['view-kit-v*']
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+      # Root install links the workspace and runs view-kit's `prepare` (tsc build).
+      - run: npm ci
+      - name: Test view-kit
+        run: npm test --workspace @anokye-labs/kbexplorer-view-kit
+
+  publish:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      - run: npm ci
+
+      # Build the package explicitly (in addition to the `prepare` hook) so
+      # dist/ is present regardless of workspace lifecycle ordering.
+      - name: Build view-kit
+        run: npm run build --workspace @anokye-labs/kbexplorer-view-kit
+
+      # Node 22's bundled npm (10.x) is below the 11.5.1 minimum required for
+      # OIDC trusted publishing (npmjs.com). Upgrade npm here (publish job only)
+      # so OIDC auth can work at all.
+      - run: npm install -g npm@latest
+
+      # OIDC trusted publishing (npmjs.com) is the auth path for this workflow;
+      # npm tries OIDC first and only falls back to _authToken if that fails, so
+      # this doesn't affect the OIDC path either way. NODE_AUTH_TOKEN is set to
+      # an EXPLICIT empty string (not omitted): actions/setup-node always writes
+      # `_authToken=${NODE_AUTH_TOKEN}` into .npmrc, and per npm's own docs an
+      # env var that is truly undefined is left as the literal unresolved
+      # "${NODE_AUTH_TOKEN}" string (a bogus non-empty token), whereas a
+      # defined-but-empty var substitutes cleanly to "". A clean "" resolves to
+      # no classic token (clean ENEEDAUTH if OIDC isn't configured yet); an
+      # unresolved placeholder would be sent as a literal invalid token instead,
+      # which registries reject with a more confusing error.
+      - name: Publish
+        run: npm publish --workspace @anokye-labs/kbexplorer-view-kit --access public
+        env:
+          NODE_AUTH_TOKEN: ''

--- a/.github/workflows/publish-view-kit.yml
+++ b/.github/workflows/publish-view-kit.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
           node-version: 22
       # Root install links the workspace and runs view-kit's `prepare` (tsc build).
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
@@ -46,9 +46,9 @@ jobs:
         run: npm run build --workspace @anokye-labs/kbexplorer-view-kit
 
       # Node 22's bundled npm (10.x) is below the 11.5.1 minimum required for
-      # OIDC trusted publishing (npmjs.com). Upgrade npm here (publish job only)
-      # so OIDC auth can work at all.
-      - run: npm install -g npm@latest
+      # OIDC trusted publishing (npmjs.com). Pin to that exact minimum (rather
+      # than a floating `@latest`) so the publish job stays deterministic.
+      - run: npm install -g npm@11.5.1
 
       # OIDC trusted publishing (npmjs.com) is the auth path for this workflow;
       # npm tries OIDC first and only falls back to _authToken if that fails, so

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -65,6 +65,51 @@ providers:
   `config.options`.
 - `cluster` / `name` — surfaced on `config` for your factory to use.
 
+## The render half (lenses)
+
+A provider has two halves. The **data half** above (its `.` entry) depends only
+on `@anokye-labs/kbexplorer-core` and stays pure ESM — no DOM, no React. The
+optional **render half** ships the provider's **lenses**: the viewers and
+block renderers that draw its typed nodes.
+
+The render half is a separate module named by `views` on the data module (the
+core `ProviderModule.views` specifier — e.g. `views: './views'`). It
+default-exports a `ProviderViews` and types against the published render
+contract, **`@anokye-labs/kbexplorer-view-kit`** — the one place `ViewerProps`,
+`ViewerComponent`, `LazyViewer`, `BlockRenderer`, `BlockOutput`, `ProviderViews`,
+and `VIEW_API_VERSION` are defined (React + Fluent are inherently UX-stack
+specific, so this contract lives outside core):
+
+```ts
+import type { ProviderViews } from '@anokye-labs/kbexplorer-view-kit'
+
+const views: ProviderViews = {
+  viewers: { myType: ({ node }) => /* ... */ },
+  blockRenderers: { myBlock: (block) => /* pure BlockOutput decision */ },
+}
+export default views
+```
+
+Two hard rules keep this clean:
+
+- **Module-graph isolation.** Importing the `.` (data) entry MUST NOT evaluate
+  the render module graph. The data entry stays pure ESM / core-only and never
+  imports view-kit or React; data-only hosts (the CLI's Node ingest, the
+  render-free engine) load it untouched. A render-capable host dynamic-imports
+  the `./views` entry to mount the lenses. `views` is an **offer**, not a
+  requirement: a dual-mode provider MUST NOT list the `'viewers'` capability.
+- **Build only the views entry.** A **no-build provider** authors viewers with
+  `React.createElement` (no JSX, no precompile). A **JSX provider** precompiles
+  *only* its `./views` entry to ESM; the `.` data entry is left as pure
+  ESM/core-only.
+
+`npm install @anokye-labs/kbexplorer-view-kit` gives a provider compile-time
+checking of its `./views` entry. Registry semantics are part of the contract:
+viewer/renderer keys are **case-insensitive** and **last registration wins** (a
+downstream provider can override a built-in). See the
+[view-kit README](https://www.npmjs.com/package/@anokye-labs/kbexplorer-view-kit)
+for the full surface and no-build / JSX authoring examples.
+
 ## Ordering
 
 Providers declare `dependencies` (other provider ids). The registry

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,14 @@
       "name": "kbexplorer-template",
       "version": "0.4.1",
       "hasInstallScript": true,
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
-        "@anokye-labs/kbexplorer-core": "^0.5.1",
+        "@anokye-labs/kbexplorer-core": "^0.6.0",
         "@anokye-labs/kbexplorer-engine": "git+https://github.com/anokye-labs/kbexplorer-engine.git#27bff04e483e68cdf1d2d5b56a24d7b71130f742",
         "@anokye-labs/kbexplorer-provider-rich-markdown": "^0.1.2",
+        "@anokye-labs/kbexplorer-view-kit": "*",
         "@fluentui/react-components": "^9.74.2",
         "@fluentui/react-icons": "^2.0.323",
         "@octokit/rest": "^22.0.1",
@@ -65,12 +69,12 @@
       }
     },
     "node_modules/@anokye-labs/kbexplorer-core": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@anokye-labs/kbexplorer-core/-/kbexplorer-core-0.5.1.tgz",
-      "integrity": "sha512-cxt+mSTuUZqGDpl5uewgJlWAV6YULoO3zmGSJghPWc4RE03BLUjcOlNkbzGE7iSYfHOjh96wHy22ywu3gSMPEQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@anokye-labs/kbexplorer-core/-/kbexplorer-core-0.6.0.tgz",
+      "integrity": "sha512-2f/TlPpj+K3MH5sppS/KSBRGwZCsAW1yeaJhpSWFCj6Tu4RPJZOC9ZwUHmAHneqOMJoLbWUcI0QCOIx9U9TszQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/@anokye-labs/kbexplorer-engine": {
@@ -90,6 +94,15 @@
         "node": ">=20"
       }
     },
+    "node_modules/@anokye-labs/kbexplorer-engine/node_modules/@anokye-labs/kbexplorer-core": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@anokye-labs/kbexplorer-core/-/kbexplorer-core-0.5.2.tgz",
+      "integrity": "sha512-P+Wyer2Q6jJyVgjHcW6iU4yIobYkHGaMA7rUFHnHUII1tpMyU30N3AxrdgxsKnhEpOZK8LNrMoFsG+L0W4KIaA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      }
+    },
     "node_modules/@anokye-labs/kbexplorer-example-quotes": {
       "resolved": "examples/quotes-provider",
       "link": true
@@ -104,6 +117,15 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@anokye-labs/kbexplorer-provider-rich-markdown/node_modules/@anokye-labs/kbexplorer-core": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@anokye-labs/kbexplorer-core/-/kbexplorer-core-0.5.2.tgz",
+      "integrity": "sha512-P+Wyer2Q6jJyVgjHcW6iU4yIobYkHGaMA7rUFHnHUII1tpMyU30N3AxrdgxsKnhEpOZK8LNrMoFsG+L0W4KIaA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@anokye-labs/kbexplorer-search": {
@@ -133,6 +155,10 @@
         "node": ">=20"
       }
     },
+    "node_modules/@anokye-labs/kbexplorer-view-kit": {
+      "resolved": "packages/view-kit",
+      "link": true
+    },
     "node_modules/@anokye-labs/kbx": {
       "version": "0.1.0",
       "resolved": "git+ssh://git@github.com/anokye-labs/kbexplorer-cli.git#d46e558c832e90882067aefaf9910ee58ab9e54a",
@@ -150,6 +176,16 @@
       "bin": {
         "kbx": "bin/kbx.js"
       },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@anokye-labs/kbx/node_modules/@anokye-labs/kbexplorer-core": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@anokye-labs/kbexplorer-core/-/kbexplorer-core-0.5.2.tgz",
+      "integrity": "sha512-P+Wyer2Q6jJyVgjHcW6iU4yIobYkHGaMA7rUFHnHUII1tpMyU30N3AxrdgxsKnhEpOZK8LNrMoFsG+L0W4KIaA==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=22"
       }
@@ -8309,6 +8345,26 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "packages/view-kit": {
+      "name": "@anokye-labs/kbexplorer-view-kit",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@anokye-labs/kbexplorer-core": "^0.6.0"
+      },
+      "devDependencies": {
+        "@types/react": "^19.2.17",
+        "react": "^19.2.5",
+        "typescript": "~6.0.2",
+        "vitest": "^4.1.9"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.4.1",
   "type": "module",
+  "workspaces": [
+    "packages/*"
+  ],
   "engines": {
     "node": ">=22"
   },
@@ -45,9 +48,10 @@
     "explore:dtu": "node scripts/explore-dtu.mjs"
   },
   "dependencies": {
-    "@anokye-labs/kbexplorer-core": "^0.5.1",
+    "@anokye-labs/kbexplorer-core": "^0.6.0",
     "@anokye-labs/kbexplorer-engine": "git+https://github.com/anokye-labs/kbexplorer-engine.git#27bff04e483e68cdf1d2d5b56a24d7b71130f742",
     "@anokye-labs/kbexplorer-provider-rich-markdown": "^0.1.2",
+    "@anokye-labs/kbexplorer-view-kit": "*",
     "@fluentui/react-components": "^9.74.2",
     "@fluentui/react-icons": "^2.0.323",
     "@octokit/rest": "^22.0.1",

--- a/packages/view-kit/README.md
+++ b/packages/view-kit/README.md
@@ -1,0 +1,124 @@
+# @anokye-labs/kbexplorer-view-kit
+
+The **render contract** for kbexplorer provider-shipped lenses — the UX-stack
+(React + [Fluent](https://react.fluentui.dev/)) half of a dual-half provider.
+
+A provider's **data half** (its `.` entry) depends only on
+[`@anokye-labs/kbexplorer-core`](https://www.npmjs.com/package/@anokye-labs/kbexplorer-core)
+and stays pure ESM / DOM-free. Its **render half** (the `./views` entry named by
+`ProviderModule.views` in core) is inherently React + Fluent specific, so its
+contract lives here — published, versioned in lockstep with the surfaces that
+consume it, and imported by both third-party providers and the host template so
+there is **exactly one definition**.
+
+```
+@anokye-labs/kbexplorer-core        →  pure data (KBNode, NodeLens, CalendarModel, ProviderModule.views specifier)
+@anokye-labs/kbexplorer-view-kit    →  render contract (this package): ViewerProps, BlockRenderer, ProviderViews, VIEW_API_VERSION
+```
+
+## Install
+
+```sh
+npm install @anokye-labs/kbexplorer-view-kit
+```
+
+- **React is a peer dependency** — supported majors: **React 18 and 19**
+  (`^18.0.0 || ^19.0.0`). The consuming app provides React.
+- **No Fluent runtime dependency.** Fluent design tokens are consumed as **CSS
+  custom properties** only; this package never imports `@fluentui/react-components`.
+  The optional presentation primitives emit `kb-*` class hooks the host styles.
+
+## Exports
+
+| Export | Kind | Purpose |
+| --- | --- | --- |
+| `ViewerProps` | type | Props handed to a viewer — `{ node: KBNode }` (core `KBNode`). |
+| `ViewerComponent` | type | `(props: ViewerProps) => ReactNode` — a viewer. |
+| `LazyViewer` | type | `() => Promise<{ default: ViewerComponent }>` — a zero-arg, code-split loader (`React.lazy` shape). |
+| `BlockRange` | type | Character offsets of a block in the source. |
+| `RichMarkdownBlock` | type | Pure-data shape of an embedded block a renderer consumes. |
+| `BlockOutput` | type | A renderer's pure decision: `mermaid` \| `svg` \| `viewer` \| `unsupported`. |
+| `BlockRenderContext` | type | Context threaded to a renderer (e.g. `isDark`). |
+| `BlockRenderer` | type | `(block, ctx?) => BlockOutput`. |
+| `ProviderViews` | type | The shape a `./views` entry default-exports: `{ viewers?, blockRenderers? }`. |
+| `VIEW_API_VERSION` | const | The view-contract version (semver), bumped independently of core's `PROVIDER_API_VERSION`. |
+| `checkViewCompatibility` | fn | Guard a render half's declared version against the host's. |
+| `EntityHeader`, `Row`, `Pill`, `ScalarList` | components | Optional house-style presentation primitives. |
+
+### `BlockOutput`
+
+```ts
+type BlockOutput =
+  | { type: 'mermaid'; source: string; title?: string }
+  | { type: 'svg'; svg: string; title?: string }
+  | { type: 'viewer'; key: string; data: unknown; title?: string }
+  | { type: 'unsupported'; kind: string; source: string; reason: string };
+```
+
+The `viewer` member delegates a structured block to a viewer resolved by registry
+`key`, handing it a pure-data `data` payload (e.g. a `'calendar-month'` viewer
+rendering a core `CalendarModel`).
+
+## Registry semantics (part of the contract)
+
+When a host merges a provider's `ProviderViews` into its registries:
+
+- **Keys are case-insensitive.** A viewer registered for `'Person'` resolves for
+  `'person'` / `'PERSON'`; a block renderer for `'Mermaid'` resolves for
+  `'mermaid'`. Whitespace-only keys are rejected.
+- **Last registration wins.** Registering the same key twice replaces the prior
+  entry, so a downstream provider (or the host) can override a built-in.
+
+## Authoring a `./views` entry
+
+The `./views` entry default-exports a `ProviderViews`. The `.` (data) entry stays
+pure core-only ESM and MUST NOT import this package or React — importing the data
+half must never evaluate the render module graph.
+
+### No-build provider (`React.createElement`, no JSX/precompile)
+
+```ts
+// views.js
+import { createElement } from 'react';
+/** @type {import('@anokye-labs/kbexplorer-view-kit').ProviderViews} */
+const views = {
+  viewers: {
+    quote: ({ node }) => createElement('blockquote', null, node.title),
+  },
+};
+export default views;
+```
+
+### JSX provider (precompile **only** the views entry)
+
+```tsx
+// views.tsx  — precompiled to ESM; the `.` data entry is left untouched
+import type { ProviderViews } from '@anokye-labs/kbexplorer-view-kit';
+import { EntityHeader } from '@anokye-labs/kbexplorer-view-kit';
+
+const views: ProviderViews = {
+  viewers: {
+    quote: ({ node }) => <EntityHeader label="Quote" id={node.identity} />,
+  },
+  blockRenderers: {
+    // return a pure decision — no DOM/React here
+    ics: (block) => (block.svg ? { type: 'svg', svg: block.svg } : {
+      type: 'unsupported', kind: block.kind, source: block.source,
+      reason: 'no live ICS renderer and no pre-built SVG',
+    }),
+  },
+};
+export default views;
+```
+
+## Compatibility
+
+`VIEW_API_VERSION` follows semver with same-major-compatible semantics: a
+same-major render half is compatible; a different major is breaking; a render
+half may not require a newer minor than the host supports. Use
+`checkViewCompatibility(declared, host?)` to guard before mounting a render half
+(mirrors core's `checkProviderCompatibility`).
+
+## License
+
+MIT

--- a/packages/view-kit/package.json
+++ b/packages/view-kit/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@anokye-labs/kbexplorer-view-kit",
+  "version": "0.1.0",
+  "description": "The UX-stack (React + Fluent) render contract that provider-shipped lenses type against: viewers, block renderers, the ProviderViews shape, and VIEW_API_VERSION.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/anokye-labs/kbexplorer-template.git",
+    "directory": "packages/view-kit"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "files": [
+    "dist"
+  ],
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "typecheck": "tsc -p tsconfig.build.json --noEmit",
+    "test": "vitest run",
+    "prepare": "npm run build"
+  },
+  "dependencies": {
+    "@anokye-labs/kbexplorer-core": "^0.6.0"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.17",
+    "react": "^19.2.5",
+    "typescript": "~6.0.2",
+    "vitest": "^4.1.9"
+  }
+}

--- a/packages/view-kit/src/blocks.ts
+++ b/packages/view-kit/src/blocks.ts
@@ -1,0 +1,80 @@
+/**
+ * The **block-render contract** — the render half of rich-Markdown / structured
+ * blocks. A provider's `./views` entry ships `blockRenderers` typed against these
+ * declarations; the host's block-renderer registry resolves a block `kind` to a
+ * renderer and turns the returned {@link BlockOutput} decision into pixels.
+ *
+ * Renderers return a **pure decision** (no DOM/React), so the registry stays
+ * node-testable; the React/DOM layer turns the decision into an element (live
+ * Mermaid SVG, an inline pre-built SVG, a delegated viewer, or a raw-code
+ * fallback).
+ */
+
+/** Character offsets of a block within the original markdown source. */
+export interface BlockRange {
+  /** Inclusive start offset into the original markdown. */
+  start: number;
+  /** Exclusive end offset into the original markdown. */
+  end: number;
+}
+
+/**
+ * One embedded block inside a rich-Markdown document.
+ *
+ * `kind` is an **open** discriminator (`'mermaid' | 'dot' | 'ics' | 'canvas' | …`)
+ * so new block kinds need no contract change. `svg` is the pre-built-SVG fallback
+ * contract: when a kind has no live renderer, the provider ships a rendered SVG
+ * so the block never degrades to a raw code dump. This type is **data only** —
+ * no DOM, no React — so it stays node-testable and is what a {@link BlockRenderer}
+ * receives.
+ */
+export interface RichMarkdownBlock {
+  /** Open block-kind discriminator, e.g. `'mermaid'`, `'dot'`, `'ics'`, `'canvas'`. */
+  kind: string;
+  /** Verbatim block source (the fenced-code body). */
+  source: string;
+  /**
+   * Content hash of `source` (e.g. `'sha256:…'`). A stable identity used for
+   * caching and as a fast-path key when matching a rendered prose fence back to
+   * its provider block. Matching also works without it (by normalized source).
+   */
+  hash?: string;
+  /** Character offsets of the block in the original markdown source. */
+  range?: BlockRange;
+  /**
+   * Pre-built SVG markup — the fallback contract for blocks with no live
+   * renderer. When present the block renders this SVG instead of raw code.
+   */
+  svg?: string;
+  /** Optional human-facing caption/label for the block. */
+  title?: string;
+}
+
+/**
+ * What a block renderer decided to produce.
+ *
+ * - `mermaid` — hand the source to the live Mermaid path (renders to SVG client-side).
+ * - `svg` — inline a pre-built SVG (the fallback contract).
+ * - `viewer` — delegate to a **viewer** resolved by registry `key`, handing it
+ *   the pure-data `data` payload (e.g. a `'calendar-month'` viewer rendering a
+ *   `CalendarModel`). This is the seam that lets a structured block render
+ *   through a full node/model viewer rather than a static SVG.
+ * - `unsupported` — no live renderer and no SVG; show the raw source as a last resort.
+ */
+export type BlockOutput =
+  | { type: 'mermaid'; source: string; title?: string }
+  | { type: 'svg'; svg: string; title?: string }
+  | { type: 'viewer'; key: string; data: unknown; title?: string }
+  | { type: 'unsupported'; kind: string; source: string; reason: string };
+
+/** Context threaded to renderers (e.g. for theme-aware live rendering). */
+export interface BlockRenderContext {
+  /** Active dark/light flag, for renderers that theme their output. */
+  isDark?: boolean;
+}
+
+/** A block renderer maps a block to a {@link BlockOutput} decision. */
+export type BlockRenderer = (
+  block: RichMarkdownBlock,
+  ctx?: BlockRenderContext,
+) => BlockOutput;

--- a/packages/view-kit/src/contract.ts
+++ b/packages/view-kit/src/contract.ts
@@ -1,0 +1,44 @@
+import type { ReactNode } from 'react';
+import type { KBNode } from '@anokye-labs/kbexplorer-core';
+
+/**
+ * Props handed to every viewer. A viewer renders a single typed {@link KBNode}
+ * — the same pure-data node contract exported by `@anokye-labs/kbexplorer-core`,
+ * so a provider's render half and its data half agree on exactly one node shape.
+ *
+ * The object is intentionally minimal (just the node) so third-party lenses stay
+ * decoupled from host internals; anything a viewer needs about a node it reads
+ * from `node.data` / `node.jsonld` / `node.entityType`.
+ */
+export interface ViewerProps {
+  /** The node to render. */
+  node: KBNode;
+}
+
+/**
+ * A **viewer** — a React function component that renders a typed node. Viewers
+ * are registered in the host's viewer registry against an `entityType` (or
+ * JSON-LD `@type`, or a {@link KBNode.lenses} `viewer` key) and resolved from it,
+ * with the host's generic structured fallback for unknown types.
+ *
+ * This is a plain `(props) => ReactNode` function so a **no-build provider** can
+ * author one with `React.createElement` (no JSX/precompile step); a JSX provider
+ * precompiles only its `./views` entry.
+ */
+export type ViewerComponent = (props: ViewerProps) => ReactNode;
+
+/**
+ * A **lazily-loaded viewer** — a zero-argument loader that resolves to a module
+ * namespace whose `default` export is the viewer. This matches the
+ * `React.lazy(() => import('./MyView'))` calling convention, so a provider can
+ * ship a heavy viewer behind a dynamic `import()` and the host can code-split it:
+ *
+ * ```ts
+ * const CalendarView: LazyViewer = () => import('./CalendarView');
+ * ```
+ *
+ * A registry accepts either an eager {@link ViewerComponent} or a `LazyViewer`;
+ * the host is responsible for turning the loader into a mounted component (e.g.
+ * via `React.lazy`).
+ */
+export type LazyViewer = () => Promise<{ default: ViewerComponent }>;

--- a/packages/view-kit/src/index.ts
+++ b/packages/view-kit/src/index.ts
@@ -1,0 +1,42 @@
+/**
+ * `@anokye-labs/kbexplorer-view-kit`
+ *
+ * The **UX-stack (React + Fluent) render contract** for kbexplorer. This is the
+ * one place a provider's **render half** — the `./views` entry it ships — types
+ * against, and the one place the host template's viewers / block renderers get
+ * their contract types from. Exactly one definition, published, versioning in
+ * lockstep with the surfaces that consume it.
+ *
+ * Where this sits in the dependency chain:
+ *   - `@anokye-labs/kbexplorer-core` — pure, dependency-free **data** contract
+ *     (KBNode / NodeLens / CalendarModel, and `ProviderModule.views`, the
+ *     *specifier* for a render entry). Core deliberately does NOT define the
+ *     render module shape.
+ *   - **this package** — the render contract that shape (`ProviderViews`) and its
+ *     parts (`ViewerProps`, `ViewerComponent`, `LazyViewer`, `BlockRenderer`,
+ *     `BlockOutput`, …) live in, plus `VIEW_API_VERSION`.
+ *
+ * React is a **peer dependency** (React 18/19). Fluent design tokens are consumed
+ * as CSS custom properties only — there is no `@fluentui/react-components` runtime
+ * dependency in this package.
+ */
+
+export type { ViewerProps, ViewerComponent, LazyViewer } from './contract.js';
+
+export type {
+  BlockRange,
+  RichMarkdownBlock,
+  BlockOutput,
+  BlockRenderContext,
+  BlockRenderer,
+} from './blocks.js';
+
+export type { ProviderViews } from './provider-views.js';
+
+export {
+  VIEW_API_VERSION,
+  checkViewCompatibility,
+  type ViewCompatibility,
+} from './version.js';
+
+export { EntityHeader, Row, ScalarList, Pill } from './primitives.js';

--- a/packages/view-kit/src/primitives.tsx
+++ b/packages/view-kit/src/primitives.tsx
@@ -1,0 +1,90 @@
+import type { ReactNode } from 'react';
+
+/**
+ * Shared **house-style presentation primitives** so third-party lenses match the
+ * built-in viewers by default.
+ *
+ * These are **className-styled only** — no pixel sizing, no inline colors, no
+ * Fluent runtime import. They emit the same `kb-structured-*` / `kb-pill-*`
+ * class hooks the host app styles (via Fluent design tokens exposed as CSS
+ * custom properties), so a viewer shipped by an external provider renders
+ * identically to a built-in one and stays SSR-safe under `renderToStaticMarkup`.
+ */
+
+/** A header strip showing the entity kind label and its JSON-LD `@id`. */
+export function EntityHeader({
+  label,
+  id,
+  native,
+}: {
+  label: string;
+  id?: string;
+  native?: string;
+}) {
+  return (
+    <div className="kb-structured-header">
+      <span className="kb-structured-type" title="JSON-LD @type">
+        {label}
+      </span>
+      {native && native.toLowerCase() !== label.toLowerCase() && (
+        <span
+          className="kb-structured-native"
+          title={`Native term — this repo calls it "${native}", unified to the canonical type`}
+        >
+          {native}
+        </span>
+      )}
+      {id && (
+        <code className="kb-structured-id" title="JSON-LD @id">
+          {id}
+        </code>
+      )}
+    </div>
+  );
+}
+
+/** A key/value table row, rendered only when `children` is truthy. */
+export function Row({ label, children }: { label: string; children: ReactNode }) {
+  if (
+    children == null ||
+    children === '' ||
+    (Array.isArray(children) && children.length === 0)
+  ) {
+    return null;
+  }
+  return (
+    <tr>
+      <th scope="row" className="kb-structured-key">
+        {label}
+      </th>
+      <td className="kb-structured-value">{children}</td>
+    </tr>
+  );
+}
+
+/** A bullet list of scalar values. */
+export function ScalarList({ items }: { items: unknown[] }) {
+  if (!items.length) return null;
+  return (
+    <ul className="kb-structured-list">
+      {items.map((it, i) => (
+        <li key={i}>{String(it)}</li>
+      ))}
+    </ul>
+  );
+}
+
+/** A small status / RAG pill whose tone maps to a className (no inline color). */
+export function Pill({ value }: { value: string }) {
+  const tone = ragTone(value);
+  return <span className={`kb-pill kb-pill-${tone}`}>{value}</span>;
+}
+
+/** Map a status / RAG string to a tone class suffix. */
+function ragTone(value: string): 'green' | 'amber' | 'red' | 'neutral' {
+  const v = value.toLowerCase();
+  if (/(green|on-track|done|complete|shipped|healthy)/.test(v)) return 'green';
+  if (/(amber|yellow|at-risk|warn|in-progress|pending)/.test(v)) return 'amber';
+  if (/(red|blocked|off-track|fail|critical)/.test(v)) return 'red';
+  return 'neutral';
+}

--- a/packages/view-kit/src/provider-views.ts
+++ b/packages/view-kit/src/provider-views.ts
@@ -1,0 +1,44 @@
+import type { ViewerComponent, LazyViewer } from './contract.js';
+import type { BlockRenderer } from './blocks.js';
+
+/**
+ * The shape a provider's **render half** (its `./views` entry) default-exports.
+ * A render-capable host dynamic-imports the specifier declared on the provider's
+ * data module (`ProviderModule.views` in `@anokye-labs/kbexplorer-core`) and
+ * mounts the contributions it finds here.
+ *
+ * Both fields are optional and additive — a provider may ship only viewers, only
+ * block renderers, both, or (by omitting the `./views` entry entirely) neither.
+ *
+ * **Registry semantics (part of the contract).** When the host merges these into
+ * its registries:
+ *   - **Keys are case-insensitive.** A viewer registered for `'Person'` resolves
+ *     for `'person'` / `'PERSON'`; a block renderer for `'Mermaid'` resolves for
+ *     `'mermaid'`. Whitespace-only keys are rejected.
+ *   - **Last registration wins.** Registering the same key twice replaces the
+ *     prior entry, so a downstream provider (or the host) can override a built-in.
+ *
+ * @example
+ * ```ts
+ * // provider ./views entry
+ * import type { ProviderViews } from '@anokye-labs/kbexplorer-view-kit';
+ * import { createElement } from 'react';
+ *
+ * const views: ProviderViews = {
+ *   viewers: {
+ *     quote: ({ node }) => createElement('blockquote', null, node.title),
+ *   },
+ * };
+ * export default views;
+ * ```
+ */
+export interface ProviderViews {
+  /**
+   * Node/entity viewers keyed by `entityType` / JSON-LD `@type` / lens `viewer`
+   * key. Each value is an eager {@link ViewerComponent} or a {@link LazyViewer}
+   * loader the host code-splits.
+   */
+  viewers?: Record<string, ViewerComponent | LazyViewer>;
+  /** Structured-block renderers keyed by block `kind`. */
+  blockRenderers?: Record<string, BlockRenderer>;
+}

--- a/packages/view-kit/src/version.ts
+++ b/packages/view-kit/src/version.ts
@@ -1,0 +1,98 @@
+/**
+ * Versioning for the **view (render) contract**.
+ *
+ * `VIEW_API_VERSION` is bumped **independently** of core's `PROVIDER_API_VERSION`:
+ * the data-side provider contract and the UX-stack render contract evolve on
+ * their own cadences. A provider's `./views` entry may declare the view-contract
+ * version it was authored against so a render-capable host can guard against
+ * drift before mounting it, exactly mirroring core's
+ * `checkProviderCompatibility` semantics.
+ */
+
+/**
+ * Current version of the view (render) contract — the surface a provider's
+ * `./views` entry (viewers + block renderers + {@link ProviderViews}) is authored
+ * against. Versioned independently of core's `PROVIDER_API_VERSION`.
+ *
+ * Semantics (semver): a same-major version is compatible; a different major is
+ * breaking. A provider may not require a newer minor than the host supports.
+ */
+export const VIEW_API_VERSION = '1.0.0' as const;
+
+/** Result of a {@link checkViewCompatibility} check. */
+export interface ViewCompatibility {
+  /** Whether the render half is safe for the host to mount. */
+  compatible: boolean;
+  /** Human-readable reason when `compatible` is `false`. */
+  reason?: string;
+}
+
+interface SemVer {
+  major: number;
+  minor: number;
+  patch: number;
+}
+
+/** Parse the `major.minor.patch` core of a semver string; ignores pre-release. */
+function parseSemVer(version: string): SemVer | null {
+  const match = /^\s*(\d+)\.(\d+)\.(\d+)/.exec(version);
+  if (!match) return null;
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+  };
+}
+
+/**
+ * Validate a render half's declared view-contract version against a host's
+ * supported version, returning a structured verdict instead of throwing.
+ *
+ * Pure: no I/O, no side effects. A host uses this to guard a provider's `./views`
+ * entry before mounting its contributions, surfacing the `reason` and skipping
+ * the render half rather than crashing.
+ *
+ * Rules (mirroring core's `checkProviderCompatibility`):
+ *   - An `undefined` declared version makes no claim and passes (the guard is
+ *     opt-in).
+ *   - A malformed version string is rejected.
+ *   - A different major version is rejected; a same-major version that requires a
+ *     newer minor than the host supports is rejected.
+ *
+ * @param declared The view-contract version the render half targets (semver), or
+ *   `undefined` to make no claim.
+ * @param host The view-contract version the host implements; defaults to
+ *   {@link VIEW_API_VERSION}.
+ */
+export function checkViewCompatibility(
+  declared: string | undefined,
+  host: string = VIEW_API_VERSION,
+): ViewCompatibility {
+  if (declared === undefined) return { compatible: true };
+
+  const target = parseSemVer(declared);
+  if (!target) {
+    return {
+      compatible: false,
+      reason: `declares a malformed view API version "${declared}" (expected semver like "${host}")`,
+    };
+  }
+
+  const supported = parseSemVer(host);
+  if (supported) {
+    if (target.major !== supported.major) {
+      return {
+        compatible: false,
+        reason: `targets view API v${declared} but the host supports v${host} (incompatible major version)`,
+      };
+    }
+    if (target.minor > supported.minor) {
+      return {
+        compatible: false,
+        reason: `targets view API v${declared} but the host only supports up to v${host} (newer minor than host)`,
+      };
+    }
+  }
+
+  return { compatible: true };
+}

--- a/packages/view-kit/test/view-compat.test.ts
+++ b/packages/view-kit/test/view-compat.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  VIEW_API_VERSION,
+  checkViewCompatibility,
+  type ViewCompatibility,
+} from '../src/index.js';
+
+describe('VIEW_API_VERSION', () => {
+  it('is a semver string', () => {
+    expect(VIEW_API_VERSION).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  it('is versioned independently — a bare, self-contained constant', () => {
+    // The view contract is bumped on its own cadence, not core's; assert it is a
+    // plain string literal this package owns (no import from core).
+    expect(typeof VIEW_API_VERSION).toBe('string');
+  });
+});
+
+describe('checkViewCompatibility', () => {
+  it('accepts a render half that makes no version claim (undefined)', () => {
+    expect(checkViewCompatibility(undefined)).toEqual({ compatible: true });
+  });
+
+  it('accepts the exact host version', () => {
+    expect(checkViewCompatibility(VIEW_API_VERSION)).toEqual({ compatible: true });
+  });
+
+  it('accepts a same-major, same-or-older minor', () => {
+    expect(checkViewCompatibility('1.0.0', '1.2.0')).toEqual({ compatible: true });
+  });
+
+  it('rejects a different major version and names the mismatch', () => {
+    const result: ViewCompatibility = checkViewCompatibility('2.0.0', VIEW_API_VERSION);
+    expect(result.compatible).toBe(false);
+    expect(result.reason).toContain('2.0.0');
+    expect(result.reason).toContain(VIEW_API_VERSION);
+    expect(result.reason).toMatch(/major/);
+  });
+
+  it('rejects a same-major render half that needs a newer minor than the host', () => {
+    const result = checkViewCompatibility('1.9.0', '1.2.0');
+    expect(result.compatible).toBe(false);
+    expect(result.reason).toMatch(/minor/);
+  });
+
+  it('rejects a malformed version', () => {
+    const result = checkViewCompatibility('banana');
+    expect(result.compatible).toBe(false);
+    expect(result.reason).toContain('malformed');
+    expect(result.reason).toContain('banana');
+  });
+
+  it('defaults the host version to VIEW_API_VERSION when omitted', () => {
+    expect(checkViewCompatibility('2.0.0')).toEqual({
+      compatible: false,
+      reason: expect.stringContaining(VIEW_API_VERSION),
+    });
+  });
+});

--- a/packages/view-kit/test/view-compat.test.ts
+++ b/packages/view-kit/test/view-compat.test.ts
@@ -4,7 +4,7 @@ import {
   VIEW_API_VERSION,
   checkViewCompatibility,
   type ViewCompatibility,
-} from '../src/index.js';
+} from '../src/index';
 
 describe('VIEW_API_VERSION', () => {
   it('is a semver string', () => {

--- a/packages/view-kit/tsconfig.build.json
+++ b/packages/view-kit/tsconfig.build.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}

--- a/packages/view-kit/vitest.config.ts
+++ b/packages/view-kit/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.test.ts'],
+    environment: 'node',
+  },
+});

--- a/src/views/ReadingView.tsx
+++ b/src/views/ReadingView.tsx
@@ -455,6 +455,11 @@ function ProseContent({
           continue;
         }
 
+        // A `viewer` decision delegates to a node/model viewer resolved by key
+        // (e.g. a `'calendar-month'` lens), which is mounted by the viewer path,
+        // not this prose-fence diagram path — leave the fence untouched here.
+        if (output.type === 'viewer') continue;
+
         // output.type === 'mermaid' — live render (the existing inline path).
         try {
           const { svg, bindFunctions } = await renderMermaid(output.source, isDark);

--- a/src/views/rich-markdown/registry.ts
+++ b/src/views/rich-markdown/registry.ts
@@ -13,30 +13,26 @@
  * an element (live Mermaid SVG, inline pre-built SVG, or a raw-code fallback).
  */
 import type { RichMarkdownBlock } from './types';
+import type {
+  BlockOutput,
+  BlockRenderContext,
+  BlockRenderer,
+} from '@anokye-labs/kbexplorer-view-kit';
 
 /**
- * What a block renderer decided to produce.
+ * The block-render contract (`BlockOutput`, `BlockRenderContext`,
+ * `BlockRenderer`) now lives in the published render contract
+ * `@anokye-labs/kbexplorer-view-kit` so a provider's render half and this host
+ * agree on exactly one definition. Re-exported here so existing `./registry`
+ * importers keep working unchanged.
  *
+ * `BlockOutput` decisions:
  * - `mermaid` — hand the source to the live Mermaid path (renders to SVG client-side).
  * - `svg` — inline a pre-built SVG (the fallback contract).
+ * - `viewer` — delegate to a viewer resolved by registry `key` with pure `data`.
  * - `unsupported` — no live renderer and no SVG; show the raw source as a last resort.
  */
-export type BlockOutput =
-  | { type: 'mermaid'; source: string; title?: string }
-  | { type: 'svg'; svg: string; title?: string }
-  | { type: 'unsupported'; kind: string; source: string; reason: string };
-
-/** Context threaded to renderers (e.g. for theme-aware live rendering). */
-export interface BlockRenderContext {
-  /** Active dark/light flag, for renderers that theme their output. */
-  isDark?: boolean;
-}
-
-/** A block renderer maps a block to a {@link BlockOutput} decision. */
-export type BlockRenderer = (
-  block: RichMarkdownBlock,
-  ctx?: BlockRenderContext,
-) => BlockOutput;
+export type { BlockOutput, BlockRenderContext, BlockRenderer };
 
 const registry = new Map<string, BlockRenderer>();
 

--- a/src/views/rich-markdown/types.ts
+++ b/src/views/rich-markdown/types.ts
@@ -12,44 +12,15 @@
  * decision; the React/DOM layer turns that decision into pixels.
  */
 import type { KBNode } from '../../types';
-
-/** Character offsets of a block within the original markdown source. */
-export interface BlockRange {
-  /** Inclusive start offset into the original markdown. */
-  start: number;
-  /** Exclusive end offset into the original markdown. */
-  end: number;
-}
+import type { BlockRange, RichMarkdownBlock } from '@anokye-labs/kbexplorer-view-kit';
 
 /**
- * One embedded block inside a rich-Markdown document.
- *
- * `kind` is an **open** discriminator (`'mermaid' | 'dot' | 'ics' | 'canvas' | …`)
- * so new block kinds need no core change. `svg` is the pre-built-SVG fallback
- * contract: when a kind has no live renderer, the provider ships a rendered SVG
- * so the block never degrades to a raw code dump.
+ * The block-data contract (`BlockRange`, `RichMarkdownBlock`) now lives in the
+ * published render contract `@anokye-labs/kbexplorer-view-kit` so a provider's
+ * render half and this host agree on exactly one block shape. Re-exported here
+ * so existing `./types` importers keep working unchanged.
  */
-export interface RichMarkdownBlock {
-  /** Open block-kind discriminator, e.g. `'mermaid'`, `'dot'`, `'ics'`, `'canvas'`. */
-  kind: string;
-  /** Verbatim block source (the fenced-code body). */
-  source: string;
-  /**
-   * Content hash of `source` (e.g. `'sha256:…'`). A stable identity used for
-   * caching and as a fast-path key when matching a rendered prose fence back to
-   * its provider block. Matching also works without it (by normalized source).
-   */
-  hash?: string;
-  /** Character offsets of the block in the original markdown source. */
-  range?: BlockRange;
-  /**
-   * Pre-built SVG markup — the fallback contract for blocks with no live
-   * renderer. When present the block renders this SVG instead of raw code.
-   */
-  svg?: string;
-  /** Optional human-facing caption/label for the block. */
-  title?: string;
-}
+export type { BlockRange, RichMarkdownBlock };
 
 /** The structured payload carried on `node.data.richMarkdown`. */
 export interface RichMarkdownDocument {

--- a/src/views/viewers/GenericStructuredView.tsx
+++ b/src/views/viewers/GenericStructuredView.tsx
@@ -1,15 +1,15 @@
-import type { KBNode } from '../../types';
+import type { ViewerComponent, ViewerProps } from '@anokye-labs/kbexplorer-view-kit';
 
 /**
- * A viewer renders a typed node. Viewers are registered against an
- * `entityType` (or JSON-LD `@type`) and resolved from the viewer registry, with
+ * The viewer contract now lives in `@anokye-labs/kbexplorer-view-kit` (the
+ * published render contract). Re-export it here so there is exactly one
+ * definition and existing `./GenericStructuredView` importers keep working.
+ *
+ * A viewer renders a typed node. Viewers are registered against an `entityType`
+ * (or JSON-LD `@type`) and resolved from the viewer registry, with
  * {@link GenericStructuredView} as the mandatory fallback for unknown types.
  */
-export type ViewerComponent = (props: ViewerProps) => React.ReactNode;
-
-export interface ViewerProps {
-  node: KBNode;
-}
+export type { ViewerComponent, ViewerProps };
 
 /** Reserved JSON-LD keys that are surfaced separately from free-form data. */
 const LD_RESERVED = new Set(['@context', '@id', '@type']);

--- a/src/views/viewers/spine-shared.tsx
+++ b/src/views/viewers/spine-shared.tsx
@@ -1,65 +1,18 @@
-import type { ReactNode } from 'react';
-
 /**
  * Shared building blocks for the content-model spine viewers (F2 / T2.5 + T2.6).
+ *
+ * These house-style primitives now live in the published render contract
+ * (`@anokye-labs/kbexplorer-view-kit`) so third-party lenses match the built-in
+ * viewers by default. Re-exported here so existing `./spine-shared` importers
+ * keep working and there is exactly one definition.
  *
  * className-styled only (no pixel sizing, SSR-safe) so the bespoke viewers render
  * identically under `renderToStaticMarkup` in tests and in the live app.
  */
-
-/** A header strip showing the entity kind label and its JSON-LD `@id`. */
-export function EntityHeader({ label, id, native }: { label: string; id?: string; native?: string }) {
-  return (
-    <div className="kb-structured-header">
-      <span className="kb-structured-type" title="JSON-LD @type">{label}</span>
-      {native && native.toLowerCase() !== label.toLowerCase() && (
-        <span
-          className="kb-structured-native"
-          title={`Native term — this repo calls it "${native}", unified to the canonical type`}
-        >
-          {native}
-        </span>
-      )}
-      {id && <code className="kb-structured-id" title="JSON-LD @id">{id}</code>}
-    </div>
-  );
-}
-
-/** A key/value table row, rendered only when `children` is truthy. */
-export function Row({ label, children }: { label: string; children: ReactNode }) {
-  if (children == null || children === '' || (Array.isArray(children) && children.length === 0)) {
-    return null;
-  }
-  return (
-    <tr>
-      <th scope="row" className="kb-structured-key">{label}</th>
-      <td className="kb-structured-value">{children}</td>
-    </tr>
-  );
-}
-
-/** A bullet list of scalar values. */
-export function ScalarList({ items }: { items: unknown[] }) {
-  if (!items.length) return null;
-  return (
-    <ul className="kb-structured-list">
-      {items.map((it, i) => <li key={i}>{String(it)}</li>)}
-    </ul>
-  );
-}
-
-/** A small status / RAG pill whose tone maps to a className (no inline color). */
-export function Pill({ value }: { value: string }) {
-  const tone = ragTone(value);
-  return <span className={`kb-pill kb-pill-${tone}`}>{value}</span>;
-}
-
-/** Map a status / RAG string to a tone class suffix. */
-function ragTone(value: string): 'green' | 'amber' | 'red' | 'neutral' {
-  const v = value.toLowerCase();
-  if (/(green|on-track|done|complete|shipped|healthy)/.test(v)) return 'green';
-  if (/(amber|yellow|at-risk|warn|in-progress|pending)/.test(v)) return 'amber';
-  if (/(red|blocked|off-track|fail|critical)/.test(v)) return 'red';
-  return 'neutral';
-}
+export {
+  EntityHeader,
+  Row,
+  ScalarList,
+  Pill,
+} from '@anokye-labs/kbexplorer-view-kit';
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
       'scripts/**/__tests__/**/*.test.js',
       'twins/**/__tests__/**/*.test.{js,mjs,ts}',
       'tests/golden/**/*.test.ts',
+      'packages/*/test/**/*.test.ts',
     ],
     exclude: ['**/node_modules/**', '**/fluentui-system-icons/**', '**/dist/**'],
     testTimeout: 10000,


### PR DESCRIPTION
## Summary

Publishes `@anokye-labs/kbexplorer-view-kit` — the UX-stack-specific (React + Fluent) **render contract** that provider-shipped lenses type their `./views` entry against. This is item **A5** of Epic anokye-labs/kbexplorer#130 and a hard blocker for A2 (#492) and B8 (provider-rich-markdown#14).

The render types previously lived as unpublished template internals. This makes the repo an npm workspace, lifts those types into `packages/view-kit`, and single-sources the template off its own package so there is exactly one definition of each contract type. The contract sits **below** `@anokye-labs/kbexplorer-core@^0.6.0` in the dependency graph: core defines the data half (`KBNode`, `NodeLens`, `CalendarModel`) plus the `ProviderModule.views` specifier string, but deliberately does **not** define the render module shape — that is view-kit's job.

## Related Issue

Refs #503

## Changes

- **New workspace package `packages/view-kit`** publishing as `@anokye-labs/kbexplorer-view-kit` (public, ESM, `files:["dist"]`, `prepare` builds dist). App package stays private.
- **Exported contract** (`@anokye-labs/kbexplorer-view-kit`):
  - `ViewerProps { node: KBNode }`, `ViewerComponent = (props: ViewerProps) => React.ReactNode`, `LazyViewer = () => Promise<{ default: ViewerComponent }>` (zero-arg loader).
  - `BlockRange`, `RichMarkdownBlock`, `BlockOutput` (incl. new `{ type: 'viewer'; key; data }` member), `BlockRenderContext`, `BlockRenderer`.
  - `ProviderViews { viewers?, blockRenderers? }` — registries documented as case-insensitive keys, last-registration-wins.
  - `VIEW_API_VERSION` (`'1.0.0'`, versioned independently of core's `PROVIDER_API_VERSION`) + `checkViewCompatibility` (same-major-compatible semantics).
  - Presentation primitives: `EntityHeader`, `Row`, `Pill`, `ScalarList`.
- **Dependencies**: `@anokye-labs/kbexplorer-core@^0.6.0` (imports `KBNode`/`NodeLens`); `react` as a **peerDependency** (`^18 || ^19`). Fluent tokens consumed as CSS custom properties only — no `@fluentui/react-components` runtime dep for the types.
- **Single-sourced template**: `src/views/viewers/GenericStructuredView.tsx`, `viewers/spine-shared.tsx`, `rich-markdown/types.ts`, `rich-markdown/registry.ts` now import (and re-export) the contract from view-kit. `ReadingView.tsx` handles the new `viewer` block output.
- **Publish workflow** `.github/workflows/publish-view-kit.yml`: tag-driven OIDC trusted publishing on `view-kit-v*` tags (mirrors core's `publish.yml`), independent of template tags.
- **Docs**: `docs/providers.md` gains a "render half (lenses)" section pointing `./views` authors at view-kit (no-build providers use `React.createElement`; JSX providers precompile only their `./views` entry; the `.` data entry stays pure ESM/core-only).
- **Tests**: view-kit `VIEW_API_VERSION` compat suite wired into the root vitest run (`packages/*/test/**`) so it runs in the CI `test` gate.

## Verification

- [x] Build/tests run
- [x] Manual or API verification completed
- Evidence (local, Node 20 path):
  - `npm ci` — clean install; workspace `prepare` builds `packages/view-kit/dist` (CI resolves the package to dist).
  - `npx tsc -b` — clean (types single-sourced from the subpackage).
  - `npm test` — **607 passed** (65 files), including the 9 view-kit compat tests.
  - `npm run lint` — 0 errors (3 pre-existing warnings, unrelated).
  - `npm run validate` (kbx graph validate) — valid, 0 warnings; `validate:drift` — manifest up to date; `kbx graph assess --gate` — quality gate passed.
  - `npx vite build` — succeeds.
  - view-kit typechecks standalone (`tsc -p packages/view-kit/tsconfig.build.json`).

## Checklist

- [x] Linked issue referenced
- [x] Documentation updated if needed
