### PR TITLE
fix(viewers): register builtin viewers on the canvas entry via a shared composition module

### DIFF
--- a/e2e/canvas-embed.spec.ts
+++ b/e2e/canvas-embed.spec.ts
@@ -251,4 +251,43 @@ test.describe('Embeddable canvas mount (#406 / #440 / #408)', () => {
     await page.waitForTimeout(500);
     expect(appErrors(errors)).toHaveLength(0);
   });
+
+  test('copilot: a spine entity (person) renders its bespoke viewer, not the generic fallback (#494)', async ({
+    page,
+  }) => {
+    const errors = collectErrors(page);
+
+    // Anchor the copilot surface directly on a `person` entity so its bespoke
+    // PersonView renders in the anchor body. The deterministic demo-entities seam
+    // (`?demo=entities`) seeds `demo-person-ada` independent of the twin/manifest.
+    // Before #494 the canvas entry never called the viewer-registration
+    // composition, so the registry was empty at boot and `resolveViewer` fell
+    // back to GenericStructuredView for every node — even here.
+    await page.addInitScript(() => {
+      (window as unknown as { __KBX_CANVAS__: unknown }).__KBX_CANVAS__ = {
+        local: false,
+        visualMode: 'inherit-host',
+        anchorNodeId: 'demo-person-ada',
+      };
+    });
+    await page.goto('/canvas.html?demo=entities', { timeout: 60000 });
+
+    const anchorView = page.locator('[data-testid="anchor-first-view"]');
+    await expect(anchorView).toBeVisible({ timeout: 15000 });
+    await expect(anchorView).toHaveAttribute('data-anchor-id', 'demo-person-ada');
+
+    // The anchor body must render PersonView's bespoke markup (kb-person-*),
+    // NOT only the GenericStructuredView key/value fallback. The generic
+    // fallback emits `.kb-structured-view` WITHOUT any `.kb-person-*` node.
+    const personView = anchorView.locator('.kb-person-view');
+    await expect(personView).toBeVisible({ timeout: 15000 });
+    await expect(personView.locator('.kb-person-name')).toContainText('Ada Okonkwo');
+    await expect(personView.locator('a[href^="mailto:"]')).toHaveAttribute(
+      'href',
+      'mailto:ada@example.com',
+    );
+
+    await page.waitForTimeout(1000);
+    expect(appErrors(errors)).toHaveLength(0);
+  });
 });

--- a/e2e/canvas-embed.spec.ts
+++ b/e2e/canvas-embed.spec.ts
@@ -267,6 +267,9 @@ test.describe('Embeddable canvas mount (#406 / #440 / #408)', () => {
       (window as unknown as { __KBX_CANVAS__: unknown }).__KBX_CANVAS__ = {
         local: false,
         visualMode: 'inherit-host',
+        // Pin the copilot surface explicitly so this test only guards viewer
+        // registration, not the boot-config default target (per PR review).
+        target: 'copilot',
         anchorNodeId: 'demo-person-ada',
       };
     });

--- a/src/canvas.tsx
+++ b/src/canvas.tsx
@@ -12,6 +12,12 @@ import { createRoot } from 'react-dom/client';
 import './index.css';
 import { EmbeddableApp } from './canvas/EmbeddableApp';
 import { readCanvasBootConfig } from './canvas/bootConfig';
+import { registerViewers } from './views/viewers/registerViewers';
+
+// Register the bespoke entity viewers so the copilot surface's anchor-first view
+// reuses them instead of falling back to GenericStructuredView for every node
+// (surface parity with `main.tsx` — kbexplorer-template#494).
+registerViewers();
 
 const boot = readCanvasBootConfig();
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,9 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
-import { registerBuiltinViewers } from './views/viewers/builtin-map'
+import { registerViewers } from './views/viewers/registerViewers'
 
-registerBuiltinViewers()
+registerViewers()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/views/viewers/index.ts
+++ b/src/views/viewers/index.ts
@@ -27,6 +27,10 @@ export {
 
 export { registerBuiltinViewers } from './builtin-map';
 
+// Shared composition seam invoked by BOTH app entries (main.tsx + canvas.tsx),
+// and the extension point for provider render contributions (#494 / A2 #492).
+export { registerViewers } from './registerViewers';
+
 // Services-monorepo bespoke viewers (#275).
 export { ServiceView } from './ServiceView';
 export { DecisionView } from './DecisionView';

--- a/src/views/viewers/registerViewers.ts
+++ b/src/views/viewers/registerViewers.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared viewer-registration composition (A4, epic anokye-labs/kbexplorer#130).
+ *
+ * The single seam that BOTH app entries — the full-page SPA (`main.tsx`) and the
+ * embeddable canvas (`canvas.tsx`) — call once at boot to populate the viewer
+ * registry. Centralizing registration here makes surface parity hold *by
+ * construction*: neither entry can drift into an empty registry, which would
+ * make `resolveViewer` fall back to {@link GenericStructuredView} for every node
+ * (the copilot-surface bug this module fixes — kbexplorer-template#494).
+ *
+ * It is also the composition point where **provider render contributions** are
+ * layered on top of the built-in viewers (A2, kbexplorer-template#492). Provider
+ * `registerViewer(type, Component)` calls belong inside this function, *after*
+ * the built-ins, so the registry's last-registration-wins precedence lets a
+ * provider override a built-in viewer for a given entity type. Keep the built-in
+ * pass first and additive so that ordering contract stays intact.
+ */
+import { registerBuiltinViewers } from './builtin-map';
+
+/**
+ * Compose and register every viewer both app surfaces should have at boot.
+ *
+ * Today this is just the ~15 bespoke built-in entity viewers. It is the
+ * designated extension point for A2's provider render contributions — add those
+ * here, after {@link registerBuiltinViewers}, so provider viewers can override
+ * built-ins by type.
+ */
+export function registerViewers(): void {
+  registerBuiltinViewers();
+  // A2 (kbexplorer-template#492): provider render contributions are composed
+  // here, after the built-ins, so a provider viewer wins for its entity type.
+}


### PR DESCRIPTION
## Summary

On the copilot (embeddable canvas) surface the viewer registry was empty at boot, so `resolveViewer` fell back to `GenericStructuredView` for every node — even though `AnchorFirstView` intends to reuse the ~15 bespoke entity viewers. Root cause: `registerBuiltinViewers()` was called only from the full-page SPA entry (`src/main.tsx`); the canvas entry (`src/canvas.tsx`) never called it.

This extracts viewer registration into a **shared composition module** that BOTH entries call once at boot, so surface parity holds by construction. The module is also the designated composition point for **provider render contributions** (A2, #492).

## Related Issue

Refs #494

(A4 of Epic anokye-labs/kbexplorer#130 — structured-file visualization.)

## Changes

- **New:** `src/views/viewers/registerViewers.ts` — shared composition module exporting `registerViewers(): void`. Calls `registerBuiltinViewers()` and documents the A2 provider-contribution extension point (provider `registerViewer` calls layer *after* the built-ins so last-registration-wins precedence lets a provider override a built-in viewer by type).
- `src/canvas.tsx` — calls `registerViewers()` at boot (the fix).
- `src/main.tsx` — swapped `registerBuiltinViewers()` → `registerViewers()` (behavior-identical for the SPA).
- `src/views/viewers/index.ts` — re-exports `registerViewers`.
- `e2e/canvas-embed.spec.ts` — new test asserting a spine person node renders its bespoke `kb-person-*` markup (not the `kb-structured-view` fallback) on the copilot surface. Proven to fail without the fix.

## Verification

- [x] Build/tests run (if applicable)
- [x] Manual or API verification completed
- Evidence:
  - Unit tests: 598 passed.
  - Lint: 0 errors (3 pre-existing warnings, unrelated).
  - `tsc -b` + `vite build`: green.
  - e2e (chromium, local mode with augmented manifest): **94 passed**.
  - Bug-catch proof: temporarily disabling `registerViewers()` in `canvas.tsx` makes the new #494 test fail (generic fallback); restoring it passes (bespoke `kb-person-view`).

## Checklist

- [x] Linked issue referenced
- [x] Documentation updated if needed

---

**Note for A2 (#492):** the shared module is `src/views/viewers/registerViewers.ts`, exported signature `registerViewers(): void`, re-exported from the `src/views/viewers` barrel. Both entries call it at boot; add provider render contributions inside it, after the built-in pass.