### PR TITLE
chore(ci): add renovate config for npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,5 @@
 version: 2
 updates:
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "weekly"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,8 @@
   "packageRules": [
     {
       "matchManagers": ["npm"],
-      "matchPackagePatterns": ["^@anokye-labs/"],
+      "matchDatasources": ["npm"],
+      "matchPackageNames": ["@anokye-labs/**"],
       "groupName": "anokye-labs",
       "groupSlug": "anokye-labs"
     },

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "enabledManagers": ["npm"],
   "schedule": ["before 3am on Monday"],
   "packageRules": [
     {

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "schedule": ["before 3am on Monday"],
+  "packageRules": [
+    {
+      "matchManagers": ["npm"],
+      "matchPackagePatterns": ["^@anokye-labs/"],
+      "groupName": "anokye-labs",
+      "groupSlug": "anokye-labs"
+    },
+    {
+      "matchUpdateTypes": ["major"],
+      "automerge": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a Renovate config that extends `config:recommended`
- group all `@anokye-labs/*` npm dependencies into an `anokye-labs` group on a weekly schedule
- keep major updates out of automerge
- retain Dependabot GitHub Actions updates while removing overlapping npm automation

refs anokye-labs/kbexplorer#133